### PR TITLE
fix args normalization in getHeightRangeHashes

### DIFF
--- a/lib/bcoin/txdb.js
+++ b/lib/bcoin/txdb.js
@@ -1327,6 +1327,10 @@ TXDB.prototype.getHeightRangeHashes = function getHeightRangeHashes(address, opt
   if (typeof address === 'function') {
     callback = address;
     address = null;
+  } else if (address && typeof address === 'object') {
+    callback = options;
+    options = address;
+    address = null;
   }
 
   callback = utils.ensure(callback);


### PR DESCRIPTION
broke for me while playing around with the spvnode. `removeBlockSPV` => `getHeightHashes` => `getHeightRangeHashes`