### PR TITLE
Add `level-js` as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "bn.js": "4.10.3",
     "elliptic": "6.0.2",
+    "level-js": "2.2.3",
     "leveldown": "1.4.4",
     "levelup": "1.3.1"
   },
@@ -39,7 +40,6 @@
   },
   "devDependencies": {
     "hash.js": "1.0.3",
-    "level-js": "2.2.3",
     "browserify": "13.0.0",
     "uglify-js": "2.6.1",
     "mocha": "1.21.5",


### PR DESCRIPTION
Moves `level-js` as a dependency. For browser-based dependants, this results in [missing package](https://github.com/bcoin-org/bcoin/blob/master/lib/bcoin/walletdb.js#L104) exceptions deep in the library.