### PR TITLE
Add simple plug-in management

### DIFF
--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -51,6 +51,7 @@ function Node(options) {
   this.http = null;
 
   this._bound = [];
+  this._plugins = [];
 
   this.__init();
 }
@@ -88,6 +89,7 @@ Node.prototype.__init = function __init() {
 
 Node.prototype._onOpen = function _onOpen() {
   var self = this;
+  var i, plugin;
 
   this.logger.open();
 
@@ -119,6 +121,13 @@ Node.prototype._onOpen = function _onOpen() {
     }
     self.emit('error', err);
   });
+
+  for (i = 0; i < this._plugins.length; i++) {
+    plugin = this._plugins[i];
+    plugin.open(this).catch(function(err) {
+      self.logger.error('Plug-in open error: %s', err.message);
+    });
+  }
 };
 
 /**
@@ -127,7 +136,8 @@ Node.prototype._onOpen = function _onOpen() {
  */
 
 Node.prototype._onClose = function _onClose() {
-  var i, bound;
+  var self = this;
+  var i, bound, plugin;
 
   this.logger.close();
 
@@ -137,6 +147,13 @@ Node.prototype._onClose = function _onClose() {
   }
 
   this._bound.length = 0;
+
+  for (i = 0; i < this._plugins.length; i++) {
+    plugin = this._plugins[i];
+    plugin.close(this).catch(function(err) {
+      self.logger.error('Plug-in close error: %s', err.message);
+    });
+  }
 };
 
 /**
@@ -302,6 +319,36 @@ Node.prototype.send = function send(tx) {
 
   return Promise.resolve();
 };
+
+/**
+ * Attaches a plug-in.
+ * @param {Object} plugin
+ * @returns {Object}
+ */
+Node.prototype.attach = function attach(plugin) {
+  assert(plugin, 'No plug-in specified for attachment.');
+
+  var base, nopp;
+
+  nopp = function(node) {
+    return Promise.resolve(node);
+  };
+
+  if (typeof plugin === 'function')
+    plugin = { open: plugin };
+
+  base = { open: nopp, close: nopp };
+  plugin = Object.assign({}, base, plugin);
+
+  assert(plugin.open !== nopp || plugin.close !== nopp, utils.format([
+    'Plug-ins must implement at least one base method (%s).',
+    Object.keys(base).join(', ')
+  ], false));
+
+  this._plugins.push(plugin);
+
+  return plugin;
+}
 
 /*
  * Expose

--- a/test/plugins-test.js
+++ b/test/plugins-test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+var bcoin = require('../').set('regtest');
+var assert = require('assert');
+var utils = require('../lib/utils');
+var co = require('../lib/utils/co');
+var cob = co.cob;
+
+describe('Plug-ins', function() {
+  var nopp, node, plugin;
+
+  nopp = function(node) {
+    return Promise.resolve(node);
+  };
+
+  node = new bcoin.fullnode({ db: 'memory' });
+  plugin = { open: nopp, close: nopp };
+
+  it('should attach a simplified plug-in', function() {
+		var attached = node.attach(nopp);
+    assert.deepEqual({ open: nopp, close: attached.close }, attached);
+  });
+
+  it('should attach a standard plug-in', function() {
+    var attached = node.attach(plugin);
+    assert.deepEqual(plugin, attached);
+  });
+
+  it('should bind the plug-in methods to the node', cob(function* () {
+    var called, arg;
+    node.attach(function(node) {
+      called = true;
+      arg = node;
+      return Promise.resolve();
+    });
+    yield node.open();
+    assert(called);
+    assert.deepEqual(arg, node);
+  }));
+
+  it('should trigger the plug-in close method on node close', cob(function* () {
+    var called, arg;
+    node.attach({
+      close: function(node) {
+        called = true;
+        arg = node;
+        return Promise.resolve();
+      }
+    });
+    yield node.close();
+    assert(called);
+    assert.deepEqual(arg, node);
+  }));
+
+  it('should not accept plug-in not implementing base methods', function() {
+    assert.throws(function() {
+      node.attach({ nonBaseMethod: nopp });
+    }, assert.AssertionError);
+  });
+
+  it('should handle exceptions gracefully', cob(function* () {
+    assert.doesNotThrow(function() {
+      node.attach({
+        close: function() {
+          return Promise.resolve().then(function() {
+            throw new Error('Plug-in failure')
+          })
+        }
+      });
+    });
+    yield node.open();
+  }));
+
+  it('should cleanup', cob(function* () {
+    yield node.close();
+  }));
+});


### PR DESCRIPTION
This implements a simple plug-in manager, it accepts either a function plugin that will be called on node `open` or a 'standard' plug-in implementing at least one method from a set (currently `open` and/or  `close`). Plug-in methods receive the node instance and must always return a `Promise`.