### PR TITLE
Solved p2pk ownership comparison in mtx

### DIFF
--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -486,7 +486,7 @@ MTX.prototype.signVector = function signVector(prev, vector, sig, ring) {
   // P2PK
   if (prev.isPubkey()) {
     // Make sure the pubkey is ours.
-    if (!utils.equal(ring.keyHash, prev.get(0)))
+    if (!utils.equal(ring.publicKey, prev.get(0)))
       return false;
 
     // Already signed.


### PR DESCRIPTION
Changed public key comparison at mtx.js signVector method for P2PK case. Before It gave an error while using an imported raw coinbase transaction. I don't know if the same change is needed for the other comparison cases.