### PR TITLE
fix: take into account var_int for `addr`. move to parser.

### DIFF
--- a/lib/bcoin/peer.js
+++ b/lib/bcoin/peer.js
@@ -311,47 +311,19 @@ Peer.prototype._handleGetData = function handleGetData(items) {
   }, this);
 };
 
-Peer.prototype._handleAddr = function handleAddr(addr) {
-  var count, date, network, ipv4, ipv6, port, i;
-
-  // count
-  count = addr[0];
-  addr = addr.slice(1);
-
-  for (i = 0; i < count; i++) {
-    // date - LE
-    date = utils.readU32(addr, 0);
-
-    // NODE_NETWORK service - LE
-    network = utils.readU64(addr, 4);
-
-    // ipv4 - BE
-    ipv4 = utils.readU32BE(addr, 24);
-    ipv4 = ((ipv4 >> 24) & 0xff) + '.' +
-      ((ipv4 >> 16) & 0xff) + '.' +
-      ((ipv4 >> 8) & 0xff) + '.' +
-      ((ipv4 >> 0) & 0xff);
-
-    // ipv6 - BE
-    ipv6 = utils.toHex(addr.slice(12, 24));
-    ipv6 = ipv6.replace(/(.{4})/g, '$1:').replace(/:$/, '');
-
-    // port - BE
-    port = utils.readU16BE(addr, 28);
-
+Peer.prototype._handleAddr = function handleAddr(addrs) {
+  addrs.forEach(function(addr) {
     this.emit('addr', {
-      date: new Date(date * 1000),
-      network: network,
-      address: ipv4,
-      ipv4: ipv4,
-      ipv6: ipv6,
-      port: port,
-      host: ipv4 + ':' + port,
-      host6: '[' + ipv6 + ']:' + port
+      date: new Date(addr.date * 1000),
+      network: addr.network,
+      address: addr.ipv4,
+      ipv4: addr.ipv4,
+      ipv6: addr.ipv6,
+      port: addr.port,
+      host: addr.ipv4 + ':' + addr.port,
+      host6: '[' + addr.ipv6 + ']:' + addr.port
     });
-
-    addr = addr.slice(30);
-  }
+  }, this);
 };
 
 Peer.prototype._handlePing = function handlePing() {

--- a/lib/bcoin/protocol/parser.js
+++ b/lib/bcoin/protocol/parser.js
@@ -103,6 +103,8 @@ Parser.prototype.parsePayload = function parsePayload(cmd, p) {
     return this.parseTX(p);
   else if (cmd === 'reject')
     return this.parseReject(p);
+  else if (cmd === 'addr')
+    return this.parseAddr(p);
   else
     return p;
 };
@@ -347,4 +349,52 @@ Parser.prototype.parseReject = function parseReject(p) {
     ccode: ccode,
     reason: reason
   };
+};
+
+Parser.prototype.parseAddr = function parseAddr(p) {
+  if (p.length < 31)
+    return this._error('Invalid addr size');
+
+  var addrs = [];
+  var len, off, count, date, network, ipv4, ipv6, port, i;
+
+  // count
+  len = readIntv(p, 0);
+  off = len.off;
+  count = len.r;
+  p = p.slice(off);
+
+  for (i = 0; i < count; i++) {
+    // date - LE
+    date = utils.readU32(p, 0);
+
+    // NODE_NETWORK service - LE
+    network = utils.readU64(p, 4);
+
+    // ipv6 - BE
+    ipv6 = utils.toHex(p.slice(12, 24));
+    ipv6 = '::' + ipv6.replace(/(.{4})/g, '$1:').slice(0, -1);
+
+    // ipv4 - BE
+    ipv4 = utils.readU32BE(p, 24);
+    ipv4 = ((ipv4 >> 24) & 0xff) + '.' +
+      ((ipv4 >> 16) & 0xff) + '.' +
+      ((ipv4 >> 8) & 0xff) + '.' +
+      ((ipv4 >> 0) & 0xff);
+
+    // port - BE
+    port = utils.readU16BE(p, 28);
+
+    addrs.push({
+      date: date,
+      network: network,
+      ipv6: ipv6,
+      ipv4: ipv4,
+      port: port
+    });
+
+    p = p.slice(30);
+  }
+
+  return addrs;
 };


### PR DESCRIPTION
I realized there is a `var_int` at the start of the data in the `addr` packet. I didn't take this into account originally. It's now fixed, and I moved the actual packet parsing into protocol/parser.js (it seemed more appropriate, not to mention, the readIntv function is there).