### PR TITLE
framer: fix array length, assuming user-agent is below 0xfd in length.

### DIFF
--- a/lib/bcoin/protocol/framer.js
+++ b/lib/bcoin/protocol/framer.js
@@ -59,7 +59,7 @@ Framer.prototype._addr = function addr(buf, off) {
 };
 
 Framer.prototype.version = function version(packet) {
-  var p = new Array(86);
+  var p = new Array(86 + this.agent.length);
   var off = 0;
 
   if (!packet)


### PR DESCRIPTION
The commit that didn't make it. Not a big deal.