### PR TITLE
test: include derivation test when private key has leading zeros

### DIFF
--- a/test/hd-test.js
+++ b/test/hd-test.js
@@ -137,6 +137,14 @@ describe('HD', function() {
     assert.equal(child6.xpubkey, child6_pub);
   });
 
+  it('should derive correctly when private key has leading zeros', function() {
+    var key = 'xprv9s21ZrQH143K3ckY9DgU79uMTJkQRLdbCCVDh81SnxTgPzLLGax6uHeBULTtaEtcAvKjXfT7ZWtHzKjTpujMkUd9dDb8msDeAfnJxrgAYhr';
+    var hdkey = bcoin.hd.PrivateKey.fromBase58(key);
+    assert.equal(hdkey.privateKey.toString('hex'), '00000055378cf5fafb56c711c674143f9b0ee82ab0ba2924f19b64f5ae7cdbfd');
+    var child = hdkey.derivePath('m/44\'/0\'/0\'/0/0\'');
+    assert.equal(child.privateKey.toString('hex'), '3348069561d2a0fb925e74bf198762acc47dce7db27372257d2d959a9e6f8aeb');
+  });
+
   it('should deserialize master private key', function() {
     bcoin.hd.PrivateKey.fromBase58(master.xprivkey);
   });


### PR DESCRIPTION
- Tests derivation implementation to bip32 spec when private key has leading zeros as it's possible that the private key could be represented with less than 32 bytes, but should use full 32 bytes.
- Cross tested against:
  - libbtc at https://github.com/braydonf/libbtc/commits/cross-ref
  - hdkey at https://github.com/cryptocoinjs/hdkey/pull/9
  - yours-bitcoin at https://github.com/yoursnetwork/yours-bitcoin/pull/48
  - bitcoinjs-lib at https://github.com/bitcoinjs/bitcoinjs-lib/pull/673
  - bitcore-lib at https://github.com/bitpay/bitcore-lib/pull/97

