### PR TITLE
Fixed out of bounds error on empty strings

### DIFF
--- a/lib/bcoin/writer.js
+++ b/lib/bcoin/writer.js
@@ -102,7 +102,11 @@ BufferWriter.prototype.render = function render(keep) {
       case VARINT: off = utils.writeVarint(data, item[1], off); break;
       case VARINT2: off = utils.writeVarint2(data, item[1], off); break;
       case BYTES: off += item[1].copy(data, off); break;
-      case STR: off += data.write(item[1], off, item[2]); break;
+      case STR:
+        if (item[1].length > 0) {
+          off += data.write(item[1], off, item[2]);
+        }
+        break;
       case CHECKSUM:
         off += utils.checksum(data.slice(0, off)).copy(data, off);
         break;


### PR DESCRIPTION
When initiating bcoin on anything but the webserver sample, you get an out of bounds exception because a check isn't made on string lengths on the BufferWriter. This PR solves that.