### PR TITLE
chain: fix undefined var in storage.del call.

### DIFF
--- a/lib/bcoin/chain.js
+++ b/lib/bcoin/chain.js
@@ -181,7 +181,7 @@ Chain.prototype._killFork = function _killFork(probe) {
     return true;
 
   var self = this;
-  this.storage.del(this.prefix + hash, obj, function(err) {
+  this.storage.del(this.prefix + hash, function(err) {
     if (err)
       self.emit('error', err);
   });


### PR DESCRIPTION
`obj` doesn't exist and is unnecessary.