### PR TITLE
Node 4 process.hrtime(undefined)

### DIFF
--- a/lib/bcoin/utils.js
+++ b/lib/bcoin/utils.js
@@ -403,7 +403,8 @@ utils.hrtime = function hrtime(time) {
     return [sec, ms * 1e6];
   }
 
-  return process.hrtime(time);
+  return Array.isArray(time) && time.length == 2 ?
+    process.hrtime(time) : process.hrtime();
 };
 
 /**


### PR DESCRIPTION
- Calling process.hrtime is predicated on being called with an Array type with two elements or with no explicit parameters.
- Node 4 (LTS) seems to be persnickety regarding matching undefined as a
actual parameter in process.hrtime (and possibly all functions).