### PR TITLE
tx-pool: allow tx-pool to function without a wallet.

### DIFF
--- a/lib/bcoin/tx-pool.js
+++ b/lib/bcoin/tx-pool.js
@@ -4,15 +4,25 @@ var bcoin = require('../bcoin');
 var assert = bcoin.utils.assert;
 var EventEmitter = require('events').EventEmitter;
 
-function TXPool(wallet) {
+function TXPool(options) {
   if (!(this instanceof TXPool))
-    return new TXPool(wallet);
+    return new TXPool(options);
 
   EventEmitter.call(this);
 
+  var options = options || {};
+  var wallet;
+
+  // Legacy:
+  if (options instanceof bcoin.wallet)
+    wallet = options;
+  else if (options.wallet)
+    wallet = options.wallet;
+
+  this.options = options;
   this._wallet = wallet;
-  this._storage = wallet.storage;
-  this._prefix = wallet.prefix + 'tx/';
+  this._storage = options.storage;
+  this._prefix = (options.prefix || 'bt/') + 'tx/';
   this._all = {};
   this._unspent = {};
   this._orphans = {};
@@ -69,7 +79,7 @@ TXPool.prototype.add = function add(tx, noWrite) {
   }
   this._all[hash] = tx;
 
-  var own = this._wallet.ownOutput(tx);
+  var own = !this._wallet || this._wallet.ownOutput(tx);
   var updated = false;
 
   // Consume unspent money or add orphans
@@ -107,7 +117,7 @@ TXPool.prototype.add = function add(tx, noWrite) {
       this.emit('update', this._lastTs, tx);
 
     // Save spending TXs without adding unspents
-    if (this._storage && this._wallet.ownInput(tx))
+    if (this._storage && (!this._wallet || this._wallet.ownInput(tx)))
       this._storeTX(hash, tx);
     return;
   }
@@ -154,6 +164,21 @@ TXPool.prototype.add = function add(tx, noWrite) {
 
   this.emit('tx', tx);
 
+  // Since we don't have a particular key's tx's to keep track of, these might
+  // use a bit of memory. Free them up every so often.
+  if (!this._wallet) {
+    var memLimit = this.options.memLimit || 1000;
+    if (Object.keys(this._all).length > memLimit) {
+      this._all = {};
+    }
+    if (Object.keys(this._unspent).length > memLimit) {
+      this._unspent = {};
+    }
+    if (Object.keys(this._orphans).length > memLimit) {
+      this._orphans = {};
+    }
+  }
+
   return true;
 };
 
@@ -181,10 +206,44 @@ TXPool.prototype._removeTX = function _removeTX(tx) {
   });
 };
 
+TXPool.prototype._getTX = function(hash, callback) {
+  if (!this._storage)
+    return callback(new Error('No storage.'));
+  this._storage.get(this._prefix + hash, function(err, data) {
+    if (err) return callback(err);
+    var tx = bcoin.tx.fromJSON(data);
+    // self.add(tx, true);
+    return callback(null, tx);
+  });
+};
+
+TXPool.prototype.get = function(hash, options, callback) {
+  var self = this;
+
+  if (!callback) {
+    callback = options;
+    options = {};
+  }
+
+  if (options.memory === false) {
+    if (this._all[hash])
+      return callback(null, this._all[hash]);
+  }
+
+  this._getTX(hash, function(err, tx) {
+    if (err) return callback(err);
+    if (options.add)
+      self.add(tx, true);
+    return callback(null, tx);
+  });
+};
+
 TXPool.prototype.all = function all() {
   return Object.keys(this._all).map(function(key) {
     return this._all[key];
   }, this).filter(function(tx) {
+    if (!this._wallet)
+      return true;
     return this._wallet.ownOutput(tx) ||
            this._wallet.ownInput(tx);
   }, this);
@@ -194,6 +253,8 @@ TXPool.prototype.unspent = function unspent() {
   return Object.keys(this._unspent).map(function(key) {
     return this._unspent[key];
   }, this).filter(function(item) {
+    if (!this._wallet)
+      return true;
     return this._wallet.ownOutput(item.tx, item.index);
   }, this);
 };


### PR DESCRIPTION
I've been messing around with tx-pool to allow it to be instantiated without being associated with a wallet. If no wallet is passed in, it can be associated with every transaction equally.

As you guessed, this would allow easy global saving of _every_ transaction, not just those associated with a wallet:

``` js
...

// tx-pool now takes an options object (or a wallet)
var txPool = bcoin.txPool({
  storage: pool.storage
});

pool.on('tx', function(tx) {
  txPool.add(tx);
});
```

Later:

``` js
// Checks in memory storage (default limit of 1000 tx) and db storage:
txPool.get(arbitraryTx, function(err, tx) {
  if (err)
    throw err;
  console.log(tx);
});
```

Just want to know what you think, @indutny. This isn't essential by any means.  Of course, someone could simply save all transactions by hand, but having an object for it might be nicer.