### PR TITLE
Achieve compatibility with bitcore-node

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -201,6 +201,9 @@ function Environment() {
   this.require('http', './http');
   this.require('rpc', './http/rpc');
 
+  // ZeroMQ
+  this.require('zmq', './zmq');
+
   // Workers
   this.require('workers', './workers/workers');
 

--- a/lib/node/config.js
+++ b/lib/node/config.js
@@ -202,6 +202,12 @@ config.parseData = function parseData(data, prefix, dirname) {
   options.walletAuth = bool(data.walletauth);
   options.noAuth = bool(data.noauth);
 
+  // ZeroMQ
+  options.zmqPubHashTx = str(data.zmqpubhashtx);
+  options.zmqPubHashBlock = str(data.zmqpubhashblock);
+  options.zmqPubRawTx = str(data.zmqpubrawtx);
+  options.zmqPubRawBlock = str(data.zmqpubrawblock);
+
   // Wallet
   options.noScan = bool(data.noscan);
   options.wipeNoReally = bool(data.wipenoreally);

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -18,9 +18,11 @@ var Pool = require('../net/pool');
 var Miner = require('../miner/miner');
 var WalletDB = require('../wallet/walletdb');
 var HTTPServer;
+var ZeroMQSockets;
 
 try {
   HTTPServer = require('../http/server');
+  ZeroMQSockets = require('../zmq/sockets');
 } catch (e) {
   ;
 }
@@ -53,6 +55,7 @@ try {
  * @property {Miner} miner
  * @property {WalletDB} walletdb
  * @property {HTTPServer} http
+ * @property {ZeroMQSockets} zmq
  * @emits FullNode#block
  * @emits FullNode#tx
  * @emits FullNode#alert
@@ -169,6 +172,14 @@ function FullNode(options) {
       walletAuth: this.options.walletAuth,
       noAuth: this.options.noAuth
     });
+
+    this.zmq = new ZeroMQSockets({
+      node: this,
+      pubHashTx: this.options.zmqPubHashTx,
+      pubHashBlock: this.options.zmqPubHashBlock,
+      pubRawTx: this.options.zmqPubRawTx,
+      pubRawBlock: this.options.zmqPubRawBlock
+    })
   }
 
   this._init();

--- a/lib/node/spvnode.js
+++ b/lib/node/spvnode.js
@@ -14,9 +14,11 @@ var Chain = require('../chain/chain');
 var Pool = require('../net/pool');
 var WalletDB = require('../wallet/walletdb');
 var HTTPServer;
+var ZeroMQSockets;
 
 try {
   HTTPServer = require('../http/server');
+  ZeroMQSockets = require('../zmq/sockets');
 } catch (e) {
   ;
 }
@@ -108,6 +110,14 @@ function SPVNode(options) {
       walletAuth: this.options.walletAuth,
       noAuth: this.options.noAuth
     });
+
+    this.zmq = new ZeroMQSockets({
+      node: this,
+      pubHashTx: this.options.zmqPubHashTx,
+      pubHashBlock: this.options.zmqPubHashBlock,
+      pubRawTx: this.options.zmqPubRawTx,
+      pubRawBlock: this.options.zmqPubRawBlock
+    })
   }
 
   this._init();

--- a/lib/zmq/index.js
+++ b/lib/zmq/index.js
@@ -1,0 +1,14 @@
+/*!
+ * zmq/index.js - zmq for bcoin
+ * Copyright (c) 2014-2015, Fedor Indutny (MIT License)
+ * Copyright (c) 2014-2016, Christopher Jeffrey (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+var utils = require('../utils/utils');
+
+if (!utils.isBrowser) {
+  exports.sockets = require('./sockets');
+}

--- a/lib/zmq/sockets.js
+++ b/lib/zmq/sockets.js
@@ -1,0 +1,77 @@
+/*!
+ * socket.js - zmq sockets for bcoin
+ * Copyright (c) 2014-2015, Fedor Indutny (MIT License)
+ * Copyright (c) 2014-2016, Christopher Jeffrey (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+/* jshint -W069 */
+/* jshint noyield: true */
+
+var assert = require('assert');
+var zmq = require('zeromq');
+
+/**
+ * ZeroMQSockets
+ * @exports ZeroMQSockets
+ * @constructor
+ * @param {Object} options
+ * @param {Fullnode} options.node
+ */
+
+function ZeroMQSockets(options) {
+  if (!(this instanceof ZeroMQSockets))
+    return new ZeroMQSocket(options);
+
+  if (!options)
+    options = {};
+
+  this.options = options;
+  this.node = options.node;
+
+  assert(this.node, 'ZeroMQ requires a Node.');
+
+  var sockets = {};
+
+  var topics = {
+    pubHashTx: null,
+    pubHashBlock: null,
+    pubRawTx: null,
+    pubRawBlock: null
+  };
+
+  this.topics = topics;
+
+  var address;
+  for (var topic in this.topics) {
+    address = this.options[topic];
+    if (address) {
+      if (!sockets[address]) {
+        sockets[address] = zmq.socket('pub');
+        sockets[address].bindSync(address)
+      }
+      topics[topic] = sockets[address];
+    }
+  }
+
+  this.mempool = this.node.mempool;
+  this.chain = this.node.chain;
+  
+  this.mempool.on('tx', function (tx) {
+    if (topics.pubHashTx) topics.pubHashTx.send(['hashtx', tx.rhash]);
+    if (topics.pubRawTx) topics.pubHashTx.send(['rawtx', tx.getRaw()]);
+  });
+
+  this.chain.on('block', function (block) {
+    if (topics.pubHashBlock) topics.pubHashBlock.send(['hashblock', block.rhash]);
+    if (topics.pubRawBlock) topics.pubRawBlock.send(['rawblock', block.getRaw()]);
+  });
+}
+
+/*
+ * Expose
+ */
+
+module.exports = ZeroMQSockets;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "dependencies": {
     "bn.js": "4.11.6",
-    "elliptic": "6.3.2"
+    "elliptic": "6.3.2",
+    "zeromq": "^3.0.0"
   },
   "optionalDependencies": {
     "bcoin-native": "0.0.7",


### PR DESCRIPTION
This will allow a drop-in replacement of bitcoin core inside `bitcore-node`, allowing us to use any bitcore service with bcoin including `bitcore-wallet-service` and `insight-api`.

As far as I have investigated, bcoin requires these additions for it to work.

- [x] emission of block and tx hashes through zeromq.
- [ ] spent coins and timestamp indexes.
- [ ] adding `value`, `valueSat` and `address` to vin values for the `getrawtransaction` rpc method.