### PR TITLE
Normalize the peer addr tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,12 @@ var pool = new bcoin.pool({
 
 // Log connection errors to any peer
 pool.on('error', function(err, peer) {
-  console.log('Connection failed to %s:%d: %s', peer.addr.host, peer.addr.port, err);
+  console.log(
+    'Connection failed to %s:%d: %s',
+    peer.addr.host,
+    peer.addr.port,
+    err
+  );
 });
 
 // Receive the address of another peer.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ var pool = new bcoin.pool({
   })
 });
 
+// Log connection errors to any peer
+pool.on('error', function(err, peer) {
+  console.log('Connection failed to %s:%d: %s', peer.addr.host, peer.addr.port, err);
+});
+
 // Receive the address of another peer.
 pool.on('addr', function(data, peer) {
   var host = data.ipv4 + ':' + data.port;

--- a/lib/bcoin/peer.js
+++ b/lib/bcoin/peer.js
@@ -28,7 +28,7 @@ function Peer(pool, createSocket, options) {
   this.version = null;
   this.destroyed = false;
   this.ack = false;
-  this.ts = this.options.ts || 0;
+  this.addr = { ts: this.options.ts || 0 };
 
   if (this.options.backoff) {
     var self = this;
@@ -70,8 +70,15 @@ module.exports = Peer;
 
 Peer.prototype._init = function init() {
   var self = this;
+  this.addr = {
+    host: this.socket.remoteAddress || this.socket.connectAddress,
+    port: this.socket.remotePort || this.socket.connectPort || 8333,
+    ts: Date.now() / 1000 | 0
+  };
   this.socket.once('connect', function() {
-    self.ts = Date.now() / 1000 | 0;
+    self.addr.host = self.socket.remoteAddress;
+    self.addr.port = self.socket.remotePort;
+    self.addr.ts = Date.now() / 1000 | 0;
   });
   this.socket.once('error', function(err) {
     self._error(err);
@@ -109,7 +116,7 @@ Peer.prototype._init = function init() {
       return self._error(err);
     self.ack = true;
     self.emit('ack');
-    self.ts = Date.now() / 1000 | 0;
+    self.addr.ts = Date.now() / 1000 | 0;
   });
 };
 
@@ -379,13 +386,7 @@ Peer.prototype._handleGetAddr = function handleGetAddr() {
   // '0000:0000:0000:0000:0000:xxxx:xxxx:ffff'
 
   peers = peers.map(function(peer) {
-    if (!peer.socket || !peer.socket.remoteAddress)
-      return;
-    return {
-      host: peer.socket.remoteAddress,
-      port: peer.socket.remotePort || 8333,
-      ts: peer.ts
-    };
+    return peer.addr;
   }).filter(function(peer) {
     if (!peer || ~used.indexOf(peer.host))
       return;

--- a/lib/bcoin/peer.js
+++ b/lib/bcoin/peer.js
@@ -77,8 +77,14 @@ Peer.prototype._init = function init() {
   };
   this.socket.once('connect', function() {
     self.addr.ver = utils.isIP(self.socket.remoteAddress);
-    self.addr.ipv4 = self.addr.ver === 4 ? self.socket.remoteAddress : '127.0.0.1';
-    self.addr.ipv6 = self.addr.ver === 6 ? self.socket.remoteAddress : '0000:0000:0000:0000:0000:0000:0000:ffff';
+    if (self.addr.ver === 4)
+      self.addr.ipv4 = self.socket.remoteAddress;
+    else
+      self.addr.ipv4 = '127.0.0.1';
+    if (self.addr.ver === 6)
+      self.addr.ipv6 = self.socket.remoteAddress;
+    else
+      self.addr.ipv6 = '0000:0000:0000:0000:0000:0000:0000:ffff';
     self.addr.port = self.socket.remotePort;
     self.addr.ts = Date.now() / 1000 | 0;
   });

--- a/lib/bcoin/peer.js
+++ b/lib/bcoin/peer.js
@@ -71,12 +71,14 @@ module.exports = Peer;
 Peer.prototype._init = function init() {
   var self = this;
   this.addr = {
-    host: this.socket.remoteAddress || this.socket.connectAddress,
-    port: this.socket.remotePort || this.socket.connectPort || 8333,
+    host: this.socket.connectAddress,
+    port: this.socket.connectPort || 8333,
     ts: Date.now() / 1000 | 0
   };
   this.socket.once('connect', function() {
-    self.addr.host = self.socket.remoteAddress;
+    self.addr.ver = utils.isIP(self.socket.remoteAddress);
+    self.addr.ipv4 = self.addr.ver === 4 ? self.socket.remoteAddress : '127.0.0.1';
+    self.addr.ipv6 = self.addr.ver === 6 ? self.socket.remoteAddress : '0000:0000:0000:0000:0000:0000:0000:ffff';
     self.addr.port = self.socket.remotePort;
     self.addr.ts = Date.now() / 1000 | 0;
   });
@@ -382,43 +384,33 @@ Peer.prototype._handleGetAddr = function handleGetAddr() {
     this.pool.peers.load
   ).filter(Boolean);
 
-  // NOTE: For IPv6 BTC uses:
-  // '0000:0000:0000:0000:0000:xxxx:xxxx:ffff'
-
-  peers = peers.map(function(peer) {
-    return peer.addr;
-  }).filter(function(peer) {
-    if (!peer || ~used.indexOf(peer.host))
-      return;
-    used.push(peer.host);
-    return !!peer.host && utils.isIP(peer.host);
-  }).map(function(peer) {
-    var ip = peer.host;
-    var ver = utils.isIP(ip);
-    return {
-      ipv4: ver === 4 ? ip : '127.0.0.1',
-      ipv6: ver === 6 ? ip : '0000:0000:0000:0000:0000:0000:0000:ffff',
-      port: peer.port,
-      ts: peer.ts,
-      ver: ver
-    };
+  peers = peers.filter(function(peer) {
+    if(!peer.addr.ver || ~used.indexOf(peer.addr.host))
+      return false;
+    used.push(peer.addr.host);
+    return true;
   });
 
   var addrs = peers.map(function(peer) {
-    if (peer.ver === 6) {
-      while (peer.ipv6.split(':').length < 8)
-        peer.ipv6 = '0000:' + peer.ipv6;
-      if (peer.ipv6.split(':').length > 8)
-        return;
+    var addr = {
+      port: peer.addr.port,
+      ts: peer.addr.ts
     }
 
-    peer.ipv4 = peer.ipv4.split('.').map(function(n) {
+    // NOTE: For IPv6 BTC uses:
+    // '0000:0000:0000:0000:0000:xxxx:xxxx:ffff'
+    var ipv6 = peer.addr.ipv6;
+    while (ipv6.split(':').length < 8)
+      ipv6 = '0000:' + ipv6;
+    if (addr.ipv6.split(':').length > 8)
+      return;
+    addr.ipv6 = utils.toArray(ipv6, 'hex');
+
+    addr.ipv4 = addr.ipv4.split('.').map(function(n) {
       return +n;
     });
 
-    peer.ipv6 = utils.toArray(peer.ipv6, 'hex');
-
-    return peer;
+    return addr;
   }).filter(Boolean);
 
   return this._write(this.framer.addr(addrs));


### PR DESCRIPTION
This is a pretty simple patch to create a higher level peer.addr object that contains the most current/complete addr information for a peer, both during the connection process (to help with tracking connection errors / logging) and updating the ipv4/ipv6 after connecting. It simplifies the logic for handling getAddr as well :)