### PR TITLE
WalletDB v6

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -320,10 +320,15 @@ CLI.prototype.getDetails = co(function* getDetails() {
   this.log(details);
 });
 
+CLI.prototype.getWalletBlocks = co(function* getWalletBlocks() {
+  var blocks = yield this.wallet.getBlocks();
+  this.log(blocks);
+});
+
 CLI.prototype.getWalletBlock = co(function* getWalletBlock() {
   var height = this.argv[0] | 0;
-  var details = yield this.wallet.getBlock(height);
-  this.log(details);
+  var block = yield this.wallet.getBlock(height);
+  this.log(block);
 });
 
 CLI.prototype.retoken = co(function* retoken() {
@@ -486,6 +491,8 @@ CLI.prototype.handleWallet = co(function* handleWallet() {
       return yield this.zapWallet();
     case 'tx':
       return yield this.getDetails();
+    case 'blocks':
+      return yield this.getWalletBlocks();
     case 'block':
       return yield this.getWalletBlock();
     case 'view':
@@ -526,6 +533,7 @@ CLI.prototype.handleWallet = co(function* handleWallet() {
       this.log('  $ sign [tx-hex]: Sign transaction.');
       this.log('  $ zap [age?]: Zap pending wallet TXs.');
       this.log('  $ tx [hash]: View transaction details.');
+      this.log('  $ blocks: List wallet blocks.');
       this.log('  $ block [height]: View wallet block.');
       this.log('  $ view [tx-hex]: Parse and view transaction.');
       this.log('  $ import [wif|hex]: Import private or public key.');

--- a/bin/cli
+++ b/bin/cli
@@ -323,12 +323,6 @@ CLI.prototype.resendWallet = co(function* resendWallet() {
   this.log('Resending...');
 });
 
-CLI.prototype.zap = co(function* zap() {
-  var age = +this.argv[0] || 72 * 3600;
-  yield this.client.zap(age);
-  this.log('Zapped.');
-});
-
 CLI.prototype.backup = co(function* backup() {
   var path = this.argv[0];
 
@@ -529,8 +523,6 @@ CLI.prototype.handleNode = co(function* handleNode() {
       return yield this.rescan();
     case 'resend':
       return yield this.resend();
-    case 'zap':
-      return yield this.zap();
     case 'backup':
       return yield this.backup();
     case 'rpc':
@@ -547,7 +539,6 @@ CLI.prototype.handleNode = co(function* handleNode() {
       this.log('  $ block [hash/height]: View block.');
       this.log('  $ rescan [height/hash]: Rescan for transactions.');
       this.log('  $ resend: Resend pending transactions.');
-      this.log('  $ zap [age?]: Zap stale transactions from walletdb.');
       this.log('  $ backup [path]: Backup the wallet db.');
       this.log('  $ rpc [command] [args]: Execute RPC command.');
       return;

--- a/bin/cli
+++ b/bin/cli
@@ -320,6 +320,12 @@ CLI.prototype.getDetails = co(function* getDetails() {
   this.log(details);
 });
 
+CLI.prototype.getWalletBlock = co(function* getWalletBlock() {
+  var height = this.argv[0] | 0;
+  var details = yield this.wallet.getBlock(height);
+  this.log(details);
+});
+
 CLI.prototype.retoken = co(function* retoken() {
   var result = yield this.wallet.retoken();
   this.log(result);
@@ -480,6 +486,8 @@ CLI.prototype.handleWallet = co(function* handleWallet() {
       return yield this.zapWallet();
     case 'tx':
       return yield this.getDetails();
+    case 'block':
+      return yield this.getWalletBlock();
     case 'view':
       return yield this.viewTX();
     case 'import':
@@ -518,6 +526,7 @@ CLI.prototype.handleWallet = co(function* handleWallet() {
       this.log('  $ sign [tx-hex]: Sign transaction.');
       this.log('  $ zap [age?]: Zap pending wallet TXs.');
       this.log('  $ tx [hash]: View transaction details.');
+      this.log('  $ block [height]: View wallet block.');
       this.log('  $ view [tx-hex]: Parse and view transaction.');
       this.log('  $ import [wif|hex]: Import private or public key.');
       this.log('  $ watch [address]: Import an address.');

--- a/bin/cli
+++ b/bin/cli
@@ -66,21 +66,44 @@ CLI.prototype.createWallet = co(function* createWallet() {
   this.log(wallet);
 });
 
-CLI.prototype.addKey = co(function* addKey() {
+CLI.prototype.getMaster = co(function* getMaster() {
+  var master = yield this.wallet.getMaster();
+  this.log(master);
+});
+
+CLI.prototype.getKey = co(function* getKey() {
+  var address = this.argv[0];
+  var key = yield this.wallet.getKey(address);
+  this.log(key);
+});
+
+CLI.prototype.getWIF = co(function* getWIF() {
+  var address = this.argv[0];
+  var key = yield this.wallet.getWIF(address, this.config.passphrase);
+  this.log(key.privateKey);
+});
+
+CLI.prototype.addSharedKey = co(function* addSharedKey() {
   var key = this.argv[0];
-  yield this.wallet.addKey(this.config.account, key);
+  yield this.wallet.addSharedKey(this.config.account, key);
   this.log('Added key.');
 });
 
-CLI.prototype.removeKey = co(function* removeKey() {
+CLI.prototype.removeSharedKey = co(function* removeSharedKey() {
   var key = this.argv[0];
-  yield this.wallet.removeKey(this.config.account, key);
+  yield this.wallet.removeSharedKey(this.config.account, key);
   this.log('Removed key.');
 });
 
+CLI.prototype.getSharedKeys = co(function* getSharedKeys() {
+  var acct = this.argv[0] || this.config.account;
+  var account = yield this.wallet.getAccount(acct);
+  this.log(account.keys);
+});
+
 CLI.prototype.getAccount = co(function* getAccount() {
-  var account = this.argv[0] || this.config.account;
-  yield this.wallet.getAccount(account);
+  var acct = this.argv[0] || this.config.account;
+  var account = yield this.wallet.getAccount(acct);
   this.log(account);
 });
 
@@ -409,10 +432,20 @@ CLI.prototype.handleWallet = co(function* handleWallet() {
       return yield this.listenWallet();
     case 'get':
       return yield this.getWallet();
-    case 'addkey':
-      return yield this.addKey();
-    case 'rmkey':
-      return yield this.removeKey();
+    case 'master':
+      return yield this.getMaster();
+    case 'shared':
+      if (this.argv[0] === 'add') {
+        this.argv.shift();
+        return yield this.addSharedKey();
+      }
+      if (this.argv[0] === 'remove') {
+        this.argv.shift();
+        return yield this.removeSharedKey();
+      }
+      if (this.argv[0] === 'list')
+        this.argv.shift();
+      return yield this.getSharedKeys();
     case 'balance':
       return yield this.getBalance();
     case 'history':
@@ -453,6 +486,10 @@ CLI.prototype.handleWallet = co(function* handleWallet() {
       return yield this.importKey();
     case 'watch':
       return yield this.importAddress();
+    case 'key':
+      return yield this.getKey();
+    case 'dump':
+      return yield this.getWIF();
     case 'lock':
       return yield this.lock();
     case 'unlock':
@@ -464,8 +501,9 @@ CLI.prototype.handleWallet = co(function* handleWallet() {
       this.log('Commands:');
       this.log('  $ listen: Listen for events.');
       this.log('  $ get: View wallet.');
-      this.log('  $ addkey [xpubkey]: Add key to wallet.');
-      this.log('  $ rmkey [xpubkey]: Remove key from wallet.');
+      this.log('  $ master: View wallet master key.');
+      this.log('  $ shared add [xpubkey]: Add key to wallet.');
+      this.log('  $ shared remove [xpubkey]: Remove key from wallet.');
       this.log('  $ balance: Get wallet balance.');
       this.log('  $ history: View wallet TX history.');
       this.log('  $ coins: View wallet coins.');
@@ -483,6 +521,8 @@ CLI.prototype.handleWallet = co(function* handleWallet() {
       this.log('  $ view [tx-hex]: Parse and view transaction.');
       this.log('  $ import [wif|hex]: Import private or public key.');
       this.log('  $ watch [address]: Import an address.');
+      this.log('  $ key [address]: Get wallet key by address.');
+      this.log('  $ dump [address]: Get wallet key WIF by address.');
       this.log('  $ lock: Lock wallet.');
       this.log('  $ unlock [passphrase] [timeout?]: Unlock wallet.');
       this.log('  $ resend: Resend pending transactions.');

--- a/lib/chain/chain.js
+++ b/lib/chain/chain.js
@@ -707,7 +707,7 @@ Chain.prototype.verifyInputs = co(function* verifyInputs(block, prev, state) {
  * @returns {Number}
  */
 
-Chain.prototype._getCachedHeight = function _getCachedHeight(hash) {
+Chain.prototype.checkHeight = function checkHeight(hash) {
   if (this.db.hasCache(hash))
     return this.db.getCache(hash).height;
 

--- a/lib/chain/chaindb.js
+++ b/lib/chain/chaindb.js
@@ -375,16 +375,6 @@ ChainDB.prototype.commit = co(function* commit() {
 });
 
 /**
- * Add an entry to the LRU cache.
- * @param {ChainEntry} entry
- */
-
-ChainDB.prototype.addCache = function addCache(entry) {
-  this.cacheHash.set(entry.hash, entry);
-  this.cacheHeight.set(entry.height, entry);
-};
-
-/**
  * Test the cache for a present entry hash or height.
  * @param {Hash|Number} hash - Hash or height.
  */

--- a/lib/chain/chaindb.js
+++ b/lib/chain/chaindb.js
@@ -21,6 +21,7 @@ var ldb = require('../db/ldb');
 var LRU = require('../utils/lru');
 var Block = require('../primitives/block');
 var Coin = require('../primitives/coin');
+var Outpoint = require('../primitives/outpoint');
 var TX = require('../primitives/tx');
 var Address = require('../primitives/address');
 var ChainEntry = require('./chainentry');
@@ -1096,8 +1097,8 @@ ChainDB.prototype.getTXByAddress = co(function* getTXByAddress(addresses) {
 
 ChainDB.prototype.scan = co(function* scan(start, filter, iter) {
   var total = 0;
-  var i, j, entry, hashes;
-  var hash, tx, txs, block;
+  var i, j, entry, hash, tx, txs, block;
+  var found, input, output, prevout;
 
   if (start == null)
     start = this.network.genesis.hash;
@@ -1116,7 +1117,7 @@ ChainDB.prototype.scan = co(function* scan(start, filter, iter) {
     throw new Error('Cannot rescan an alternate chain.');
 
   while (entry) {
-    block = yield this.getFullBlock(entry.hash);
+    block = yield this.getBlock(entry.hash);
     txs = [];
     total++;
 
@@ -1134,11 +1135,32 @@ ChainDB.prototype.scan = co(function* scan(start, filter, iter) {
 
     for (i = 0; i < block.txs.length; i++) {
       tx = block.txs[i];
-      hashes = tx.getHashes();
+      found = false;
 
-      for (j = 0; j < hashes.length; j++) {
-        hash = hashes[j];
+      for (j = 0; j < tx.outputs.length; j++) {
+        output = tx.outputs[j];
+        hash = output.getHash();
+
+        if (!hash)
+          continue;
+
         if (filter.test(hash)) {
+          prevout = Outpoint.fromTX(tx, j);
+          filter.add(prevout.toRaw());
+          found = true;
+        }
+      }
+
+      if (found) {
+        txs.push(tx);
+        continue;
+      }
+
+      for (j = 0; j < tx.inputs.length; j++) {
+        input = tx.inputs[j];
+        prevout = input.prevout;
+
+        if (filter.test(prevout.toRaw())) {
           txs.push(tx);
           break;
         }

--- a/lib/hd/mnemonic.js
+++ b/lib/hd/mnemonic.js
@@ -121,7 +121,7 @@ Mnemonic.prototype.destroy = function destroy() {
   this.bits = constants.hd.MIN_ENTROPY;
   this.language = 'english';
   if (this.entropy) {
-    this.entropy.fill(0);
+    crypto.cleanse(this.entropy);
     this.entropy = null;
   }
   this.phrase = null;

--- a/lib/hd/private.js
+++ b/lib/hd/private.js
@@ -155,14 +155,15 @@ HDPrivateKey.prototype.__defineGetter__('xpubkey', function() {
 
 HDPrivateKey.prototype.destroy = function destroy(pub) {
   this.depth = 0;
-  this.parentFingerPrint.fill(0);
   this.childIndex = 0;
-  this.chainCode.fill(0);
-  this.privateKey.fill(0);
-  this.publicKey.fill(0);
+
+  crypto.cleanse(this.parentFingerPrint);
+  crypto.cleanse(this.chainCode);
+  crypto.cleanse(this.privateKey);
+  crypto.cleanse(this.publicKey);
 
   if (this.fingerPrint) {
-    this.fingerPrint.fill(0);
+    crypto.cleanse(this.fingerPrint);
     this.fingerPrint = null;
   }
 

--- a/lib/hd/public.js
+++ b/lib/hd/public.js
@@ -118,13 +118,14 @@ HDPublicKey.prototype.__defineGetter__('xpubkey', function() {
 
 HDPublicKey.prototype.destroy = function destroy() {
   this.depth = 0;
-  this.parentFingerPrint.fill(0);
   this.childIndex = 0;
-  this.chainCode.fill(0);
-  this.publicKey.fill(0);
+
+  crypto.cleanse(this.parentFingerPrint);
+  crypto.cleanse(this.chainCode);
+  crypto.cleanse(this.publicKey);
 
   if (this.fingerPrint) {
-    this.fingerPrint.fill(0);
+    crypto.cleanse(this.fingerPrint);
     this.fingerPrint = null;
   }
 

--- a/lib/http/client.js
+++ b/lib/http/client.js
@@ -363,17 +363,6 @@ HTTPClient.prototype.resend = function resend() {
 };
 
 /**
- * Zap stale transactions.
- * @param {Number} age
- * @returns {Promise}
- */
-
-HTTPClient.prototype.zap = function zap(age) {
-  var options = { age: age };
-  return this._post('/zap', options);
-};
-
-/**
  * Backup the walletdb.
  * @param {String} path
  * @returns {Promise}

--- a/lib/http/client.js
+++ b/lib/http/client.js
@@ -433,7 +433,7 @@ HTTPClient.prototype.none = function none() {
  * Request the raw wallet JSON (will create wallet if it does not exist).
  * @private
  * @param {Object} options - See {@link Wallet}.
- * @returns {Promise} - Returns Object.
+ * @returns {Promise}
  */
 
 HTTPClient.prototype.createWallet = function createWallet(options) {
@@ -444,7 +444,7 @@ HTTPClient.prototype.createWallet = function createWallet(options) {
  * Get the raw wallet JSON.
  * @private
  * @param {WalletID} id
- * @returns {Promise} - Returns Object.
+ * @returns {Promise}
  */
 
 HTTPClient.prototype.getWallet = function getWallet(id) {
@@ -454,7 +454,7 @@ HTTPClient.prototype.getWallet = function getWallet(id) {
 /**
  * Get wallet transaction history.
  * @param {WalletID} id
- * @returns {Promise} - Returns {@link TX}[].
+ * @returns {Promise}
  */
 
 HTTPClient.prototype.getHistory = function getHistory(id, account) {
@@ -465,7 +465,7 @@ HTTPClient.prototype.getHistory = function getHistory(id, account) {
 /**
  * Get wallet coins.
  * @param {WalletID} id
- * @returns {Promise} - Returns {@link Coin}[].
+ * @returns {Promise}
  */
 
 HTTPClient.prototype.getCoins = function getCoins(id, account) {
@@ -476,7 +476,7 @@ HTTPClient.prototype.getCoins = function getCoins(id, account) {
 /**
  * Get all unconfirmed transactions.
  * @param {WalletID} id
- * @returns {Promise} - Returns {@link TX}[].
+ * @returns {Promise}
  */
 
 HTTPClient.prototype.getPending = function getPending(id, account) {
@@ -487,7 +487,7 @@ HTTPClient.prototype.getPending = function getPending(id, account) {
 /**
  * Calculate wallet balance.
  * @param {WalletID} id
- * @returns {Promise} - Returns {@link Balance}.
+ * @returns {Promise}
  */
 
 HTTPClient.prototype.getBalance = function getBalance(id, account) {
@@ -499,7 +499,7 @@ HTTPClient.prototype.getBalance = function getBalance(id, account) {
  * Get last N wallet transactions.
  * @param {WalletID} id
  * @param {Number} limit - Max number of transactions.
- * @returns {Promise} - Returns {@link TX}[].
+ * @returns {Promise}
  */
 
 HTTPClient.prototype.getLast = function getLast(id, account, limit) {
@@ -515,7 +515,7 @@ HTTPClient.prototype.getLast = function getLast(id, account, limit) {
  * @param {Number} options.end - End time.
  * @param {Number?} options.limit - Max number of records.
  * @param {Boolean?} options.reverse - Reverse order.
- * @returns {Promise} - Returns {@link TX}[].
+ * @returns {Promise}
  */
 
 HTTPClient.prototype.getRange = function getRange(id, account, options) {
@@ -534,11 +534,22 @@ HTTPClient.prototype.getRange = function getRange(id, account, options) {
  * is available in the wallet history).
  * @param {WalletID} id
  * @param {Hash} hash
- * @returns {Promise} - Returns {@link TX}[].
+ * @returns {Promise}
  */
 
 HTTPClient.prototype.getWalletTX = function getWalletTX(id, hash) {
   return this._get('/wallet/' + id + '/tx/' + hash);
+};
+
+/**
+ * Get wallet block.
+ * @param {WalletID} id
+ * @param {Number} height
+ * @returns {Promise}
+ */
+
+HTTPClient.prototype.getWalletBlock = function getWalletBlock(id, height) {
+  return this._get('/wallet/' + id + '/block/' + height);
 };
 
 /**
@@ -547,7 +558,7 @@ HTTPClient.prototype.getWalletTX = function getWalletTX(id, hash) {
  * @param {WalletID} id
  * @param {Hash} hash
  * @param {Number} index
- * @returns {Promise} - Returns {@link Coin}[].
+ * @returns {Promise}
  */
 
 HTTPClient.prototype.getWalletCoin = function getWalletCoin(id, account, hash, index) {
@@ -562,7 +573,7 @@ HTTPClient.prototype.getWalletCoin = function getWalletCoin(id, account, hash, i
  * @param {Object} options
  * @param {Base58Address} options.address
  * @param {Amount} options.value
- * @returns {Promise} - Returns {@link TX}.
+ * @returns {Promise}
  */
 
 HTTPClient.prototype.send = function send(id, options) {
@@ -611,7 +622,7 @@ HTTPClient.prototype.setPassphrase = function setPassphrase(id, old, new_) {
  * Create a transaction, fill.
  * @param {WalletID} id
  * @param {Object} options
- * @returns {Promise} - Returns {@link TX}.
+ * @returns {Promise}
  */
 
 HTTPClient.prototype.createTX = function createTX(id, options) {
@@ -636,7 +647,7 @@ HTTPClient.prototype.createTX = function createTX(id, options) {
  * @param {WalletID} id
  * @param {TX} tx
  * @param {Object} options
- * @returns {Promise} - Returns {@link TX}.
+ * @returns {Promise}
  */
 
 HTTPClient.prototype.sign = function sign(id, tx, options) {
@@ -654,7 +665,7 @@ HTTPClient.prototype.sign = function sign(id, tx, options) {
 /**
  * Fill a transaction with coins.
  * @param {TX} tx
- * @returns {Promise} - Returns {@link TX}.
+ * @returns {Promise}
  */
 
 HTTPClient.prototype.fillCoins = function fillCoins(id, tx) {
@@ -895,7 +906,7 @@ HTTPClient.prototype.createAccount = function createAccount(id, options) {
  * Create address.
  * @param {WalletID} id
  * @param {Object} options
- * @returns {Promise} - Returns Array.
+ * @returns {Promise}
  */
 
 HTTPClient.prototype.createAddress = function createAddress(id, options) {
@@ -916,7 +927,7 @@ HTTPClient.prototype.createAddress = function createAddress(id, options) {
  * Create address.
  * @param {WalletID} id
  * @param {Object} options
- * @returns {Promise} - Returns Array.
+ * @returns {Promise}
  */
 
 HTTPClient.prototype.createNested = function createNested(id, options) {

--- a/lib/http/client.js
+++ b/lib/http/client.js
@@ -678,31 +678,55 @@ HTTPClient.prototype.zapWallet = function zapWallet(id, account, age) {
 };
 
 /**
+ * Get wallet key.
+ * @param {WalletID} id
+ * @param {Base58Address} address
+ * @returns {Promise}
+ */
+
+HTTPClient.prototype.getKey = function getKey(id, address) {
+  return this._get('/wallet/' + id + '/key/' + address);
+};
+
+/**
+ * Get wallet key WIF dump.
+ * @param {WalletID} id
+ * @param {Base58Address} address
+ * @param {String?} passphrase
+ * @returns {Promise}
+ */
+
+HTTPClient.prototype.getWIF = function getWIF(id, address, passphrase) {
+  var options = { passphrase: passphrase };
+  return this._get('/wallet/' + id + '/wif/' + address, options);
+};
+
+/**
  * Add a public account/purpose key to the wallet for multisig.
  * @param {WalletID} id
  * @param {(String|Number)?} account
- * @param {HDPublicKey|Base58String} key - Account (bip44) or
+ * @param {Base58String} key - Account (bip44) or
  * Purpose (bip45) key (can be in base58 form).
  * @returns {Promise}
  */
 
-HTTPClient.prototype.addKey = function addKey(id, account, key) {
+HTTPClient.prototype.addSharedKey = function addSharedKey(id, account, key) {
   var options = { account: account, accountKey: key };
-  return this._put('/wallet/' + id + '/key', options);
+  return this._put('/wallet/' + id + '/shared-key', options);
 };
 
 /**
  * Remove a public account/purpose key to the wallet for multisig.
  * @param {WalletID} id
  * @param {(String|Number)?} account
- * @param {HDPublicKey|Base58String} key - Account (bip44) or Purpose
+ * @param {Base58String} key - Account (bip44) or Purpose
  * (bip45) key (can be in base58 form).
  * @returns {Promise}
  */
 
-HTTPClient.prototype.removeKey = function removeKey(id, account, key) {
+HTTPClient.prototype.removeSharedKey = function removeSharedKey(id, account, key) {
   var options = { account: account, accountKey: key };
-  return this._del('/wallet/' + id + '/key', options);
+  return this._del('/wallet/' + id + '/shared-key', options);
 };
 
 /**
@@ -820,6 +844,17 @@ HTTPClient.prototype.resendWallet = function resendWallet(id) {
 
 HTTPClient.prototype.getAccounts = function getAccounts(id) {
   var path = '/wallet/' + id + '/account';
+  return this._get(path);
+};
+
+/**
+ * Get wallet master key.
+ * @param {WalletID} id
+ * @returns {Promise}
+ */
+
+HTTPClient.prototype.getMaster = function getMaster(id) {
+  var path = '/wallet/' + id + '/master';
   return this._get(path);
 };
 

--- a/lib/http/client.js
+++ b/lib/http/client.js
@@ -537,9 +537,8 @@ HTTPClient.prototype.getRange = function getRange(id, account, options) {
  * @returns {Promise} - Returns {@link TX}[].
  */
 
-HTTPClient.prototype.getWalletTX = function getWalletTX(id, account, hash) {
-  var options = { account: account };
-  return this._get('/wallet/' + id + '/tx/' + hash, options);
+HTTPClient.prototype.getWalletTX = function getWalletTX(id, hash) {
+  return this._get('/wallet/' + id + '/tx/' + hash);
 };
 
 /**

--- a/lib/http/client.js
+++ b/lib/http/client.js
@@ -542,6 +542,17 @@ HTTPClient.prototype.getWalletTX = function getWalletTX(id, hash) {
 };
 
 /**
+ * Get wallet blocks.
+ * @param {WalletID} id
+ * @param {Number} height
+ * @returns {Promise}
+ */
+
+HTTPClient.prototype.getWalletBlocks = function getWalletBlocks(id) {
+  return this._get('/wallet/' + id + '/block');
+};
+
+/**
  * Get wallet block.
  * @param {WalletID} id
  * @param {Number} height

--- a/lib/http/rpc.js
+++ b/lib/http/rpc.js
@@ -3168,7 +3168,7 @@ RPC.prototype.getwalletinfo = co(function* getwalletinfo(args) {
 
   return {
     walletid: this.wallet.id,
-    walletversion: 0,
+    walletversion: 6,
     balance: +utils.btc(balance.unconfirmed),
     unconfirmed_balance: +utils.btc(balance.unconfirmed),
     txcount: this.wallet.state.tx,

--- a/lib/http/rpc.js
+++ b/lib/http/rpc.js
@@ -415,10 +415,10 @@ RPC.prototype.addnode = function addnode(args) {
       }
       break;
     case 'onetry':
-      if (this.pool.peers.get(addr))
-        break;
-      peer = this.createPeer(addr);
-      this.peers.addPending(peer);
+      if (!this.pool.peers.get(addr)) {
+        peer = this.pool.createPeer(addr);
+        this.pool.peers.addPending(peer);
+      }
       break;
   }
 

--- a/lib/http/server.js
+++ b/lib/http/server.js
@@ -1244,17 +1244,17 @@ HTTPServer.prototype._initIO = function _initIO() {
       callback();
     });
 
-    socket.on('watch hash', function(args, callback) {
-      var hashes = args[0];
+    socket.on('watch data', function(args, callback) {
+      var chunks = args[0];
 
-      if (!Array.isArray(hashes))
+      if (!Array.isArray(chunks))
         return callback({ error: 'Invalid parameter.' });
 
       if (!socket.api)
         return callback({ error: 'Not authorized.' });
 
       try {
-        socket.addFilter(hashes);
+        socket.addFilter(chunks);
       } catch (e) {
         return callback({ error: e.message });
       }
@@ -1503,22 +1503,22 @@ ClientSocket.prototype._init = function _init() {
   });
 };
 
-ClientSocket.prototype.addFilter = function addFilter(hashes) {
-  var i, hash;
+ClientSocket.prototype.addFilter = function addFilter(chunks) {
+  var i, data;
 
   if (!this.filter)
     this.filter = Bloom.fromRate(100000, 0.001, -1);
 
-  for (i = 0; i < hashes.length; i++) {
-    hash = Address.getHash(hashes[i], 'hex');
+  for (i = 0; i < chunks.length; i++) {
+    data = chunks[i];
 
-    if (!hash)
-      throw new Error('Bad hash.');
+    if (!utils.isHex(data))
+      throw new Error('Not a hex string.');
 
-    this.filter.add(hash, 'hex');
+    this.filter.add(data, 'hex');
 
     if (this.pool.options.spv)
-      this.pool.watch(hash, 'hex');
+      this.pool.watch(data, 'hex');
   }
 };
 
@@ -1625,19 +1625,11 @@ ClientSocket.prototype.testFilterFull = function testFilterFull(tx) {
 };
 
 ClientSocket.prototype.testFilterSPV = function testFilterSPV(tx) {
+  var found = false;
   var i, hash, input, prevout, output, outpoint;
 
   if (!this.filter)
     return false;
-
-  if (!tx.isCoinbase()) {
-    for (i = 0; i < tx.inputs.length; i++) {
-      input = tx.inputs[i];
-      prevout = input.prevout;
-      if (this.filter.test(prevout.toRaw()))
-        return true;
-    }
-  }
 
   for (i = 0; i < tx.outputs.length; i++) {
     output = tx.outputs[i];
@@ -1649,7 +1641,19 @@ ClientSocket.prototype.testFilterSPV = function testFilterSPV(tx) {
     if (this.filter.test(hash)) {
       outpoint = Outpoint.fromTX(tx, i);
       this.filter.add(outpoint.toRaw());
-      return true;
+      found = true;
+    }
+  }
+
+  if (found)
+    return true;
+
+  if (!tx.isCoinbase()) {
+    for (i = 0; i < tx.inputs.length; i++) {
+      input = tx.inputs[i];
+      prevout = input.prevout;
+      if (this.filter.test(prevout.toRaw()))
+        return true;
     }
   }
 

--- a/lib/http/server.js
+++ b/lib/http/server.js
@@ -917,6 +917,12 @@ HTTPServer.prototype._init = function _init() {
     send(200, { success: true });
   }));
 
+  // List blocks
+  this.get('/wallet/:id/block', con(function* (req, res, send, next) {
+    var heights = yield req.wallet.getBlocks();
+    send(200, heights);
+  }));
+
   // Get Block Record
   this.get('/wallet/:id/block/:height', con(function* (req, res, send, next) {
     var height = req.options.height;

--- a/lib/http/server.js
+++ b/lib/http/server.js
@@ -756,6 +756,11 @@ HTTPServer.prototype._init = function _init() {
     send(200, req.wallet.toJSON());
   });
 
+  // Get wallet master key
+  this.get('/wallet/:id/master', function(req, res, send, next) {
+    send(200, req.wallet.master.toJSON(true));
+  });
+
   // Create wallet
   this.post('/wallet/:id?', con(function* (req, res, send, next) {
     var wallet = yield this.walletdb.create(req.options);
@@ -913,23 +918,56 @@ HTTPServer.prototype._init = function _init() {
   }));
 
   // Add key
-  this.put('/wallet/:id/key', con(function* (req, res, send, next) {
+  this.put('/wallet/:id/shared-key', con(function* (req, res, send, next) {
     var options = req.options;
     var acct = options.name || options.account;
     var key = options.accountKey;
     enforce(key, 'Key is required.');
-    yield req.wallet.addKey(acct, key);
+    yield req.wallet.addSharedKey(acct, key);
     send(200, { success: true });
   }));
 
   // Remove key
-  this.del('/wallet/:id/key', con(function* (req, res, send, next) {
+  this.del('/wallet/:id/shared-key', con(function* (req, res, send, next) {
     var options = req.options;
     var acct = options.name || options.account;
     var key = options.accountKey;
     enforce(key, 'Key is required.');
-    yield req.wallet.removeKey(acct, key);
+    yield req.wallet.removeSharedKey(acct, key);
     send(200, { success: true });
+  }));
+
+  // Get key by address
+  this.get('/wallet/:id/key/:address', con(function* (req, res, send, next) {
+    var options = req.options;
+    var address = options.address;
+    var key;
+
+    enforce(address instanceof Address, 'Address is required.');
+
+    key = yield req.wallet.getKey(address);
+
+    if (!key)
+      return send(404);
+
+    send(200, key.toJSON());
+  }));
+
+  // Get private key
+  this.get('/wallet/:id/wif/:address', con(function* (req, res, send, next) {
+    var options = req.options;
+    var address = options.address;
+    var passphrase = options.passphrase;
+    var key;
+
+    enforce(address instanceof Address, 'Address is required.');
+
+    key = yield req.wallet.getPrivateKey(address, passphrase);
+
+    if (!key)
+      return send(404);
+
+    send(200, { privateKey: key.toSecret() });
   }));
 
   // Create address

--- a/lib/http/server.js
+++ b/lib/http/server.js
@@ -740,18 +740,6 @@ HTTPServer.prototype._init = function _init() {
     send(200, { success: true });
   }));
 
-  // Zap
-  this.post('/zap', con(function* (req, res, send, next) {
-    var options = req.options;
-    var age = options.age;
-
-    enforce(age != null, 'Age is required.');
-
-    yield this.walletdb.zap(age);
-
-    send(200, { success: true });
-  }));
-
   // Backup WalletDB
   this.post('/backup', con(function* (req, res, send, next) {
     var options = req.options;

--- a/lib/http/server.js
+++ b/lib/http/server.js
@@ -917,6 +917,21 @@ HTTPServer.prototype._init = function _init() {
     send(200, { success: true });
   }));
 
+  // Get Block Record
+  this.get('/wallet/:id/block/:height', con(function* (req, res, send, next) {
+    var height = req.options.height;
+    var block;
+
+    enforce(height != null, 'Height is required.');
+
+    block = yield req.wallet.getBlock(height);
+
+    if (!block)
+      return send(404);
+
+    send(200, block.toJSON());
+  }));
+
   // Add key
   this.put('/wallet/:id/shared-key', con(function* (req, res, send, next) {
     var options = req.options;

--- a/lib/http/wallet.js
+++ b/lib/http/wallet.js
@@ -105,7 +105,7 @@ HTTPWallet.prototype.open = co(function* open(options) {
 
   wallet = yield this.client.getWallet(this.id);
 
-  yield this.client.join(this.id, wallet.token);
+  yield this.client.join(this.id, this.token);
 
   return wallet;
 });
@@ -118,12 +118,18 @@ HTTPWallet.prototype.open = co(function* open(options) {
 
 HTTPWallet.prototype.create = co(function* create(options) {
   var wallet;
+
   yield this.client.open();
+
   wallet = yield this.client.createWallet(options);
-  return yield this.open({
-    id: wallet.id,
-    token: wallet.token
-  });
+
+  this.id = wallet.id;
+  this.token = wallet.token;
+  this.client.token = this.token;
+
+  yield this.client.join(this.id, this.token);
+
+  return wallet;
 });
 
 /**
@@ -244,7 +250,7 @@ HTTPWallet.prototype.fillCoins = function fillCoins(tx) {
  * @see HTTPClient#getWallet
  */
 
-HTTPWallet.prototype.getInfo = function getInfo(callback) {
+HTTPWallet.prototype.getInfo = function getInfo() {
   return this.client.getWallet(this.id);
 };
 
@@ -252,8 +258,16 @@ HTTPWallet.prototype.getInfo = function getInfo(callback) {
  * @see Wallet#getAccounts
  */
 
-HTTPWallet.prototype.getAccounts = function getAccounts(callback) {
+HTTPWallet.prototype.getAccounts = function getAccounts() {
   return this.client.getAccounts(this.id);
+};
+
+/**
+ * @see Wallet#master
+ */
+
+HTTPWallet.prototype.getMaster = function getMaster() {
+  return this.client.getMaster(this.id);
 };
 
 /**
@@ -391,6 +405,51 @@ HTTPWallet.prototype.lock = function lock() {
 
 HTTPWallet.prototype.unlock = function unlock(passphrase, timeout) {
   return this.client.unlock(this.id, passphrase, timeout);
+};
+
+/**
+ * Get wallet key.
+ * @param {Base58Address} address
+ * @returns {Promise}
+ */
+
+HTTPWallet.prototype.getKey = function getKey(address) {
+  return this.client.getKey(this.id, address);
+};
+
+/**
+ * Get wallet key WIF dump.
+ * @param {Base58Address} address
+ * @param {String?} passphrase
+ * @returns {Promise}
+ */
+
+HTTPWallet.prototype.getWIF = function getWIF(address, passphrase) {
+  return this.client.getWIF(this.id, address, passphrase);
+};
+
+/**
+ * Add a public account/purpose key to the wallet for multisig.
+ * @param {(String|Number)?} account
+ * @param {Base58String} key - Account (bip44) or
+ * Purpose (bip45) key (can be in base58 form).
+ * @returns {Promise}
+ */
+
+HTTPWallet.prototype.addSharedKey = function addSharedKey(account, key) {
+  return this.client.addSharedKey(this.id, account, key);
+};
+
+/**
+ * Remove a public account/purpose key to the wallet for multisig.
+ * @param {(String|Number)?} account
+ * @param {Base58String} key - Account (bip44) or Purpose
+ * (bip45) key (can be in base58 form).
+ * @returns {Promise}
+ */
+
+HTTPWallet.prototype.removeSharedKey = function removeSharedKey(account, key) {
+  return this.client.removeSharedKey(this.id, account, key);
 };
 
 /**

--- a/lib/http/wallet.js
+++ b/lib/http/wallet.js
@@ -188,8 +188,8 @@ HTTPWallet.prototype.getRange = function getRange(account, options) {
  * @see Wallet#getTX
  */
 
-HTTPWallet.prototype.getTX = function getTX(account, hash) {
-  return this.client.getWalletTX(this.id, account, hash);
+HTTPWallet.prototype.getTX = function getTX(hash) {
+  return this.client.getWalletTX(this.id, hash);
 };
 
 /**

--- a/lib/http/wallet.js
+++ b/lib/http/wallet.js
@@ -199,6 +199,14 @@ HTTPWallet.prototype.getTX = function getTX(hash) {
 };
 
 /**
+ * @see Wallet#getBlocks
+ */
+
+HTTPWallet.prototype.getBlocks = function getBlocks() {
+  return this.client.getWalletBlocks(this.id);
+};
+
+/**
  * @see Wallet#getBlock
  */
 

--- a/lib/http/wallet.js
+++ b/lib/http/wallet.js
@@ -199,6 +199,14 @@ HTTPWallet.prototype.getTX = function getTX(hash) {
 };
 
 /**
+ * @see Wallet#getBlock
+ */
+
+HTTPWallet.prototype.getBlock = function getBlock(height) {
+  return this.client.getWalletBlock(this.id, height);
+};
+
+/**
  * @see Wallet#getCoin
  */
 

--- a/lib/net/peer.js
+++ b/lib/net/peer.js
@@ -2286,7 +2286,7 @@ Peer.prototype.sendGetHeaders = function sendGetHeaders(locator, stop) {
     this.hostname);
 
   if (packet.locator.length > 0) {
-    height = this.chain._getCachedHeight(packet.locator[0]);
+    height = this.chain.checkHeight(packet.locator[0]);
     hash = utils.revHex(packet.locator[0]);
   }
 
@@ -2314,7 +2314,7 @@ Peer.prototype.sendGetBlocks = function getBlocks(locator, stop) {
     this.hostname);
 
   if (packet.locator.length > 0) {
-    height = this.chain._getCachedHeight(packet.locator[0]);
+    height = this.chain.checkHeight(packet.locator[0]);
     hash = utils.revHex(packet.locator[0]);
   }
 

--- a/lib/node/config.js
+++ b/lib/node/config.js
@@ -45,6 +45,7 @@ config.alias = {
 
 config.parse = function parse(options) {
   var data = {};
+  var raw = {};
   var arg, conf, prefix, filename, dirname;
 
   if (!options)
@@ -54,16 +55,19 @@ config.parse = function parse(options) {
 
   if (options.env) {
     arg = config.parseEnv();
+    merge(raw, arg.data);
     merge(data, arg);
   }
 
   if (options.arg) {
     arg = config.parseArg();
+    merge(raw, arg.data);
     merge(data, arg);
   }
 
   if (options.query) {
     arg = config.parseQuery();
+    merge(raw, arg.data);
     merge(data, arg);
   }
 
@@ -76,6 +80,7 @@ config.parse = function parse(options) {
 
     dirname = utils.normalize(filename, true);
     conf = config.readConfig(filename, prefix, dirname);
+    raw = merge(conf.data, raw);
     data = merge(conf, data);
 
     prefix = config.getPrefix(data);
@@ -90,6 +95,8 @@ config.parse = function parse(options) {
       data.authPeers = config.readAuth(filename);
     }
   }
+
+  data.data = raw;
 
   // Force fast properties
   // after all those merges.

--- a/lib/node/config.js
+++ b/lib/node/config.js
@@ -203,7 +203,6 @@ config.parseData = function parseData(data, prefix, dirname) {
   options.noAuth = bool(data.noauth);
 
   // Wallet
-  options.noScan = bool(data.noscan);
   options.wipeNoReally = bool(data.wipenoreally);
 
   options.data = data;

--- a/lib/node/config.js
+++ b/lib/node/config.js
@@ -210,6 +210,7 @@ config.parseData = function parseData(data, prefix, dirname) {
   options.noAuth = bool(data.noauth);
 
   // Wallet
+  options.startHeight = num(data.startheight);
   options.wipeNoReally = bool(data.wipenoreally);
 
   options.data = data;

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -148,7 +148,6 @@ function FullNode(options) {
     witness: this.options.witness,
     useCheckpoints: this.options.useCheckpoints,
     maxFiles: this.options.maxFiles,
-    noScan: this.options.noScan,
     wipeNoReally: this.options.wipeNoReally,
     resolution: false,
     verify: false

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -145,7 +145,7 @@ function FullNode(options) {
     client: this,
     db: this.options.db,
     location: this.location('walletdb'),
-    witness: this.options.witness,
+    witness: false,
     useCheckpoints: this.options.useCheckpoints,
     maxFiles: this.options.maxFiles,
     startHeight: this.options.startHeight,

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -278,12 +278,12 @@ FullNode.prototype._close = co(function* close() {
 });
 
 /**
- * Watch address or tx hashes (nop).
- * @param {Hash[]} hashes
+ * Watch address or outpoints (nop).
+ * @param {Hash[]} chunks
  * @returns {Promise}
  */
 
-FullNode.prototype.watchHash = function watchHash(hashes) {
+FullNode.prototype.watchData = function watchData(chunks) {
   return Promise.resolve();
 };
 

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -148,6 +148,7 @@ function FullNode(options) {
     witness: this.options.witness,
     useCheckpoints: this.options.useCheckpoints,
     maxFiles: this.options.maxFiles,
+    startHeight: this.options.startHeight,
     wipeNoReally: this.options.wipeNoReally,
     resolution: false,
     verify: false

--- a/lib/node/spvnode.js
+++ b/lib/node/spvnode.js
@@ -88,7 +88,6 @@ function SPVNode(options) {
     location: this.location('walletdb'),
     witness: this.options.witness,
     maxFiles: this.options.maxFiles,
-    noScan: this.options.noScan,
     wipeNoReally: this.options.wipeNoReally,
     resolution: true,
     verify: true

--- a/lib/node/spvnode.js
+++ b/lib/node/spvnode.js
@@ -195,18 +195,18 @@ SPVNode.prototype._close = co(function* close() {
 });
 
 /**
- * Watch address hashes.
- * @param {Hash[]} hashes
+ * Watch address hashes or outpoints.
+ * @param {Hash[]} chunks
  * @returns {Promise}
  */
 
-SPVNode.prototype.watchHash = function watchHash(hashes) {
+SPVNode.prototype.watchData = function watchData(chunks) {
   var i;
 
-  this.logger.info('Adding %d addresses to filter.', hashes.length);
+  this.logger.info('Adding %d addresses to filter.', chunks.length);
 
-  for (i = 0; i < hashes.length; i++)
-    this.pool.watch(hashes[i], 'hex');
+  for (i = 0; i < chunks.length; i++)
+    this.pool.watch(chunks[i], 'hex');
 
   return Promise.resolve();
 };

--- a/lib/node/spvnode.js
+++ b/lib/node/spvnode.js
@@ -88,6 +88,7 @@ function SPVNode(options) {
     location: this.location('walletdb'),
     witness: this.options.witness,
     maxFiles: this.options.maxFiles,
+    startHeight: this.options.startHeight,
     wipeNoReally: this.options.wipeNoReally,
     resolution: true,
     verify: true

--- a/lib/node/spvnode.js
+++ b/lib/node/spvnode.js
@@ -86,7 +86,7 @@ function SPVNode(options) {
     client: this,
     db: this.options.db,
     location: this.location('walletdb'),
-    witness: this.options.witness,
+    witness: false,
     maxFiles: this.options.maxFiles,
     startHeight: this.options.startHeight,
     wipeNoReally: this.options.wipeNoReally,

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -218,7 +218,7 @@ Account.fromOptions = function fromOptions(db, options) {
  * @const {Number}
  */
 
-Account.MAX_LOOKAHEAD = 50;
+Account.MAX_LOOKAHEAD = 40;
 
 /**
  * Attempt to intialize the account (generating
@@ -726,12 +726,33 @@ Account.prototype.syncDepth = co(function* syncDepth(receive, change, nested) {
  */
 
 Account.prototype.setLookahead = co(function* setLookahead(lookahead) {
-  var i, key, depth, target;
+  var i, diff, key, depth, target;
 
-  if (lookahead <= this.lookahead) {
+  if (lookahead === this.lookahead) {
     this.db.logger.warning(
-      'Lookahead is not increasing for: %s/%s.',
+      'Lookahead is not changing for: %s/%s.',
       this.id, this.name);
+    return;
+  }
+
+  if (lookahead < this.lookahead) {
+    diff = this.lookahead - lookahead;
+
+    this.receiveDepth += diff;
+    this.receive = this.deriveReceive(this.receiveDepth - 1);
+
+    this.changeDepth += diff;
+    this.change = this.deriveChange(this.changeDepth - 1);
+
+    if (this.witness) {
+      this.nestedDepth += diff;
+      this.nested = this.deriveNested(this.nestedDepth - 1);
+    }
+
+    this.lookahead = lookahead;
+
+    this.save();
+
     return;
   }
 

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -49,7 +49,6 @@ function Account(db, options) {
   this.db = db;
   this.network = db.network;
   this.wallet = null;
-  this.lookahead = Account.MAX_LOOKAHEAD;
 
   this.receive = null;
   this.change = null;
@@ -68,6 +67,7 @@ function Account(db, options) {
   this.receiveDepth = 0;
   this.changeDepth = 0;
   this.nestedDepth = 0;
+  this.lookahead = 5;
   this.accountKey = null;
   this.keys = [];
 
@@ -175,6 +175,13 @@ Account.prototype.fromOptions = function fromOptions(options) {
     this.nestedDepth = options.nestedDepth;
   }
 
+  if (options.lookahead != null) {
+    assert(utils.isNumber(options.lookahead));
+    assert(options.lookahead >= 0);
+    assert(options.lookahead <= Account.MAX_LOOKAHEAD);
+    this.lookahead = options.lookahead;
+  }
+
   this.accountKey = options.accountKey;
 
   if (this.n > 1)
@@ -211,7 +218,7 @@ Account.fromOptions = function fromOptions(db, options) {
  * @const {Number}
  */
 
-Account.MAX_LOOKAHEAD = 10;
+Account.MAX_LOOKAHEAD = 20;
 
 /**
  * Attempt to intialize the account (generating
@@ -670,7 +677,7 @@ Account.prototype.syncDepth = co(function* syncDepth(receive, change, nested) {
   if (receive > this.receiveDepth) {
     depth = this.receiveDepth + this.lookahead;
 
-    assert(receive < depth);
+    assert(receive <= depth);
 
     for (i = depth; i < receive + this.lookahead; i++) {
       key = this.deriveReceive(i);
@@ -687,7 +694,7 @@ Account.prototype.syncDepth = co(function* syncDepth(receive, change, nested) {
   if (change > this.changeDepth) {
     depth = this.changeDepth + this.lookahead;
 
-    assert(change < depth);
+    assert(change <= depth);
 
     for (i = depth; i < change + this.lookahead; i++) {
       key = this.deriveChange(i);
@@ -703,7 +710,7 @@ Account.prototype.syncDepth = co(function* syncDepth(receive, change, nested) {
   if (this.witness && nested > this.nestedDepth) {
     depth = this.nestedDepth + this.lookahead;
 
-    assert(nested < depth);
+    assert(nested <= depth);
 
     for (i = depth; i < nested + this.lookahead; i++) {
       key = this.deriveNested(i);
@@ -781,6 +788,7 @@ Account.prototype.inspect = function inspect() {
     receiveDepth: this.receiveDepth,
     changeDepth: this.changeDepth,
     nestedDepth: this.nestedDepth,
+    lookahead: this.lookahead,
     address: this.initialized
       ? this.receive.getAddress()
       : null,
@@ -815,6 +823,7 @@ Account.prototype.toJSON = function toJSON(minimal) {
     receiveDepth: this.receiveDepth,
     changeDepth: this.changeDepth,
     nestedDepth: this.nestedDepth,
+    lookahead: this.lookahead,
     receiveAddress: this.receive
       ? this.receive.getAddress('base58')
       : null,
@@ -850,6 +859,7 @@ Account.prototype.toRaw = function toRaw(writer) {
   p.writeU32(this.receiveDepth);
   p.writeU32(this.changeDepth);
   p.writeU32(this.nestedDepth);
+  p.writeU8(this.lookahead);
   p.writeBytes(this.accountKey.toRaw());
   p.writeU8(this.keys.length);
 
@@ -885,6 +895,7 @@ Account.prototype.fromRaw = function fromRaw(data) {
   this.receiveDepth = p.readU32();
   this.changeDepth = p.readU32();
   this.nestedDepth = p.readU32();
+  this.lookahead = p.readU8();
   this.accountKey = HD.fromRaw(p.readBytes(82));
 
   assert(Account.typesByVal[this.type]);

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -67,7 +67,7 @@ function Account(db, options) {
   this.receiveDepth = 0;
   this.changeDepth = 0;
   this.nestedDepth = 0;
-  this.lookahead = 5;
+  this.lookahead = 10;
   this.accountKey = null;
   this.keys = [];
 
@@ -441,9 +441,9 @@ Account.prototype.createKey = co(function* createKey(branch) {
       this.receive = key;
       break;
     case 1:
-      // Note: no lookahead here.
       key = this.deriveChange(this.changeDepth);
-      yield this.saveKey(key);
+      lookahead = this.deriveReceive(this.changeDepth + this.lookahead);
+      yield this.saveKey(lookahead);
       this.changeDepth++;
       this.change = key;
       break;
@@ -621,11 +621,17 @@ Account.prototype.initDepth = co(function* initDepth() {
     yield this.saveKey(key);
   }
 
-  // Change Address (no lookahead)
+  // Change Address
   this.change = this.deriveChange(0);
   this.changeDepth = 1;
 
   yield this.saveKey(this.change);
+
+  // Lookahead
+  for (i = 0; i < this.lookahead; i++) {
+    key = this.deriveChange(i + 1);
+    yield this.saveKey(key);
+  }
 
   // Nested Address
   if (this.witness) {
@@ -660,7 +666,7 @@ Account.prototype.syncDepth = co(function* syncDepth(receive, change, nested) {
   if (receive > this.receiveDepth) {
     depth = this.receiveDepth + this.lookahead;
 
-    assert(this.lookahead === 0 || receive <= depth);
+    assert(receive <= depth + 1);
 
     for (i = depth; i < receive + this.lookahead; i++) {
       key = this.deriveReceive(i);
@@ -675,12 +681,16 @@ Account.prototype.syncDepth = co(function* syncDepth(receive, change, nested) {
   }
 
   if (change > this.changeDepth) {
-    assert(change === this.changeDepth + 1);
+    depth = this.changeDepth + this.lookahead;
 
-    key = this.deriveChange(change - 1);
-    yield this.saveKey(key);
+    assert(change <= depth + 1);
 
-    this.change = key;
+    for (i = depth; i < change + this.lookahead; i++) {
+      key = this.deriveChange(i);
+      yield this.saveKey(key);
+    }
+
+    this.change = this.deriveChange(change - 1);
     this.changeDepth = change;
 
     derived = true;
@@ -689,7 +699,7 @@ Account.prototype.syncDepth = co(function* syncDepth(receive, change, nested) {
   if (this.witness && nested > this.nestedDepth) {
     depth = this.nestedDepth + this.lookahead;
 
-    assert(this.lookahead === 0 || nested <= depth);
+    assert(nested <= depth + 1);
 
     for (i = depth; i < nested + this.lookahead; i++) {
       key = this.deriveNested(i);

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -234,7 +234,8 @@ Account.prototype.init = co(function* init() {
   assert(this.nestedDepth === 0);
 
   this.initialized = true;
-  yield this.setDepth(1, 1, 1);
+
+  yield this.initDepth();
 });
 
 /**
@@ -433,32 +434,29 @@ Account.prototype.createNested = function createNested() {
  */
 
 Account.prototype.createKey = co(function* createKey(branch) {
-  var ring, lookahead;
+  var key, lookahead;
 
   switch (branch) {
     case 0:
-      ring = this.deriveReceive(this.receiveDepth);
+      key = this.deriveReceive(this.receiveDepth);
       lookahead = this.deriveReceive(this.receiveDepth + this.lookahead);
-      yield this.saveKey(ring);
       yield this.saveKey(lookahead);
       this.receiveDepth++;
-      this.receive = ring;
+      this.receive = key;
       break;
     case 1:
-      ring = this.deriveChange(this.changeDepth);
+      key = this.deriveChange(this.changeDepth);
       lookahead = this.deriveChange(this.changeDepth + this.lookahead);
-      yield this.saveKey(ring);
       yield this.saveKey(lookahead);
       this.changeDepth++;
-      this.change = ring;
+      this.change = key;
       break;
     case 2:
-      ring = this.deriveNested(this.nestedDepth);
+      key = this.deriveNested(this.nestedDepth);
       lookahead = this.deriveNested(this.nestedDepth + this.lookahead);
-      yield this.saveKey(ring);
       yield this.saveKey(lookahead);
       this.nestedDepth++;
-      this.nested = ring;
+      this.nested = key;
       break;
     default:
       throw new Error('Bad branch: ' + branch);
@@ -466,7 +464,7 @@ Account.prototype.createKey = co(function* createKey(branch) {
 
   this.save();
 
-  return ring;
+  return key;
 });
 
 /**
@@ -608,68 +606,121 @@ Account.prototype.savePath = function savePath(path) {
 };
 
 /**
- * Set change and receiving depth (depth is the index of the _next_ address).
- * Allocate all addresses up to depth. Note that this also allocates
- * new lookahead addresses.
- * @param {Number} depth
- * @returns {Promise} - Returns {@link WalletKey}, {@link WalletKey}.
+ * Initialize address depths (including lookahead).
+ * @returns {Promise}
  */
 
-Account.prototype.setDepth = co(function* setDepth(receiveDepth, changeDepth, nestedDepth) {
-  var i = -1;
-  var receive, change, nested, lookahead;
+Account.prototype.initDepth = co(function* initDepth() {
+  var i, key;
 
-  if (receiveDepth > this.receiveDepth) {
-    for (i = this.receiveDepth; i < receiveDepth; i++) {
-      receive = this.deriveReceive(i);
-      yield this.saveKey(receive);
-    }
+  // Receive Address
+  this.receive = this.deriveReceive(0);
+  this.receiveDepth = 1;
 
-    for (i = receiveDepth; i < receiveDepth + this.lookahead; i++) {
-      lookahead = this.deriveReceive(i);
-      yield this.saveKey(lookahead);
-    }
+  yield this.saveKey(this.receive);
 
-    this.receive = receive;
-    this.receiveDepth = receiveDepth;
+  // Change Address
+  this.change = this.deriveChange(0);
+  this.changeDepth = 1;
+
+  yield this.saveKey(this.change);
+
+  // Nested Address
+  if (this.witness) {
+    this.nested = this.deriveNested(0);
+    this.nestedDepth = 1;
+
+    yield this.saveKey(this.nested);
   }
 
-  if (changeDepth > this.changeDepth) {
-    for (i = this.changeDepth; i < changeDepth; i++) {
-      change = this.deriveChange(i);
-      yield this.saveKey(change);
-    }
-
-    for (i = changeDepth; i < changeDepth + this.lookahead; i++) {
-      lookahead = this.deriveChange(i);
-      yield this.saveKey(lookahead);
-    }
-
-    this.change = change;
-    this.changeDepth = changeDepth;
+  // Lookaheads
+  for (i = 0; i < this.lookahead; i++) {
+    key = this.deriveReceive(i + 1);
+    yield this.saveKey(key);
   }
 
-  if (this.witness && nestedDepth > this.nestedDepth) {
-    for (i = this.nestedDepth; i < nestedDepth; i++) {
-      nested = this.deriveNested(i);
-      yield this.saveKey(nested);
-    }
-
-    for (i = nestedDepth; i < nestedDepth + this.lookahead; i++) {
-      lookahead = this.deriveNested(i);
-      yield this.saveKey(lookahead);
-    }
-
-    this.nested = nested;
-    this.nestedDepth = nestedDepth;
+  for (i = 0; i < this.lookahead; i++) {
+    key = this.deriveChange(i + 1);
+    yield this.saveKey(key);
   }
 
-  if (i === -1)
-    return;
+  if (this.witness) {
+    for (i = 0; i < this.lookahead; i++) {
+      key = this.deriveNested(i + 1);
+      yield this.saveKey(key);
+    }
+  }
 
   this.save();
+});
 
-  return receive || nested;
+/**
+ * Allocate new lookahead addresses if necessary.
+ * @param {Number} receiveDepth
+ * @param {Number} changeDepth
+ * @param {Number} nestedDepth
+ * @returns {Promise} - Returns {@link WalletKey}.
+ */
+
+Account.prototype.syncDepth = co(function* syncDepth(receive, change, nested) {
+  var derived = false;
+  var result = null;
+  var i, depth, key;
+
+  if (receive > this.receiveDepth) {
+    depth = this.receiveDepth + this.lookahead;
+
+    assert(receive < depth);
+
+    for (i = depth; i < receive + this.lookahead; i++) {
+      key = this.deriveReceive(i);
+      yield this.saveKey(key);
+    }
+
+    this.receive = this.deriveReceive(receive - 1);
+    this.receiveDepth = receive;
+
+    derived = true;
+    result = this.receive;
+  }
+
+  if (change > this.changeDepth) {
+    depth = this.changeDepth + this.lookahead;
+
+    assert(change < depth);
+
+    for (i = depth; i < change + this.lookahead; i++) {
+      key = this.deriveChange(i);
+      yield this.saveKey(key);
+    }
+
+    this.change = this.deriveChange(change - 1);
+    this.changeDepth = change;
+
+    derived = true;
+  }
+
+  if (this.witness && nested > this.nestedDepth) {
+    depth = this.nestedDepth + this.lookahead;
+
+    assert(nested < depth);
+
+    for (i = depth; i < nested + this.lookahead; i++) {
+      key = this.deriveNested(i);
+      yield this.saveKey(key);
+    }
+
+    this.nested = this.deriveNested(nested - 1);
+    this.nestedDepth = nested;
+
+    derived = true;
+    result = this.nested;
+  }
+
+  if (derived)
+    this.save();
+
+  return result;
 });
 
 /**

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -452,9 +452,9 @@ Account.prototype.createKey = co(function* createKey(branch) {
       this.receive = key;
       break;
     case 1:
+      // Note: no lookahead here.
       key = this.deriveChange(this.changeDepth);
-      lookahead = this.deriveChange(this.changeDepth + this.lookahead);
-      yield this.saveKey(lookahead);
+      yield this.saveKey(key);
       this.changeDepth++;
       this.change = key;
       break;
@@ -626,7 +626,13 @@ Account.prototype.initDepth = co(function* initDepth() {
 
   yield this.saveKey(this.receive);
 
-  // Change Address
+  // Lookahead
+  for (i = 0; i < this.lookahead; i++) {
+    key = this.deriveReceive(i + 1);
+    yield this.saveKey(key);
+  }
+
+  // Change Address (no lookahead)
   this.change = this.deriveChange(0);
   this.changeDepth = 1;
 
@@ -638,20 +644,8 @@ Account.prototype.initDepth = co(function* initDepth() {
     this.nestedDepth = 1;
 
     yield this.saveKey(this.nested);
-  }
 
-  // Lookaheads
-  for (i = 0; i < this.lookahead; i++) {
-    key = this.deriveReceive(i + 1);
-    yield this.saveKey(key);
-  }
-
-  for (i = 0; i < this.lookahead; i++) {
-    key = this.deriveChange(i + 1);
-    yield this.saveKey(key);
-  }
-
-  if (this.witness) {
+    // Lookahead
     for (i = 0; i < this.lookahead; i++) {
       key = this.deriveNested(i + 1);
       yield this.saveKey(key);
@@ -677,7 +671,7 @@ Account.prototype.syncDepth = co(function* syncDepth(receive, change, nested) {
   if (receive > this.receiveDepth) {
     depth = this.receiveDepth + this.lookahead;
 
-    assert(receive <= depth);
+    assert(this.lookahead === 0 || receive <= depth);
 
     for (i = depth; i < receive + this.lookahead; i++) {
       key = this.deriveReceive(i);
@@ -692,14 +686,10 @@ Account.prototype.syncDepth = co(function* syncDepth(receive, change, nested) {
   }
 
   if (change > this.changeDepth) {
-    depth = this.changeDepth + this.lookahead;
+    assert(change === this.changeDepth + 1);
 
-    assert(change <= depth);
-
-    for (i = depth; i < change + this.lookahead; i++) {
-      key = this.deriveChange(i);
-      yield this.saveKey(key);
-    }
+    key = this.deriveChange(change - 1);
+    yield this.saveKey(key);
 
     this.change = this.deriveChange(change - 1);
     this.changeDepth = change;
@@ -710,7 +700,7 @@ Account.prototype.syncDepth = co(function* syncDepth(receive, change, nested) {
   if (this.witness && nested > this.nestedDepth) {
     depth = this.nestedDepth + this.lookahead;
 
-    assert(nested <= depth);
+    assert(this.lookahead === 0 || nested <= depth);
 
     for (i = depth; i < nested + this.lookahead; i++) {
       key = this.deriveNested(i);

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -334,7 +334,7 @@ Account.prototype.spliceKey = function spliceKey(key) {
  * @returns {Promise}
  */
 
-Account.prototype.addKey = co(function* addKey(key) {
+Account.prototype.addSharedKey = co(function* addSharedKey(key) {
   var result = false;
   var exists;
 
@@ -385,7 +385,7 @@ Account.prototype._checkKeys = co(function* _checkKeys() {
  * @returns {Promise}
  */
 
-Account.prototype.removeKey = function removeKey(key) {
+Account.prototype.removeSharedKey = function removeSharedKey(key) {
   var result = false;
 
   try {
@@ -781,54 +781,6 @@ Account.prototype.toJSON = function toJSON(minimal) {
 };
 
 /**
- * Inject properties from json object.
- * @private
- * @param {Object} json
- */
-
-Account.prototype.fromJSON = function fromJSON(json) {
-  var i, key;
-
-  assert(utils.isNumber(json.wid));
-  assert(utils.isName(json.id), 'Bad wallet ID.');
-  assert(utils.isName(json.name), 'Bad account name.');
-  assert(typeof json.initialized === 'boolean');
-  assert(typeof json.watchOnly === 'boolean');
-  assert(typeof json.type === 'string');
-  assert(utils.isNumber(json.m));
-  assert(utils.isNumber(json.n));
-  assert(typeof json.witness === 'boolean');
-  assert(utils.isNumber(json.accountIndex));
-  assert(utils.isNumber(json.receiveDepth));
-  assert(utils.isNumber(json.changeDepth));
-  assert(utils.isNumber(json.nestedDepth));
-  assert(Array.isArray(json.keys));
-
-  this.wid = json.wid;
-  this.name = json.name;
-  this.initialized = json.initialized;
-  this.witness = json.witness;
-  this.watchOnly = json.watchOnly;
-  this.type = Account.types[json.type.toUpperCase()];
-  this.m = json.m;
-  this.n = json.n;
-  this.accountIndex = json.accountIndex;
-  this.receiveDepth = json.receiveDepth;
-  this.changeDepth = json.changeDepth;
-  this.nestedDepth = json.nestedDepth;
-  this.accountKey = HD.fromBase58(json.accountKey);
-
-  assert(this.type != null);
-
-  for (i = 0; i < json.keys.length; i++) {
-    key = HD.fromBase58(json.keys[i]);
-    this.pushKey(key);
-  }
-
-  return this;
-};
-
-/**
  * Serialize the account.
  * @returns {Buffer}
  */
@@ -905,18 +857,6 @@ Account.prototype.fromRaw = function fromRaw(data) {
 
 Account.fromRaw = function fromRaw(db, data) {
   return new Account(db).fromRaw(data);
-};
-
-/**
- * Instantiate a Account from a
- * jsonified account object.
- * @param {WalletDB} db
- * @param {Object} json - The jsonified account object.
- * @returns {Account}
- */
-
-Account.fromJSON = function fromJSON(db, json) {
-  return new Account(db).fromJSON(json);
 };
 
 /**

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -67,7 +67,7 @@ function Account(db, options) {
   this.receiveDepth = 0;
   this.changeDepth = 0;
   this.nestedDepth = 0;
-  this.lookahead = 10;
+  this.lookahead = 20;
   this.accountKey = null;
   this.keys = [];
 
@@ -218,7 +218,7 @@ Account.fromOptions = function fromOptions(db, options) {
  * @const {Number}
  */
 
-Account.MAX_LOOKAHEAD = 20;
+Account.MAX_LOOKAHEAD = 50;
 
 /**
  * Attempt to intialize the account (generating
@@ -717,6 +717,52 @@ Account.prototype.syncDepth = co(function* syncDepth(receive, change, nested) {
     this.save();
 
   return result;
+});
+
+/**
+ * Allocate new lookahead addresses.
+ * @param {Number} lookahead
+ * @returns {Promise}
+ */
+
+Account.prototype.setLookahead = co(function* setLookahead(lookahead) {
+  var i, key, depth, target;
+
+  if (lookahead <= this.lookahead) {
+    this.db.logger.warning(
+      'Lookahead is not increasing for: %s/%s.',
+      this.id, this.name);
+    return;
+  }
+
+  depth = this.receiveDepth + this.lookahead
+  target = this.receiveDepth + lookahead;
+
+  for (i = depth; i < target; i++) {
+    key = this.deriveReceive(i);
+    yield this.saveKey(key);
+  }
+
+  depth = this.changeDepth + this.lookahead
+  target = this.changeDepth + lookahead;
+
+  for (i = depth; i < target; i++) {
+    key = this.deriveChange(i);
+    yield this.saveKey(key);
+  }
+
+  if (this.witness) {
+    depth = this.nestedDepth + this.lookahead
+    target = this.nestedDepth + lookahead;
+
+    for (i = depth; i < target; i++) {
+      key = this.deriveNested(i);
+      yield this.saveKey(key);
+    }
+  }
+
+  this.lookahead = lookahead;
+  this.save();
 });
 
 /**

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -691,7 +691,7 @@ Account.prototype.syncDepth = co(function* syncDepth(receive, change, nested) {
     key = this.deriveChange(change - 1);
     yield this.saveKey(key);
 
-    this.change = this.deriveChange(change - 1);
+    this.change = key;
     this.changeDepth = change;
 
     derived = true;

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -289,6 +289,9 @@ Account.prototype.pushKey = function pushKey(key) {
   if (!key.isAccount44())
     throw new Error('Must add HD account keys to BIP44 wallet.');
 
+  if (this.type !== Account.types.MULTISIG)
+    throw new Error('Cannot add keys to non-multisig wallet.');
+
   if (key.equal(this.accountKey))
     throw new Error('Cannot add own key.');
 
@@ -326,8 +329,8 @@ Account.prototype.spliceKey = function spliceKey(key) {
   if (!key.isAccount44())
     throw new Error('Must add HD account keys to BIP44 wallet.');
 
-  if (key.equal(this.accountKey))
-    throw new Error('Cannot remove own key.');
+  if (this.type !== Account.types.MULTISIG)
+    throw new Error('Cannot remove keys from non-multisig wallet.');
 
   if (this.keys.length === this.n - 1)
     throw new Error('Cannot remove key.');
@@ -343,16 +346,8 @@ Account.prototype.spliceKey = function spliceKey(key) {
  */
 
 Account.prototype.addSharedKey = co(function* addSharedKey(key) {
-  var result = false;
-  var exists;
-
-  try {
-    result = this.pushKey(key);
-  } catch (e) {
-    throw e;
-  }
-
-  exists = yield this._checkKeys();
+  var result = this.pushKey(key);
+  var exists = yield this._hasDuplicate();
 
   if (exists) {
     this.spliceKey(key);
@@ -371,11 +366,8 @@ Account.prototype.addSharedKey = co(function* addSharedKey(key) {
  * @returns {Promise}
  */
 
-Account.prototype._checkKeys = co(function* _checkKeys() {
+Account.prototype._hasDuplicate = function _hasDuplicate() {
   var ring, hash;
-
-  if (this.initialized || this.type !== Account.types.MULTISIG)
-    return false;
 
   if (this.keys.length !== this.n - 1)
     return false;
@@ -383,8 +375,8 @@ Account.prototype._checkKeys = co(function* _checkKeys() {
   ring = this.deriveReceive(0);
   hash = ring.getScriptHash('hex');
 
-  return yield this.wallet.hasAddress(hash);
-});
+  return this.wallet.hasAddress(hash);
+};
 
 /**
  * Remove a public account key from the account (multisig).
@@ -394,17 +386,14 @@ Account.prototype._checkKeys = co(function* _checkKeys() {
  */
 
 Account.prototype.removeSharedKey = function removeSharedKey(key) {
-  var result = false;
+  var result = this.spliceKey(key);
 
-  try {
-    result = this.spliceKey(key);
-  } catch (e) {
-    return Promise.reject(e);
-  }
+  if (!result)
+    return false;
 
   this.save();
 
-  return Promise.resolve(result);
+  return true;
 };
 
 /**

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -721,44 +721,6 @@ Account.prototype.syncDepth = co(function* syncDepth(receive, change, nested) {
 });
 
 /**
- * Get witness version for a path.
- * @param {Path}
- * @returns {Number}
- */
-
-Account.prototype.getWitnessVersion = function getWitnessVersion(path) {
-  if (!this.witness)
-    return -1;
-
-  if (path.branch === 2)
-    return -1;
-
-  return 0;
-};
-
-/**
- * Get address type for a path.
- * @param {Path} path
- * @returns {Number}
- */
-
-Account.prototype.getAddressType = function getAddressType(path) {
-  if (path.branch === 2)
-    return Script.types.SCRIPTHASH;
-
-  if (this.witness) {
-    if (this.type === Account.types.MULTISIG)
-      return Script.types.WITNESSSCRIPTHASH;
-    return Script.types.WITNESSPUBKEYHASH;
-  }
-
-  if (this.type === Account.types.MULTISIG)
-    return Script.types.SCRIPTHASH;
-
-  return Script.types.PUBKEYHASH;
-};
-
-/**
  * Convert the account to a more inspection-friendly object.
  * @returns {Object}
  */

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -67,7 +67,7 @@ function Account(db, options) {
   this.receiveDepth = 0;
   this.changeDepth = 0;
   this.nestedDepth = 0;
-  this.lookahead = 20;
+  this.lookahead = 10;
   this.accountKey = null;
   this.keys = [];
 

--- a/lib/wallet/browser.js
+++ b/lib/wallet/browser.js
@@ -60,7 +60,7 @@ layout.walletdb = {
   bb: function bb(key) {
     return +key.slice(1);
   },
-  o: function o(hash) {
+  o: function o(hash, index) {
     return 'o' + hash + pad32(index);
   },
   oo: function oo(key) {

--- a/lib/wallet/browser.js
+++ b/lib/wallet/browser.js
@@ -62,6 +62,12 @@ layout.walletdb = {
   },
   ee: function ee(key) {
     return key.slice(1);
+  },
+  o: function o(hash) {
+    return 'o' + hash + pad32(index);
+  },
+  oo: function oo(key) {
+    return [key.slice(1, 65), +key.slice(65)];
   }
 };
 

--- a/lib/wallet/browser.js
+++ b/lib/wallet/browser.js
@@ -188,6 +188,12 @@ layout.txdb = {
   },
   r: function r(hash) {
     return this.ha('r', hash);
+  },
+  b: function b(height) {
+    return 'b' + pad32(height);
+  },
+  bb: function bb(key) {
+    return +key.slice(1);
   }
 };
 

--- a/lib/wallet/browser.js
+++ b/lib/wallet/browser.js
@@ -50,6 +50,9 @@ layout.walletdb = {
   ii: function ii(key) {
     return [+key.slice(1, 11), key.slice(11)];
   },
+  n: function n(wid, index) {
+    return 'n' + pad32(wid) + pad32(index);
+  },
   R: 'R',
   h: function c(height) {
     return 'h' + pad32(height);

--- a/lib/wallet/browser.js
+++ b/lib/wallet/browser.js
@@ -45,23 +45,14 @@ layout.walletdb = {
     return [+key.slice(1, 11), key.slice(11)];
   },
   R: 'R',
-  c: function c(height) {
-    return 'c' + pad32(height);
-  },
-  cc: function cc(key) {
-    return +key.slice(1);
+  h: function c(height) {
+    return 'h' + pad32(height);
   },
   b: function b(height) {
     return 'b' + pad32(height);
   },
   bb: function bb(key) {
     return +key.slice(1);
-  },
-  e: function e(hash) {
-    return 'e' + hash;
-  },
-  ee: function ee(key) {
-    return key.slice(1);
   },
   o: function o(hash) {
     return 'o' + hash + pad32(index);

--- a/lib/wallet/browser.js
+++ b/lib/wallet/browser.js
@@ -23,6 +23,12 @@ layout.walletdb = {
   Pp: function Pp(key) {
     return key.slice(11);
   },
+  r: function r(wid, index, hash) {
+    return 'r' + pad32(wid) + pad32(index) + hash;
+  },
+  rr: function rr(key) {
+    return key.slice(21);
+  },
   w: function w(wid) {
     return 'w' + pad32(wid);
   },

--- a/lib/wallet/browser.js
+++ b/lib/wallet/browser.js
@@ -199,7 +199,8 @@ layout.txdb = {
     return 'b' + pad32(height);
   },
   bb: function bb(key) {
-    return +key.slice(1);
+    key = key.slice(12);
+    return +key.slice(0);
   }
 };
 

--- a/lib/wallet/masterkey.js
+++ b/lib/wallet/masterkey.js
@@ -530,16 +530,18 @@ MasterKey.fromKey = function fromKey(key) {
 
 /**
  * Convert master key to a jsonifiable object.
+ * @param {Boolean?} unsafe - Whether to include
+ * the key data in the JSON.
  * @returns {Object}
  */
 
-MasterKey.prototype.toJSON = function toJSON() {
+MasterKey.prototype.toJSON = function toJSON(unsafe) {
   if (this.encrypted) {
     return {
       encrypted: true,
       until: this.until,
       iv: this.iv.toString('hex'),
-      ciphertext: this.ciphertext.toString('hex'),
+      ciphertext: unsafe ? this.ciphertext.toString('hex') : undefined,
       algorithm: MasterKey.algByVal[this.alg],
       N: this.N,
       r: this.r,
@@ -549,50 +551,8 @@ MasterKey.prototype.toJSON = function toJSON() {
 
   return {
     encrypted: false,
-    key: this.key.toJSON()
+    key: unsafe ? this.key.toJSON() : undefined
   };
-};
-
-/**
- * Inject properties from JSON object.
- * @private
- * @param {Object} json
- */
-
-MasterKey.prototype.fromJSON = function fromJSON(json) {
-  assert(typeof json.encrypted === 'boolean');
-
-  this.encrypted = json.encrypted;
-
-  if (json.encrypted) {
-    assert(typeof json.iv === 'string');
-    assert(typeof json.ciphertext === 'string');
-    assert(typeof json.algorithm === 'string');
-    assert(utils.isNumber(json.N));
-    assert(utils.isNumber(json.r));
-    assert(utils.isNumber(json.p));
-    this.iv = new Buffer(json.iv, 'hex');
-    this.ciphertext = new Buffer(json.ciphertext, 'hex');
-    this.alg = MasterKey.alg[json.algorithm];
-    assert(this.alg != null);
-    this.N = json.N;
-    this.r = json.r;
-    this.p = json.p;
-  } else {
-    this.key = HD.fromJSON(json.key);
-  }
-
-  return this;
-};
-
-/**
- * Instantiate master key from jsonified object.
- * @param {Object} json
- * @returns {MasterKey}
- */
-
-MasterKey.fromJSON = function fromJSON(json) {
-  return new MasterKey().fromJSON(json);
 };
 
 /**
@@ -601,7 +561,7 @@ MasterKey.fromJSON = function fromJSON(json) {
  */
 
 MasterKey.prototype.inspect = function inspect() {
-  var json = this.toJSON();
+  var json = this.toJSON(true);
   if (this.key)
     json.key = this.key.toJSON();
   return json;

--- a/lib/wallet/masterkey.js
+++ b/lib/wallet/masterkey.js
@@ -315,7 +315,7 @@ MasterKey.prototype._lock = function lock() {
   }
 
   if (this.aesKey) {
-    this.aesKey.fill(0);
+    crypto.cleanse(this.aesKey);
     this.aesKey = null;
   }
 };
@@ -371,7 +371,7 @@ MasterKey.prototype._decrypt = co(function* decrypt(passphrase, aes) {
   this.ciphertext = null;
 
   if (!aes) {
-    key.fill(0);
+    crypto.cleanse(key);
     return;
   }
 
@@ -423,7 +423,7 @@ MasterKey.prototype._encrypt = co(function* encrypt(passphrase, aes) {
   this.ciphertext = data;
 
   if (!aes) {
-    key.fill(0);
+    crypto.cleanse(key);
     return;
   }
 

--- a/lib/wallet/records.js
+++ b/lib/wallet/records.js
@@ -362,19 +362,6 @@ TXMapRecord.prototype.remove = function remove(wid) {
   return utils.binaryRemove(this.wids, wid, cmp);
 };
 
-TXMapRecord.prototype.toRaw = function toRaw() {
-  return serializeWallets(this.wids);
-};
-
-TXMapRecord.prototype.fromRaw = function fromRaw(data) {
-  this.wids = parseWallets(data);
-  return this;
-};
-
-TXMapRecord.fromRaw = function fromRaw(hash, data) {
-  return new TXMapRecord(hash).fromRaw(data);
-};
-
 /**
  * Outpoint Map
  * @constructor

--- a/lib/wallet/records.js
+++ b/lib/wallet/records.js
@@ -19,9 +19,9 @@ var BufferWriter = require('../utils/writer');
  * @param {Number} height
  */
 
-function SyncState() {
-  if (!(this instanceof SyncState))
-    return new SyncState();
+function ChainState() {
+  if (!(this instanceof ChainState))
+    return new ChainState();
 
   this.start = new HeaderRecord();
   this.tip = new HeaderRecord();
@@ -29,13 +29,13 @@ function SyncState() {
 
 /**
  * Clone the block.
- * @returns {SyncState}
+ * @returns {ChainState}
  */
 
-SyncState.prototype.clone = function clone() {
-  var state = new SyncState();
-  state.start = this.start.clone();
-  state.tip = this.tip.clone();
+ChainState.prototype.clone = function clone() {
+  var state = new ChainState();
+  state.start = this.start;
+  state.tip = this.tip;
   return state;
 };
 
@@ -45,7 +45,7 @@ SyncState.prototype.clone = function clone() {
  * @param {Buffer} data
  */
 
-SyncState.prototype.fromRaw = function fromRaw(data) {
+ChainState.prototype.fromRaw = function fromRaw(data) {
   var p = new BufferReader(data);
   this.start.fromRaw(p);
   this.tip.fromRaw(p);
@@ -56,11 +56,11 @@ SyncState.prototype.fromRaw = function fromRaw(data) {
  * Instantiate wallet block from serialized data.
  * @param {Hash} hash
  * @param {Buffer} data
- * @returns {SyncState}
+ * @returns {ChainState}
  */
 
-SyncState.fromRaw = function fromRaw(data) {
-  return new SyncState().fromRaw(data);
+ChainState.fromRaw = function fromRaw(data) {
+  return new ChainState().fromRaw(data);
 };
 
 /**
@@ -68,7 +68,7 @@ SyncState.fromRaw = function fromRaw(data) {
  * @returns {Buffer}
  */
 
-SyncState.prototype.toRaw = function toRaw(writer) {
+ChainState.prototype.toRaw = function toRaw(writer) {
   var p = new BufferWriter(writer);
 
   this.start.toRaw(p);
@@ -432,7 +432,7 @@ function serializeWallets(wids) {
  * Expose
  */
 
-exports.SyncState = SyncState;
+exports.ChainState = ChainState;
 exports.HeaderRecord = HeaderRecord;
 exports.BlockMapRecord = BlockMapRecord;
 exports.TXMapRecord = TXMapRecord;

--- a/lib/wallet/records.js
+++ b/lib/wallet/records.js
@@ -19,6 +19,74 @@ var BufferWriter = require('../utils/writer');
  * @param {Number} height
  */
 
+function SyncState() {
+  if (!(this instanceof SyncState))
+    return new SyncState();
+
+  this.start = new HeaderRecord();
+  this.tip = new HeaderRecord();
+}
+
+/**
+ * Clone the block.
+ * @returns {SyncState}
+ */
+
+SyncState.prototype.clone = function clone() {
+  var state = new SyncState();
+  state.start = this.start.clone();
+  state.tip = this.tip.clone();
+  return state;
+};
+
+/**
+ * Instantiate wallet block from serialized tip data.
+ * @private
+ * @param {Buffer} data
+ */
+
+SyncState.prototype.fromRaw = function fromRaw(data) {
+  var p = new BufferReader(data);
+  this.start.fromRaw(p);
+  this.tip.fromRaw(p);
+  return this;
+};
+
+/**
+ * Instantiate wallet block from serialized data.
+ * @param {Hash} hash
+ * @param {Buffer} data
+ * @returns {SyncState}
+ */
+
+SyncState.fromRaw = function fromRaw(data) {
+  return new SyncState().fromRaw(data);
+};
+
+/**
+ * Serialize the wallet block as a tip (hash and height).
+ * @returns {Buffer}
+ */
+
+SyncState.prototype.toRaw = function toRaw(writer) {
+  var p = new BufferWriter(writer);
+
+  this.start.toRaw(p);
+  this.tip.toRaw(p);
+
+  if (!writer)
+    p = p.render();
+
+  return p;
+};
+
+/**
+ * Wallet Tip
+ * @constructor
+ * @param {Hash} hash
+ * @param {Number} height
+ */
+
 function HeaderRecord(hash, height, ts) {
   if (!(this instanceof HeaderRecord))
     return new HeaderRecord(hash, height, ts);
@@ -364,6 +432,7 @@ function serializeWallets(wids) {
  * Expose
  */
 
+exports.SyncState = SyncState;
 exports.HeaderRecord = HeaderRecord;
 exports.BlockMapRecord = BlockMapRecord;
 exports.TXMapRecord = TXMapRecord;

--- a/lib/wallet/records.js
+++ b/lib/wallet/records.js
@@ -244,7 +244,7 @@ function BlockMapRecord(height) {
 
 BlockMapRecord.prototype.fromRaw = function fromRaw(data) {
   var p = new BufferReader(data);
-  var count = p.readVarint();
+  var count = p.readU32();
   var i, hash, tx;
 
   for (i = 0; i < count; i++) {
@@ -278,7 +278,7 @@ BlockMapRecord.prototype.toRaw = function toRaw(writer) {
   var p = new BufferWriter(writer);
   var i, tx;
 
-  p.writeVarint(this.txs.length);
+  p.writeU32(this.txs.length);
 
   for (i = 0; i < this.txs.length; i++) {
     tx = this.txs[i];
@@ -450,7 +450,7 @@ function cmpid(a, b) {
 
 function parseWallets(data) {
   var p = new BufferReader(data);
-  var count = p.readVarint();
+  var count = p.readU32();
   var wids = [];
   var i;
 
@@ -464,7 +464,7 @@ function serializeWallets(wids, writer) {
   var p = new BufferWriter(writer);
   var i, wid;
 
-  p.writeVarint(wids.length);
+  p.writeU32(wids.length);
 
   for (i = 0; i < wids.length; i++) {
     wid = wids[i];

--- a/lib/wallet/records.js
+++ b/lib/wallet/records.js
@@ -13,47 +13,48 @@ var BufferReader = require('../utils/reader');
 var BufferWriter = require('../utils/writer');
 
 /**
- * Wallet Tip
+ * Chain State
  * @constructor
- * @param {Hash} hash
- * @param {Number} height
  */
 
 function ChainState() {
   if (!(this instanceof ChainState))
     return new ChainState();
 
-  this.start = new HeaderRecord();
-  this.tip = new HeaderRecord();
+  this.startHeight = -1;
+  this.startHash = constants.NULL_HASH;
+  this.height = -1;
 }
 
 /**
- * Clone the block.
+ * Clone the state.
  * @returns {ChainState}
  */
 
 ChainState.prototype.clone = function clone() {
   var state = new ChainState();
-  state.start = this.start;
-  state.tip = this.tip;
+  state.startHeight = this.startHeight;
+  state.startHash = this.startHash;
+  state.height = this.height;
   return state;
 };
 
 /**
- * Instantiate wallet block from serialized tip data.
+ * Inject properties from serialized data.
  * @private
  * @param {Buffer} data
  */
 
 ChainState.prototype.fromRaw = function fromRaw(data) {
   var p = new BufferReader(data);
-  this.start.fromRaw(p);
-  this.tip.fromRaw(p);
+  this.startHeight = p.readU32();
+  this.startHash = p.readHash('hex');
+  this.height = p.readU32();
   return this;
 };
 
 /**
- * Instantiate wallet block from serialized data.
+ * Instantiate chain state from serialized data.
  * @param {Hash} hash
  * @param {Buffer} data
  * @returns {ChainState}
@@ -64,15 +65,16 @@ ChainState.fromRaw = function fromRaw(data) {
 };
 
 /**
- * Serialize the wallet block as a tip (hash and height).
+ * Serialize the chain state.
  * @returns {Buffer}
  */
 
 ChainState.prototype.toRaw = function toRaw(writer) {
   var p = new BufferWriter(writer);
 
-  this.start.toRaw(p);
-  this.tip.toRaw(p);
+  p.writeU32(this.startHeight);
+  p.writeHash(this.startHash);
+  p.writeU32(this.height);
 
   if (!writer)
     p = p.render();
@@ -81,15 +83,16 @@ ChainState.prototype.toRaw = function toRaw(writer) {
 };
 
 /**
- * Wallet Tip
+ * Block Meta
  * @constructor
  * @param {Hash} hash
  * @param {Number} height
+ * @param {Number} ts
  */
 
-function HeaderRecord(hash, height, ts) {
-  if (!(this instanceof HeaderRecord))
-    return new HeaderRecord(hash, height, ts);
+function BlockMeta(hash, height, ts) {
+  if (!(this instanceof BlockMeta))
+    return new BlockMeta(hash, height, ts);
 
   this.hash = hash || constants.NULL_HASH;
   this.height = height != null ? height : -1;
@@ -98,20 +101,29 @@ function HeaderRecord(hash, height, ts) {
 
 /**
  * Clone the block.
- * @returns {HeaderRecord}
+ * @returns {BlockMeta}
  */
 
-HeaderRecord.prototype.clone = function clone() {
-  return new HeaderRecord(this.hash, this.height, this.ts);
+BlockMeta.prototype.clone = function clone() {
+  return new BlockMeta(this.hash, this.height, this.ts);
 };
 
 /**
- * Instantiate wallet block from chain entry.
+ * Get block meta hash as a buffer.
+ * @returns {Buffer}
+ */
+
+BlockMeta.prototype.toHash = function toHash() {
+  return new Buffer(this.hash, 'hex');
+};
+
+/**
+ * Instantiate block meta from chain entry.
  * @private
  * @param {ChainEntry} entry
  */
 
-HeaderRecord.prototype.fromEntry = function fromEntry(entry) {
+BlockMeta.prototype.fromEntry = function fromEntry(entry) {
   this.hash = entry.hash;
   this.height = entry.height;
   this.ts = entry.ts;
@@ -119,12 +131,12 @@ HeaderRecord.prototype.fromEntry = function fromEntry(entry) {
 };
 
 /**
- * Instantiate wallet block from json object.
+ * Instantiate block meta from json object.
  * @private
  * @param {Object} json
  */
 
-HeaderRecord.prototype.fromJSON = function fromJSON(json) {
+BlockMeta.prototype.fromJSON = function fromJSON(json) {
   this.hash = utils.revHex(json.hash);
   this.height = json.height;
   this.ts = json.ts;
@@ -132,12 +144,12 @@ HeaderRecord.prototype.fromJSON = function fromJSON(json) {
 };
 
 /**
- * Instantiate wallet block from serialized tip data.
+ * Instantiate block meta from serialized tip data.
  * @private
  * @param {Buffer} data
  */
 
-HeaderRecord.prototype.fromRaw = function fromRaw(data) {
+BlockMeta.prototype.fromRaw = function fromRaw(data) {
   var p = new BufferReader(data);
   this.hash = p.readHash('hex');
   this.height = p.readU32();
@@ -146,42 +158,42 @@ HeaderRecord.prototype.fromRaw = function fromRaw(data) {
 };
 
 /**
- * Instantiate wallet block from chain entry.
+ * Instantiate block meta from chain entry.
  * @param {ChainEntry} entry
- * @returns {HeaderRecord}
+ * @returns {BlockMeta}
  */
 
-HeaderRecord.fromEntry = function fromEntry(entry) {
-  return new HeaderRecord().fromEntry(entry);
+BlockMeta.fromEntry = function fromEntry(entry) {
+  return new BlockMeta().fromEntry(entry);
 };
 
 /**
- * Instantiate wallet block from json object.
+ * Instantiate block meta from json object.
  * @param {Object} json
- * @returns {HeaderRecord}
+ * @returns {BlockMeta}
  */
 
-HeaderRecord.fromJSON = function fromJSON(json) {
-  return new HeaderRecord().fromJSON(json);
+BlockMeta.fromJSON = function fromJSON(json) {
+  return new BlockMeta().fromJSON(json);
 };
 
 /**
- * Instantiate wallet block from serialized data.
+ * Instantiate block meta from serialized data.
  * @param {Hash} hash
  * @param {Buffer} data
- * @returns {HeaderRecord}
+ * @returns {BlockMeta}
  */
 
-HeaderRecord.fromRaw = function fromRaw(data) {
-  return new HeaderRecord().fromRaw(data);
+BlockMeta.fromRaw = function fromRaw(data) {
+  return new BlockMeta().fromRaw(data);
 };
 
 /**
- * Serialize the wallet block as a tip (hash and height).
+ * Serialize the block meta.
  * @returns {Buffer}
  */
 
-HeaderRecord.prototype.toRaw = function toRaw(writer) {
+BlockMeta.prototype.toRaw = function toRaw(writer) {
   var p = new BufferWriter(writer);
 
   p.writeHash(this.hash);
@@ -195,11 +207,11 @@ HeaderRecord.prototype.toRaw = function toRaw(writer) {
 };
 
 /**
- * Convert the block to a more json-friendly object.
+ * Convert the block meta to a more json-friendly object.
  * @returns {Object}
  */
 
-HeaderRecord.prototype.toJSON = function toJSON() {
+BlockMeta.prototype.toJSON = function toJSON() {
   return {
     hash: utils.revHex(this.hash),
     height: this.height,
@@ -364,6 +376,38 @@ TXMapRecord.fromRaw = function fromRaw(hash, data) {
 };
 
 /**
+ * Outpoint Map
+ * @constructor
+ */
+
+function OutpointMapRecord(hash, index, wids) {
+  this.hash = hash || constants.NULL_HASH;
+  this.index = index != null ? index : -1;
+  this.wids = wids || [];
+}
+
+OutpointMapRecord.prototype.add = function add(wid) {
+  return utils.binaryInsert(this.wids, wid, cmp, true) !== -1;
+};
+
+OutpointMapRecord.prototype.remove = function remove(wid) {
+  return utils.binaryRemove(this.wids, wid, cmp);
+};
+
+OutpointMapRecord.prototype.toRaw = function toRaw() {
+  return serializeWallets(this.wids);
+};
+
+OutpointMapRecord.prototype.fromRaw = function fromRaw(data) {
+  this.wids = parseWallets(data);
+  return this;
+};
+
+OutpointMapRecord.fromRaw = function fromRaw(hash, index, data) {
+  return new OutpointMapRecord(hash, index).fromRaw(data);
+};
+
+/**
  * Path Record
  * @constructor
  */
@@ -433,9 +477,10 @@ function serializeWallets(wids) {
  */
 
 exports.ChainState = ChainState;
-exports.HeaderRecord = HeaderRecord;
+exports.BlockMeta = BlockMeta;
 exports.BlockMapRecord = BlockMapRecord;
 exports.TXMapRecord = TXMapRecord;
+exports.OutpointMapRecord = OutpointMapRecord;
 exports.PathMapRecord = PathMapRecord;
 
 module.exports = exports;

--- a/lib/wallet/records.js
+++ b/lib/wallet/records.js
@@ -244,14 +244,12 @@ function BlockMapRecord(height) {
 
 BlockMapRecord.prototype.fromRaw = function fromRaw(data) {
   var p = new BufferReader(data);
-  var i, hash, tx, count;
+  var count = p.readVarint();
+  var i, hash, tx;
 
-  while (p.left()) {
+  for (i = 0; i < count; i++) {
     hash = p.readHash('hex');
-    tx = new TXMapRecord(hash);
-    count = p.readVarint();
-    for (i = 0; i < count; i++)
-      tx.wids.push(p.readU32());
+    tx = TXMapRecord.fromRaw(hash, p);
     this.txs.push(tx);
     this.index[tx.hash] = tx;
   }
@@ -278,14 +276,14 @@ BlockMapRecord.fromRaw = function fromRaw(height, data) {
 
 BlockMapRecord.prototype.toRaw = function toRaw(writer) {
   var p = new BufferWriter(writer);
-  var i, j, tx;
+  var i, tx;
+
+  p.writeVarint(this.txs.length);
 
   for (i = 0; i < this.txs.length; i++) {
     tx = this.txs[i];
     p.writeHash(tx.hash);
-    p.writeVarint(tx.wids.length);
-    for (j = 0; j < tx.wids.length; j++)
-      p.writeU32(tx.wids[j]);
+    tx.toRaw(p);
   }
 
   if (!writer)
@@ -362,6 +360,19 @@ TXMapRecord.prototype.remove = function remove(wid) {
   return utils.binaryRemove(this.wids, wid, cmp);
 };
 
+TXMapRecord.prototype.toRaw = function toRaw(writer) {
+  return serializeWallets(this.wids, writer);
+};
+
+TXMapRecord.prototype.fromRaw = function fromRaw(data) {
+  this.wids = parseWallets(data);
+  return this;
+};
+
+TXMapRecord.fromRaw = function fromRaw(hash, data) {
+  return new TXMapRecord(hash).fromRaw(data);
+};
+
 /**
  * Outpoint Map
  * @constructor
@@ -381,8 +392,8 @@ OutpointMapRecord.prototype.remove = function remove(wid) {
   return utils.binaryRemove(this.wids, wid, cmp);
 };
 
-OutpointMapRecord.prototype.toRaw = function toRaw() {
-  return serializeWallets(this.wids);
+OutpointMapRecord.prototype.toRaw = function toRaw(writer) {
+  return serializeWallets(this.wids, writer);
 };
 
 OutpointMapRecord.prototype.fromRaw = function fromRaw(data) {
@@ -412,8 +423,8 @@ PathMapRecord.prototype.remove = function remove(wid) {
   return utils.binaryRemove(this.wids, wid, cmp);
 };
 
-PathMapRecord.prototype.toRaw = function toRaw() {
-  return serializeWallets(this.wids);
+PathMapRecord.prototype.toRaw = function toRaw(writer) {
+  return serializeWallets(this.wids, writer);
 };
 
 PathMapRecord.prototype.fromRaw = function fromRaw(data) {
@@ -439,24 +450,31 @@ function cmpid(a, b) {
 
 function parseWallets(data) {
   var p = new BufferReader(data);
+  var count = p.readVarint();
   var wids = [];
+  var i;
 
-  while (p.left())
+  for (i = 0; i < count; i++)
     wids.push(p.readU32());
 
   return wids;
 }
 
-function serializeWallets(wids) {
-  var p = new BufferWriter();
+function serializeWallets(wids, writer) {
+  var p = new BufferWriter(writer);
   var i, wid;
+
+  p.writeVarint(wids.length);
 
   for (i = 0; i < wids.length; i++) {
     wid = wids[i];
     p.writeU32(wid);
   }
 
-  return p.render();
+  if (!writer)
+    p = p.render();
+
+  return p;
 }
 
 /*

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -198,7 +198,8 @@ var layout = {
     return key;
   },
   bb: function bb(key) {
-    return key.readUInt32BE(1, true);
+    key = key.slice(6);
+    return key.readUInt32BE(0, true);
   }
 };
 
@@ -973,6 +974,19 @@ TXDB.prototype.removeBlockMap = co(function* removeBlockMap(tx, height) {
 
   this.walletdb.writeBlockMap(this.wallet, height, block);
 });
+
+/**
+ * List block records.
+ * @returns {Promise}
+ */
+
+TXDB.prototype.getBlocks = function getBlocks() {
+  return this.keys({
+    gte: layout.b(0),
+    lte: layout.b(0xffffffff),
+    parse: layout.bb
+  });
+};
 
 /**
  * Get block record.

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -981,37 +981,38 @@ TXDB.prototype.removeBlockMap = co(function* removeBlockMap(tx, height) {
  */
 
 TXDB.prototype.getBlock = co(function* getBlock(height) {
-  var data = yield this.db.get(layout.b(height));
+  var data = yield this.get(layout.b(height));
+
   if (!data)
     return;
+
   return BlockRecord.fromRaw(data);
 });
 
 /**
  * Append to the global block record.
  * @param {TX} tx
- * @param {Number} height
+ * @param {BlockMeta} entry
  * @returns {Promise}
  */
 
 TXDB.prototype.addBlock = co(function* addBlock(tx, entry) {
   var hash = tx.hash('hex');
-  var block = yield this.getBlock(entry.height);
+  var height = tx.height;
+  var block = yield this.getBlock(height);
 
   if (!block)
-    block = new BlockRecord(entry.hash, entry.height, entry.ts);
+    block = new BlockRecord(tx.block, tx.height, tx.ts);
 
-  if (block.hashes.indexOf(hash) !== -1)
+  if (!block.add(hash))
     return;
 
-  block.hashes.push(hash);
-
-  this.put(layout.b(entry.height), block.toRaw());
+  this.put(layout.b(height), block.toRaw());
 });
 
 /**
  * Remove from the global block record.
- * @param {TX}
+ * @param {TX} tx
  * @param {Number} height
  * @returns {Promise}
  */
@@ -1019,17 +1020,12 @@ TXDB.prototype.addBlock = co(function* addBlock(tx, entry) {
 TXDB.prototype.removeBlock = co(function* removeBlock(tx, height) {
   var hash = tx.hash('hex');
   var block = yield this.getBlock(height);
-  var index;
 
   if (!block)
     return;
 
-  index = block.hashes.indexOf(hash);
-
-  if (index === -1)
+  if (!block.remove(hash))
     return;
-
-  block.hashes.splice(index, 1);
 
   if (block.hashes.length === 0) {
     this.del(layout.b(height));
@@ -1043,6 +1039,7 @@ TXDB.prototype.removeBlock = co(function* removeBlock(tx, height) {
  * Add transaction, potentially runs
  * `confirm()` and `removeConflicts()`.
  * @param {TX} tx
+ * @param {BlockMeta} block
  * @returns {Promise}
  */
 
@@ -1127,6 +1124,7 @@ TXDB.prototype._add = co(function* add(tx, block) {
  * Insert transaction.
  * @private
  * @param {TX} tx
+ * @param {BlockMeta} block
  * @returns {Promise}
  */
 
@@ -1267,8 +1265,10 @@ TXDB.prototype.insert = co(function* insert(tx, block) {
       this.put(layout.H(account, tx.height, hash), DUMMY);
   }
 
-  if (tx.height !== -1)
+  if (tx.height !== -1) {
     yield this.addBlockMap(tx, tx.height);
+    yield this.addBlock(tx, block);
+  }
 
   // Update the transaction counter and
   // commit the new state. This state will
@@ -1296,6 +1296,7 @@ TXDB.prototype.insert = co(function* insert(tx, block) {
  * Attempt to confirm a transaction.
  * @private
  * @param {TX} tx
+ * @param {BlockMeta} block
  * @returns {Promise}
  */
 
@@ -1333,6 +1334,7 @@ TXDB.prototype.confirm = co(function* confirm(hash, block) {
  * Attempt to confirm a transaction.
  * @private
  * @param {TX} tx
+ * @param {BlockMeta} block
  * @returns {Promise}
  */
 
@@ -1437,8 +1439,10 @@ TXDB.prototype._confirm = co(function* confirm(tx, block) {
     this.put(layout.H(account, tx.height, hash), DUMMY);
   }
 
-  if (tx.height !== -1)
+  if (tx.height !== -1) {
     yield this.addBlockMap(tx, tx.height);
+    yield this.addBlock(tx, block);
+  }
 
   // Commit the new state. The balance has updated.
   this.put(layout.R, this.pending.commit());
@@ -1567,8 +1571,10 @@ TXDB.prototype.erase = co(function* erase(tx) {
       this.del(layout.H(account, tx.height, hash));
   }
 
-  if (tx.height !== -1)
+  if (tx.height !== -1) {
     yield this.removeBlockMap(tx, tx.height);
+    yield this.removeBlock(tx, tx.height);
+  }
 
   // Update the transaction counter
   // and commit new state due to
@@ -1740,6 +1746,7 @@ TXDB.prototype.disconnect = co(function* disconnect(tx) {
   }
 
   yield this.removeBlockMap(tx, height);
+  yield this.removeBlock(tx, height);
 
   // We need to update the now-removed
   // block properties and reindex due
@@ -3359,7 +3366,53 @@ function BlockRecord(hash, height, ts) {
   this.height = height != null ? height : -1;
   this.ts = ts || 0;
   this.hashes = [];
+  this.index = {};
 }
+
+/**
+ * Add transaction to block record.
+ * @param {Hash} hash
+ * @returns {Boolean}
+ */
+
+BlockRecord.prototype.add = function add(hash) {
+  if (this.index[hash])
+    return false;
+
+  this.index[hash] = true;
+  this.hashes.push(hash);
+
+  return true;
+};
+
+/**
+ * Remove transaction from block record.
+ * @param {Hash} hash
+ * @returns {Boolean}
+ */
+
+BlockRecord.prototype.remove = function remove(hash) {
+  var index;
+
+  if (!this.index[hash])
+    return false;
+
+  delete this.index[hash];
+
+  // Fast case
+  if (this.hashes[this.hashes.length - 1] === hash) {
+    this.hashes.pop();
+    return true;
+  }
+
+  index = this.hashes.indexOf(hash);
+
+  assert(index !== -1);
+
+  this.hashes.splice(index, 1);
+
+  return true;
+};
 
 /**
  * Instantiate wallet block from serialized tip data.
@@ -3369,12 +3422,17 @@ function BlockRecord(hash, height, ts) {
 
 BlockRecord.prototype.fromRaw = function fromRaw(data) {
   var p = new BufferReader(data);
+  var hash;
+
   this.hash = p.readHash('hex');
   this.height = p.readU32();
   this.ts = p.readU32();
 
-  while (p.left())
-    this.hashes.push(p.readHash('hex'));
+  while (p.left()) {
+    hash = p.readHash('hex');
+    this.index[hash] = true;
+    this.hashes.push(hash);
+  }
 
   return this;
 };

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -19,7 +19,6 @@ var Coin = require('../primitives/coin');
 var Outpoint = require('../primitives/outpoint');
 var records = require('./records');
 var BlockMapRecord = records.BlockMapRecord;
-var TXMapRecord = records.TXMapRecord;
 var OutpointMapRecord = records.OutpointMapRecord;
 var DUMMY = new Buffer([0]);
 
@@ -888,49 +887,6 @@ TXDB.prototype.isSpent = function isSpent(hash, index) {
 };
 
 /**
- * Append to the global tx record.
- * @param {TX} tx
- * @returns {Promise}
- */
-
-TXDB.prototype.addTXMap = co(function* addTXMap(tx) {
-  var hash = tx.hash('hex');
-  var map = yield this.walletdb.getTXMap(hash);
-
-  if (!map)
-    map = new TXMapRecord(hash);
-
-  if (!map.add(this.wallet.wid))
-    return;
-
-  this.walletdb.writeTXMap(this.wallet, hash, map);
-});
-
-/**
- * Remove from the global tx record.
- * @param {TX} tx
- * @returns {Promise}
- */
-
-TXDB.prototype.removeTXMap = co(function* removeTXMap(tx) {
-  var hash = tx.hash('hex');
-  var map = yield this.walletdb.getTXMap(hash);
-
-  if (!map)
-    return;
-
-  if (!map.remove(this.wallet.wid))
-    return;
-
-  if (map.wids.length === 0) {
-    this.walletdb.unwriteTXMap(this.wallet, hash);
-    return;
-  }
-
-  this.walletdb.writeTXMap(this.wallet, hash, map);
-});
-
-/**
  * Append to the global unspent record.
  * @param {Hash} hash
  * @param {Number} index
@@ -1311,8 +1267,6 @@ TXDB.prototype.insert = co(function* insert(tx, block) {
       this.put(layout.H(account, tx.height, hash), DUMMY);
   }
 
-  yield this.addTXMap(tx);
-
   if (tx.height !== -1)
     yield this.addBlockMap(tx, tx.height);
 
@@ -1483,8 +1437,6 @@ TXDB.prototype._confirm = co(function* confirm(tx, block) {
     this.put(layout.H(account, tx.height, hash), DUMMY);
   }
 
-  yield this.addTXMap(tx);
-
   if (tx.height !== -1)
     yield this.addBlockMap(tx, tx.height);
 
@@ -1614,8 +1566,6 @@ TXDB.prototype.erase = co(function* erase(tx) {
     else
       this.del(layout.H(account, tx.height, hash));
   }
-
-  yield this.removeTXMap(tx);
 
   if (tx.height !== -1)
     yield this.removeBlockMap(tx, tx.height);

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -3442,7 +3442,7 @@ BlockRecord.prototype.fromRaw = function fromRaw(data) {
   this.height = p.readU32();
   this.ts = p.readU32();
 
-  count = p.readVarint();
+  count = p.readU32();
 
   for (i = 0; i < count; i++) {
     hash = p.readHash('hex');
@@ -3477,7 +3477,7 @@ BlockRecord.prototype.toRaw = function toRaw(writer) {
   p.writeU32(this.height);
   p.writeU32(this.ts);
 
-  p.writeVarint(this.hashes.length);
+  p.writeU32(this.hashes.length);
 
   for (i = 0; i < this.hashes.length; i++)
     p.writeHash(this.hashes[i]);

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -190,6 +190,15 @@ var layout = {
   },
   r: function r(hash) {
     return layout.ha(0x72, hash);
+  },
+  b: function b(height) {
+    var key = new Buffer(5);
+    key[0] = 0x62;
+    key.writeUInt32BE(height, 1, true);
+    return key;
+  },
+  bb: function bb(key) {
+    return key.readUInt32BE(1, true);
   }
 };
 
@@ -955,6 +964,71 @@ TXDB.prototype.removeBlockRecord = co(function* removeBlockRecord(tx, height) {
   }
 
   this.walletdb.writeBlockMap(this.wallet, height, block);
+});
+
+/**
+ * Get block record.
+ * @param {Number} height
+ * @returns {Promise}
+ */
+
+TXDB.prototype.getBlock = co(function* getBlock(height) {
+  var data = yield this.db.get(layout.b(height));
+  if (!data)
+    return;
+  return BlockRecord.fromRaw(data);
+});
+
+/**
+ * Append to the global block record.
+ * @param {TX} tx
+ * @param {Number} height
+ * @returns {Promise}
+ */
+
+TXDB.prototype.addBlock = co(function* addBlock(tx, entry) {
+  var hash = tx.hash('hex');
+  var block = yield this.getBlock(entry.height);
+
+  if (!block)
+    block = new BlockRecord(entry.hash, entry.height, entry.ts);
+
+  if (block.hashes.indexOf(hash) !== -1)
+    return;
+
+  block.hashes.push(hash);
+
+  this.put(layout.b(entry.height), block.toRaw());
+});
+
+/**
+ * Remove from the global block record.
+ * @param {TX}
+ * @param {Number} height
+ * @returns {Promise}
+ */
+
+TXDB.prototype.removeBlock = co(function* removeBlock(tx, height) {
+  var hash = tx.hash('hex');
+  var block = yield this.getBlock(height);
+  var index;
+
+  if (!block)
+    return;
+
+  index = block.hashes.indexOf(hash);
+
+  if (index === -1)
+    return;
+
+  block.hashes.splice(index, 1);
+
+  if (block.hashes.length === 0) {
+    this.del(layout.b(height));
+    return;
+  }
+
+  this.put(layout.b(height), block.toRaw());
 });
 
 /**
@@ -3265,6 +3339,89 @@ DetailsMember.prototype.toJSON = function toJSON(network) {
     path: this.path
       ? this.path.toJSON()
       : null
+  };
+};
+
+/**
+ * Block Record
+ * @constructor
+ * @param {Hash} hash
+ * @param {Number} height
+ * @param {Number} ts
+ */
+
+function BlockRecord(hash, height, ts) {
+  if (!(this instanceof BlockRecord))
+    return new BlockRecord(hash, height, ts);
+
+  this.hash = hash || constants.NULL_HASH;
+  this.height = height != null ? height : -1;
+  this.ts = ts || 0;
+  this.hashes = [];
+}
+
+/**
+ * Instantiate wallet block from serialized tip data.
+ * @private
+ * @param {Buffer} data
+ */
+
+BlockRecord.prototype.fromRaw = function fromRaw(data) {
+  var p = new BufferReader(data);
+  this.hash = p.readHash('hex');
+  this.height = p.readU32();
+  this.ts = p.readU32();
+
+  while (p.left())
+    this.hashes.push(p.readHash('hex'));
+
+  return this;
+};
+
+/**
+ * Instantiate wallet block from serialized data.
+ * @param {Hash} hash
+ * @param {Buffer} data
+ * @returns {BlockRecord}
+ */
+
+BlockRecord.fromRaw = function fromRaw(data) {
+  return new BlockRecord().fromRaw(data);
+};
+
+/**
+ * Serialize the wallet block as a tip (hash and height).
+ * @returns {Buffer}
+ */
+
+BlockRecord.prototype.toRaw = function toRaw(writer) {
+  var p = new BufferWriter(writer);
+  var i;
+
+  p.writeHash(this.hash);
+  p.writeU32(this.height);
+  p.writeU32(this.ts);
+
+  for (i = 0; i < this.hashes.length; i++)
+    p.writeHash(this.hashes[i]);
+
+  if (!writer)
+    p = p.render();
+
+  return p;
+};
+
+/**
+ * Convert the block to a more json-friendly object.
+ * @returns {Object}
+ */
+
+BlockRecord.prototype.toJSON = function toJSON() {
+  return {
+    hash: utils.revHex(this.hash),
+    height: this.height,
+    ts: this.ts,
+    hashes: this.hashes.map(utils.revHex)
   };
 };
 

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -20,6 +20,7 @@ var Outpoint = require('../primitives/outpoint');
 var records = require('./records');
 var BlockMapRecord = records.BlockMapRecord;
 var TXMapRecord = records.TXMapRecord;
+var OutpointMapRecord = records.OutpointMapRecord;
 var DUMMY = new Buffer([0]);
 
 /*
@@ -687,14 +688,18 @@ TXDB.prototype.resolveOutputs = co(function* resolveOutputs(tx, block, resolved)
  * @param {Path} path
  */
 
-TXDB.prototype.saveCredit = function saveCredit(credit, path) {
-  var prevout = credit.coin;
-  var key = prevout.hash + prevout.index;
+TXDB.prototype.saveCredit = co(function* saveCredit(credit, path) {
+  var coin = credit.coin;
+  var key = coin.hash + coin.index;
   var raw = credit.toRaw();
-  this.put(layout.c(prevout.hash, prevout.index), raw);
-  this.put(layout.C(path.account, prevout.hash, prevout.index), DUMMY);
+
+  yield this.addOutpointMap(coin.hash, coin.index);
+
+  this.put(layout.c(coin.hash, coin.index), raw);
+  this.put(layout.C(path.account, coin.hash, coin.index), DUMMY);
+
   this.coinCache.push(key, raw);
-};
+});
 
 /**
  * Remove credit.
@@ -702,13 +707,17 @@ TXDB.prototype.saveCredit = function saveCredit(credit, path) {
  * @param {Path} path
  */
 
-TXDB.prototype.removeCredit = function removeCredit(credit, path) {
-  var prevout = credit.coin;
-  var key = prevout.hash + prevout.index;
-  this.del(layout.c(prevout.hash, prevout.index));
-  this.del(layout.C(path.account, prevout.hash, prevout.index));
+TXDB.prototype.removeCredit = co(function* removeCredit(credit, path) {
+  var coin = credit.coin;
+  var key = coin.hash + coin.index;
+
+  yield this.removeOutpointMap(coin.hash, coin.index);
+
+  this.del(layout.c(coin.hash, coin.index));
+  this.del(layout.C(path.account, coin.hash, coin.index));
+
   this.coinCache.unpush(key);
-};
+});
 
 /**
  * Spend credit.
@@ -799,7 +808,7 @@ TXDB.prototype.resolveInput = co(function* resolveInput(tx, index, path) {
   // it retroactively.
   if (stx.height === -1) {
     credit.spent = true;
-    this.saveCredit(credit, path);
+    yield this.saveCredit(credit, path);
     if (tx.height !== -1)
       this.pending.confirmed += credit.coin.value;
   }
@@ -884,7 +893,7 @@ TXDB.prototype.isSpent = function isSpent(hash, index) {
  * @returns {Promise}
  */
 
-TXDB.prototype.addTXRecord = co(function* addTXRecord(tx) {
+TXDB.prototype.addTXMap = co(function* addTXMap(tx) {
   var hash = tx.hash('hex');
   var map = yield this.walletdb.getTXMap(hash);
 
@@ -903,7 +912,7 @@ TXDB.prototype.addTXRecord = co(function* addTXRecord(tx) {
  * @returns {Promise}
  */
 
-TXDB.prototype.removeTXRecord = co(function* removeTXRecord(tx) {
+TXDB.prototype.removeTXMap = co(function* removeTXMap(tx) {
   var hash = tx.hash('hex');
   var map = yield this.walletdb.getTXMap(hash);
 
@@ -922,13 +931,56 @@ TXDB.prototype.removeTXRecord = co(function* removeTXRecord(tx) {
 });
 
 /**
+ * Append to the global unspent record.
+ * @param {Hash} hash
+ * @param {Number} index
+ * @returns {Promise}
+ */
+
+TXDB.prototype.addOutpointMap = co(function* addOutpointMap(hash, i) {
+  var map = yield this.walletdb.getOutpointMap(hash, i);
+
+  if (!map)
+    map = new OutpointMapRecord(hash, i);
+
+  if (!map.add(this.wallet.wid))
+    return;
+
+  this.walletdb.writeOutpointMap(this.wallet, hash, i, map);
+});
+
+/**
+ * Remove from the global unspent record.
+ * @param {Hash} hash
+ * @param {Number} index
+ * @returns {Promise}
+ */
+
+TXDB.prototype.removeOutpointMap = co(function* removeOutpointMap(hash, i) {
+  var map = yield this.walletdb.getOutpointMap(hash, i);
+
+  if (!map)
+    return;
+
+  if (!map.remove(this.wallet.wid))
+    return;
+
+  if (map.wids.length === 0) {
+    this.walletdb.unwriteOutpointMap(this.wallet, hash, i);
+    return;
+  }
+
+  this.walletdb.writeOutpointMap(this.wallet, hash, i, map);
+});
+
+/**
  * Append to the global block record.
  * @param {TX} tx
  * @param {Number} height
  * @returns {Promise}
  */
 
-TXDB.prototype.addBlockRecord = co(function* addBlockRecord(tx, height) {
+TXDB.prototype.addBlockMap = co(function* addBlockMap(tx, height) {
   var hash = tx.hash('hex');
   var block = yield this.walletdb.getBlockMap(height);
 
@@ -948,7 +1000,7 @@ TXDB.prototype.addBlockRecord = co(function* addBlockRecord(tx, height) {
  * @returns {Promise}
  */
 
-TXDB.prototype.removeBlockRecord = co(function* removeBlockRecord(tx, height) {
+TXDB.prototype.removeBlockMap = co(function* removeBlockMap(tx, height) {
   var hash = tx.hash('hex');
   var block = yield this.walletdb.getBlockMap(height);
 
@@ -1181,7 +1233,7 @@ TXDB.prototype.insert = co(function* insert(tx, block) {
         // possible to compare the on-chain
         // state vs. the mempool state.
         credit.spent = true;
-        this.saveCredit(credit, path);
+        yield this.saveCredit(credit, path);
       } else {
         // If the tx is mined, we can safely
         // remove the coin being spent. This
@@ -1189,7 +1241,7 @@ TXDB.prototype.insert = co(function* insert(tx, block) {
         // coin so it can be reconnected
         // later during a reorg.
         this.pending.confirmed -= coin.value;
-        this.removeCredit(credit, path);
+        yield this.removeCredit(credit, path);
       }
 
       updated = true;
@@ -1221,7 +1273,7 @@ TXDB.prototype.insert = co(function* insert(tx, block) {
     if (tx.height !== -1)
       this.pending.confirmed += output.value;
 
-    this.saveCredit(credit, path);
+    yield this.saveCredit(credit, path);
 
     updated = true;
   }
@@ -1259,10 +1311,10 @@ TXDB.prototype.insert = co(function* insert(tx, block) {
       this.put(layout.H(account, tx.height, hash), DUMMY);
   }
 
-  yield this.addTXRecord(tx);
+  yield this.addTXMap(tx);
 
   if (tx.height !== -1)
-    yield this.addBlockRecord(tx, tx.height);
+    yield this.addBlockMap(tx, tx.height);
 
   // Update the transaction counter and
   // commit the new state. This state will
@@ -1380,7 +1432,7 @@ TXDB.prototype._confirm = co(function* confirm(tx, block) {
       // been removed on-chain.
       this.pending.confirmed -= coin.value;
 
-      this.removeCredit(credit, path);
+      yield this.removeCredit(credit, path);
     }
   }
 
@@ -1411,7 +1463,7 @@ TXDB.prototype._confirm = co(function* confirm(tx, block) {
 
     this.pending.confirmed += output.value;
 
-    this.saveCredit(credit, path);
+    yield this.saveCredit(credit, path);
   }
 
   // Remove the RBF index if we have one.
@@ -1431,10 +1483,10 @@ TXDB.prototype._confirm = co(function* confirm(tx, block) {
     this.put(layout.H(account, tx.height, hash), DUMMY);
   }
 
-  yield this.addTXRecord(tx);
+  yield this.addTXMap(tx);
 
   if (tx.height !== -1)
-    yield this.addBlockRecord(tx, tx.height);
+    yield this.addBlockMap(tx, tx.height);
 
   // Commit the new state. The balance has updated.
   this.put(layout.R, this.pending.commit());
@@ -1511,7 +1563,7 @@ TXDB.prototype.erase = co(function* erase(tx) {
         this.pending.confirmed += coin.value;
 
       this.unspendCredit(tx, i);
-      this.saveCredit(credit, path);
+      yield this.saveCredit(credit, path);
     }
   }
 
@@ -1534,7 +1586,7 @@ TXDB.prototype.erase = co(function* erase(tx) {
     if (tx.height !== -1)
       this.pending.confirmed -= output.value;
 
-    this.removeCredit(credit, path);
+    yield this.removeCredit(credit, path);
   }
 
   // Remove the RBF index if we have one.
@@ -1563,10 +1615,10 @@ TXDB.prototype.erase = co(function* erase(tx) {
       this.del(layout.H(account, tx.height, hash));
   }
 
-  yield this.removeTXRecord(tx);
+  yield this.removeTXMap(tx);
 
   if (tx.height !== -1)
-    yield this.removeBlockRecord(tx, tx.height);
+    yield this.removeBlockMap(tx, tx.height);
 
   // Update the transaction counter
   // and commit new state due to
@@ -1701,7 +1753,7 @@ TXDB.prototype.disconnect = co(function* disconnect(tx) {
       // Resave the credit and mark it
       // as spent in the mempool instead.
       credit.spent = true;
-      this.saveCredit(credit, path);
+      yield this.saveCredit(credit, path);
     }
   }
 
@@ -1734,10 +1786,10 @@ TXDB.prototype.disconnect = co(function* disconnect(tx) {
 
     this.pending.confirmed -= output.value;
 
-    this.saveCredit(credit, path);
+    yield this.saveCredit(credit, path);
   }
 
-  yield this.removeBlockRecord(tx, height);
+  yield this.removeBlockMap(tx, height);
 
   // We need to update the now-removed
   // block properties and reindex due
@@ -3152,7 +3204,7 @@ function Details(txdb, tx) {
   this.wid = this.wallet.wid;
   this.id = this.wallet.id;
 
-  this.chainHeight = txdb.walletdb.height;
+  this.chainHeight = txdb.walletdb.state.height;
 
   this.hash = tx.hash('hex');
   this.tx = tx;

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -3436,13 +3436,15 @@ BlockRecord.prototype.remove = function remove(hash) {
 
 BlockRecord.prototype.fromRaw = function fromRaw(data) {
   var p = new BufferReader(data);
-  var hash;
+  var i, hash, count;
 
   this.hash = p.readHash('hex');
   this.height = p.readU32();
   this.ts = p.readU32();
 
-  while (p.left()) {
+  count = p.readVarint();
+
+  for (i = 0; i < count; i++) {
     hash = p.readHash('hex');
     this.index[hash] = true;
     this.hashes.push(hash);
@@ -3474,6 +3476,8 @@ BlockRecord.prototype.toRaw = function toRaw(writer) {
   p.writeHash(this.hash);
   p.writeU32(this.height);
   p.writeU32(this.ts);
+
+  p.writeVarint(this.hashes.length);
 
   for (i = 0; i < this.hashes.length; i++)
     p.writeHash(this.hashes[i]);

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1550,13 +1550,13 @@ TXDB.prototype.removeRecursive = co(function* removeRecursive(tx) {
  * @returns {Promise}
  */
 
-TXDB.prototype.unconfirm = co(function* unconfirm(hash, block) {
+TXDB.prototype.unconfirm = co(function* unconfirm(hash) {
   var details;
 
   this.start();
 
   try {
-    details = yield this._unconfirm(hash, block);
+    details = yield this._unconfirm(hash);
   } catch (e) {
     this.drop();
     throw e;
@@ -1574,13 +1574,13 @@ TXDB.prototype.unconfirm = co(function* unconfirm(hash, block) {
  * @returns {Promise}
  */
 
-TXDB.prototype._unconfirm = co(function* unconfirm(hash, block) {
+TXDB.prototype._unconfirm = co(function* unconfirm(hash) {
   var tx = yield this.getTX(hash);
 
   if (!tx)
     return;
 
-  return yield this.disconnect(tx, block);
+  return yield this.disconnect(tx);
 });
 
 /**
@@ -1589,7 +1589,7 @@ TXDB.prototype._unconfirm = co(function* unconfirm(hash, block) {
  * @returns {Promise}
  */
 
-TXDB.prototype.disconnect = co(function* disconnect(tx, block) {
+TXDB.prototype.disconnect = co(function* disconnect(tx) {
   var hash = tx.hash('hex');
   var details = new Details(this, tx);
   var height = tx.height;

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -3290,7 +3290,6 @@ Details.prototype.toJSON = function toJSON() {
   return {
     wid: this.wid,
     id: this.id,
-    chainHeight: this.chainHeight,
     hash: utils.revHex(this.hash),
     height: this.height,
     block: this.block ? utils.revHex(this.block) : null,

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -254,10 +254,10 @@ Wallet.prototype.destroy = co(function* destroy() {
  * @returns {Promise}
  */
 
-Wallet.prototype.addKey = co(function* addKey(acct, key) {
+Wallet.prototype.addSharedKey = co(function* addSharedKey(acct, key) {
   var unlock = yield this.writeLock.lock();
   try {
-    return yield this._addKey(acct, key);
+    return yield this._addSharedKey(acct, key);
   } finally {
     unlock();
   }
@@ -271,7 +271,7 @@ Wallet.prototype.addKey = co(function* addKey(acct, key) {
  * @returns {Promise}
  */
 
-Wallet.prototype._addKey = co(function* addKey(acct, key) {
+Wallet.prototype._addSharedKey = co(function* addSharedKey(acct, key) {
   var account, result;
 
   if (!key) {
@@ -290,7 +290,7 @@ Wallet.prototype._addKey = co(function* addKey(acct, key) {
   this.start();
 
   try {
-    result = yield account.addKey(key);
+    result = yield account.addSharedKey(key);
   } catch (e) {
     this.drop();
     throw e;
@@ -308,10 +308,10 @@ Wallet.prototype._addKey = co(function* addKey(acct, key) {
  * @returns {Promise}
  */
 
-Wallet.prototype.removeKey = co(function* removeKey(acct, key) {
+Wallet.prototype.removeSharedKey = co(function* removeSharedKey(acct, key) {
   var unlock = yield this.writeLock.lock();
   try {
-    return yield this._removeKey(acct, key);
+    return yield this._removeSharedKey(acct, key);
   } finally {
     unlock();
   }
@@ -325,7 +325,7 @@ Wallet.prototype.removeKey = co(function* removeKey(acct, key) {
  * @returns {Promise}
  */
 
-Wallet.prototype._removeKey = co(function* removeKey(acct, key) {
+Wallet.prototype._removeSharedKey = co(function* removeSharedKey(acct, key) {
   var account, result;
 
   if (!key) {
@@ -344,7 +344,7 @@ Wallet.prototype._removeKey = co(function* removeKey(acct, key) {
   this.start();
 
   try {
-    result = yield account.removeKey(key);
+    result = yield account.removeSharedKey(key);
   } catch (e) {
     this.drop();
     throw e;
@@ -1650,6 +1650,36 @@ Wallet.prototype.getKey = co(function* getKey(address) {
 });
 
 /**
+ * Retrieve a single keyring by address
+ * (with the private key reference).
+ * @param {Address|Hash} hash
+ * @param {(Buffer|String)?} passphrase
+ * @returns {Promise}
+ */
+
+Wallet.prototype.getPrivateKey = co(function* getPrivateKey(address, passphrase) {
+  var hash = Address.getHash(address, 'hex');
+  var path, account;
+
+  if (!hash)
+    return;
+
+  path = yield this.getPath(hash);
+
+  if (!path)
+    return;
+
+  account = yield this.getAccount(path.account);
+
+  if (!account)
+    return;
+
+  yield this.unlock(passphrase);
+
+  return account.derivePath(path, this.master);
+});
+
+/**
  * Map input addresses to paths.
  * @param {TX} tx
  * @returns {Promise} - Returns {@link Path}[].
@@ -2457,12 +2487,13 @@ Wallet.prototype.inspect = function inspect() {
 
 /**
  * Convert the wallet to an object suitable for
- * serialization. Will automatically encrypt the
- * master key based on the `passphrase` option.
+ * serialization.
+ * @param {Boolean?} unsafe - Whether to include
+ * the master key in the JSON.
  * @returns {Object}
  */
 
-Wallet.prototype.toJSON = function toJSON() {
+Wallet.prototype.toJSON = function toJSON(unsafe) {
   return {
     network: this.network.type,
     wid: this.wid,
@@ -2473,42 +2504,9 @@ Wallet.prototype.toJSON = function toJSON() {
     token: this.token.toString('hex'),
     tokenDepth: this.tokenDepth,
     state: this.state.toJSON(true),
-    master: this.master.toJSON(),
-    account: this.account ? this.account.toJSON(true) : null
+    master: this.master.toJSON(unsafe),
+    account: this.account.toJSON(true)
   };
-};
-
-/**
- * Inject properties from json object.
- * @private
- * @param {Object} json
- */
-
-Wallet.prototype.fromJSON = function fromJSON(json) {
-  var network;
-
-  assert(utils.isNumber(json.wid));
-  assert(typeof json.initialized === 'boolean');
-  assert(typeof json.watchOnly === 'boolean');
-  assert(utils.isName(json.id), 'Bad wallet ID.');
-  assert(utils.isNumber(json.accountDepth));
-  assert(typeof json.token === 'string');
-  assert(json.token.length === 64);
-  assert(utils.isNumber(json.tokenDepth));
-
-  network = Network.get(json.network);
-
-  this.wid = json.wid;
-  this.id = json.id;
-  this.initialized = json.initialized;
-  this.watchOnly = json.watchOnly;
-  this.accountDepth = json.accountDepth;
-  this.token = new Buffer(json.token, 'hex');
-  this.master.fromJSON(json.master);
-
-  assert(network === this.db.network, 'Wallet network mismatch.');
-
-  return this;
 };
 
 /**
@@ -2569,17 +2567,6 @@ Wallet.prototype.fromRaw = function fromRaw(data) {
 
 Wallet.fromRaw = function fromRaw(db, data) {
   return new Wallet(db).fromRaw(data);
-};
-
-/**
- * Instantiate a Wallet from a
- * jsonified wallet object.
- * @param {Object} json - The jsonified wallet object.
- * @returns {Wallet}
- */
-
-Wallet.fromJSON = function fromJSON(db, json) {
-  return new Wallet(db).fromJSON(json);
 };
 
 /**

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1659,7 +1659,7 @@ Wallet.prototype.getKey = co(function* getKey(address) {
 
 Wallet.prototype.getPrivateKey = co(function* getPrivateKey(address, passphrase) {
   var hash = Address.getHash(address, 'hex');
-  var path, account;
+  var path, account, key;
 
   if (!hash)
     return;
@@ -1676,7 +1676,12 @@ Wallet.prototype.getPrivateKey = co(function* getPrivateKey(address, passphrase)
 
   yield this.unlock(passphrase);
 
-  return account.derivePath(path, this.master);
+  key = account.derivePath(path, this.master);
+
+  if (!key.privateKey)
+    return;
+
+  return key;
 });
 
 /**
@@ -1796,7 +1801,7 @@ Wallet.prototype.syncOutputDepth = co(function* syncOutputDepth(details) {
     if (!account)
       continue;
 
-    ring = yield account.setDepth(receive, change, nested);
+    ring = yield account.syncDepth(receive, change, nested);
 
     if (ring)
       derived.push(ring);

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1965,10 +1965,10 @@ Wallet.prototype._insert = co(function* insert(tx, block) {
  * @returns {Promise}
  */
 
-Wallet.prototype.unconfirm = co(function* unconfirm(hash, block) {
+Wallet.prototype.unconfirm = co(function* unconfirm(hash) {
   var unlock = yield this.writeLock.lock();
   try {
-    return yield this.txdb.unconfirm(hash, block);
+    return yield this.txdb.unconfirm(hash);
   } finally {
     unlock();
   }

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -405,12 +405,12 @@ Wallet.prototype._encrypt = co(function* encrypt(passphrase) {
   try {
     yield this.db.encryptKeys(this, key);
   } catch (e) {
-    key.fill(0);
+    crypto.cleanse(key);
     this.drop();
     throw e;
   }
 
-  key.fill(0);
+  crypto.cleanse(key);
 
   this.save();
 
@@ -447,12 +447,12 @@ Wallet.prototype._decrypt = co(function* decrypt(passphrase) {
   try {
     yield this.db.decryptKeys(this, key);
   } catch (e) {
-    key.fill(0);
+    crypto.cleanse(key);
     this.drop();
     throw e;
   }
 
-  key.fill(0);
+  crypto.cleanse(key);
 
   this.save();
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1434,7 +1434,7 @@ Wallet.prototype._fund = co(function* fund(tx, options) {
     hardFee: options.hardFee,
     subtractFee: options.subtractFee,
     changeAddress: account.change.getAddress(),
-    height: this.db.height,
+    height: this.db.state.height,
     rate: rate,
     maxFee: options.maxFee,
     m: account.m,
@@ -1455,7 +1455,7 @@ Wallet.prototype._fund = co(function* fund(tx, options) {
 
 Wallet.prototype.createTX = co(function* createTX(options, force) {
   var outputs = options.outputs;
-  var i, tx, total;
+  var i, tx, total, output;
 
   if (!Array.isArray(outputs) || outputs.length === 0)
     throw new Error('No outputs.');
@@ -1464,8 +1464,11 @@ Wallet.prototype.createTX = co(function* createTX(options, force) {
   tx = new MTX();
 
   // Add the outputs
-  for (i = 0; i < outputs.length; i++)
+  for (i = 0; i < outputs.length; i++) {
     tx.addOutput(outputs[i]);
+    if (tx.outputs[i].isDust(constants.tx.MIN_RELAY))
+      throw new Error('Output is dust.');
+  }
 
   // Fill the inputs with unspents
   yield this.fund(tx, options, force);
@@ -1478,18 +1481,18 @@ Wallet.prototype.createTX = co(function* createTX(options, force) {
   // if (options.locktime != null)
   //   tx.setLocktime(options.locktime);
   // else
-  //   tx.avoidFeeSniping(this.db.height);
+  //   tx.avoidFeeSniping(this.db.state.height);
 
   if (!tx.isSane())
     throw new Error('CheckTransaction failed.');
 
-  if (!tx.checkInputs(this.db.height))
+  if (!tx.checkInputs(this.db.state.height))
     throw new Error('CheckInputs failed.');
 
   total = yield this.template(tx);
 
   if (total === 0)
-    throw new Error('template failed.');
+    throw new Error('Templating failed.');
 
   return tx;
 });
@@ -1530,6 +1533,8 @@ Wallet.prototype._send = co(function* send(options, passphrase) {
     throw new Error('TX could not be fully signed.');
 
   tx = tx.toTX();
+
+  assert(tx.getFee() <= constants.tx.MAX_FEE, 'TX exceeds maxfee.');
 
   yield this.db.addTX(tx);
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1863,11 +1863,6 @@ Wallet.prototype.syncOutputDepth = co(function* syncOutputDepth(details) {
   if (!details)
     return derived;
 
-  if (this.db.options.safeSync) {
-    if (details.height === -1)
-      return;
-  }
-
   for (i = 0; i < details.outputs.length; i++) {
     path = details.outputs[i].path;
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1857,11 +1857,16 @@ Wallet.prototype._setLookahead = co(function* setLookahead(acct, lookahead) {
 Wallet.prototype.syncOutputDepth = co(function* syncOutputDepth(details) {
   var derived = [];
   var accounts = {};
-  var i, j, path, paths, account;
+  var i, j, path, paths, acct, account;
   var receive, change, nested, ring;
 
   if (!details)
     return derived;
+
+  if (this.db.options.safeSync) {
+    if (details.height === -1)
+      return;
+  }
 
   for (i = 0; i < details.outputs.length; i++) {
     path = details.outputs[i].path;
@@ -1882,7 +1887,7 @@ Wallet.prototype.syncOutputDepth = co(function* syncOutputDepth(details) {
 
   for (i = 0; i < accounts.length; i++) {
     paths = accounts[i];
-    account = paths[0].account;
+    acct = paths[0].account;
     receive = -1;
     change = -1;
     nested = -1;
@@ -1910,10 +1915,8 @@ Wallet.prototype.syncOutputDepth = co(function* syncOutputDepth(details) {
     change += 2;
     nested += 2;
 
-    account = yield this.getAccount(account);
-
-    if (!account)
-      continue;
+    account = yield this.getAccount(acct);
+    assert(account);
 
     ring = yield account.syncDepth(receive, change, nested);
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -787,11 +787,7 @@ Wallet.prototype.getAddressHashes = function getAddressHashes(acct) {
  */
 
 Wallet.prototype.getAccountHashes = co(function* getAccountHashes(acct) {
-  var index = yield this.ensureIndex(acct);
-
-  if (index == null)
-    throw new Error('Account not provided.');
-
+  var index = yield this.ensureIndex(acct, true);
   return yield this.db.getAccountHashes(this.wid, index);
 });
 
@@ -891,12 +887,17 @@ Wallet.prototype.getAccountIndex = co(function* getAccountIndex(name) {
  */
 
 Wallet.prototype.getAccountName = co(function* getAccountName(index) {
-  var account = yield this.getAccount(index);
+  var account;
 
-  if (!account)
-    return null;
+  if (typeof index === 'string')
+    return index;
 
-  return account.name;
+  account = this.accountCache.get(index);
+
+  if (account)
+    return account.name;
+
+  return yield this.db.getAccountName(this.wid, index);
 });
 
 /**
@@ -1072,6 +1073,28 @@ Wallet.prototype.hasAddress = co(function* hasAddress(address) {
  */
 
 Wallet.prototype.getPath = co(function* getPath(address) {
+  var path = yield this.readPath(address);
+
+  if (!path)
+    return;
+
+  path.name = yield this.getAccountName(path.account);
+
+  assert(path.name);
+
+  this.pathCache.set(path.hash, path);
+
+  return path;
+});
+
+/**
+ * Get path by address hash (without account name).
+ * @private
+ * @param {Address|Hash} address
+ * @returns {Promise} - Returns {@link Path}.
+ */
+
+Wallet.prototype.readPath = co(function* readPath(address) {
   var hash = Address.getHash(address, 'hex');
   var path;
 
@@ -1089,11 +1112,6 @@ Wallet.prototype.getPath = co(function* getPath(address) {
     return;
 
   path.id = this.id;
-  path.name = yield this.getAccountName(path.account);
-
-  assert(path.name);
-
-  this.pathCache.set(hash, path);
 
   return path;
 });
@@ -1153,16 +1171,25 @@ Wallet.prototype.getPaths = co(function* getPaths(acct) {
  */
 
 Wallet.prototype.getAccountPaths = co(function* getAccountPaths(acct) {
-  var index = yield this.ensureIndex(acct);
+  var index = yield this.ensureIndex(acct, true);
   var hashes = yield this.getAccountHashes(index);
+  var name = yield this.getAccountName(acct);
   var result = [];
   var i, hash, path;
 
+  assert(name);
+
   for (i = 0; i < hashes.length; i++) {
     hash = hashes[i];
-    path = yield this.getPath(hash);
+    path = yield this.readPath(hash);
+
     assert(path);
     assert(path.account === index);
+
+    path.name = name;
+
+    this.pathCache.set(path.hash, path);
+
     result.push(path);
   }
 
@@ -2228,11 +2255,14 @@ Wallet.prototype.getLast = co(function* getLast(acct, limit) {
  * @returns {Promise}
  */
 
-Wallet.prototype.ensureIndex = co(function* ensureIndex(acct) {
+Wallet.prototype.ensureIndex = co(function* ensureIndex(acct, enforce) {
   var index;
 
-  if (acct == null)
+  if (acct == null) {
+    if (enforce)
+      throw new Error('No account provided.');
     return null;
+  }
 
   index = yield this.getAccountIndex(acct);
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1795,6 +1795,58 @@ Wallet.prototype.getOutputPaths = co(function* getOutputPaths(tx) {
 });
 
 /**
+ * Increase lookahead for account.
+ * @param {(Number|String)?} account
+ * @param {Number} lookahead
+ * @returns {Promise}
+ */
+
+Wallet.prototype.setLookahead = co(function* setLookahead(acct, lookahead) {
+  var unlock = yield this.writeLock.lock();
+  try {
+    return this._setLookahead(acct, lookahead);
+  } finally {
+    unlock();
+  }
+});
+
+/**
+ * Increase lookahead for account (without a lock).
+ * @private
+ * @param {(Number|String)?} account
+ * @param {Number} lookahead
+ * @returns {Promise}
+ */
+
+Wallet.prototype._setLookahead = co(function* setLookahead(acct, lookahead) {
+  var account;
+
+  if (lookahead == null) {
+    lookahead = acct;
+    acct = null;
+  }
+
+  if (acct == null)
+    acct = 0;
+
+  account = yield this.getAccount(acct);
+
+  if (!account)
+    throw new Error('Account not found.');
+
+  this.start();
+
+  try {
+    yield account.setLookahead(lookahead);
+  } catch (e) {
+    this.drop();
+    throw e;
+  }
+
+  yield this.commit();
+});
+
+/**
  * Sync address depths based on a transaction's outputs.
  * This is used for deriving new addresses when
  * a confirmed transaction is seen.

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1975,21 +1975,6 @@ Wallet.prototype.unconfirm = co(function* unconfirm(hash) {
 });
 
 /**
- * Confirm a wallet transcation.
- * @param {Hash} hash
- * @returns {Promise}
- */
-
-Wallet.prototype.confirm = co(function* confirm(hash, block) {
-  var unlock = yield this.writeLock.lock();
-  try {
-    return yield this.txdb.confirm(hash, block);
-  } finally {
-    unlock();
-  }
-});
-
-/**
  * Remove a wallet transaction.
  * @param {Hash} hash
  * @returns {Promise}

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -770,12 +770,30 @@ Wallet.prototype.getAccounts = function getAccounts() {
 
 /**
  * Get all wallet address hashes.
+ * @param {(String|Number)?} acct
  * @returns {Promise} - Returns Array.
  */
 
-Wallet.prototype.getAddressHashes = function getAddressHashes() {
+Wallet.prototype.getAddressHashes = function getAddressHashes(acct) {
+  if (acct != null)
+    return this.getAccountHashes(acct);
   return this.db.getWalletHashes(this.wid);
 };
+
+/**
+ * Get all account address hashes.
+ * @param {String|Number} acct
+ * @returns {Promise} - Returns Array.
+ */
+
+Wallet.prototype.getAccountHashes = co(function* getAccountHashes(acct) {
+  var index = yield this.ensureIndex(acct);
+
+  if (index == null)
+    throw new Error('Account not provided.');
+
+  return yield this.db.getAccountHashes(this.wid, index);
+});
 
 /**
  * Retrieve an account from the database.
@@ -1075,12 +1093,6 @@ Wallet.prototype.getPath = co(function* getPath(address) {
 
   assert(path.name);
 
-  // account = yield this.getAccount(path.account);
-  // assert(account);
-  // path.name = account.name;
-  // path.version = account.getWitnessVersion(path);
-  // path.type = account.getAddressType(path);
-
   this.pathCache.set(hash, path);
 
   return path;
@@ -1111,29 +1123,47 @@ Wallet.prototype.hasPath = co(function* hasPath(address) {
  */
 
 Wallet.prototype.getPaths = co(function* getPaths(acct) {
-  var index = yield this.ensureIndex(acct);
-  var paths = yield this.db.getWalletPaths(this.wid);
-  var result = [];
-  var i, path;
+  var i, paths, path, result;
+
+  if (acct != null)
+    return yield this.getAccountPaths(acct);
+
+  paths = yield this.db.getWalletPaths(this.wid);
+  result = [];
 
   for (i = 0; i < paths.length; i++) {
     path = paths[i];
-    if (index == null || path.account === index) {
-      path.id = this.id;
-      path.name = yield this.getAccountName(path.account);
+    path.id = this.id;
+    path.name = yield this.getAccountName(path.account);
 
-      assert(path.name);
+    assert(path.name);
 
-      // account = yield this.getAccount(path.account);
-      // assert(account);
-      // path.name = account.name;
-      // path.version = account.getWitnessVersion(path);
-      // path.type = account.getAddressType(path);
+    this.pathCache.set(path.hash, path);
 
-      this.pathCache.set(path.hash, path);
+    result.push(path);
+  }
 
-      result.push(path);
-    }
+  return result;
+});
+
+/**
+ * Get all account paths.
+ * @param {String|Number} acct
+ * @returns {Promise} - Returns {@link Path}.
+ */
+
+Wallet.prototype.getAccountPaths = co(function* getAccountPaths(acct) {
+  var index = yield this.ensureIndex(acct);
+  var hashes = yield this.getAccountHashes(index);
+  var result = [];
+  var i, hash, path;
+
+  for (i = 0; i < hashes.length; i++) {
+    hash = hashes[i];
+    path = yield this.getPath(hash);
+    assert(path);
+    assert(path.account === index);
+    result.push(path);
   }
 
   return result;

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2550,10 +2550,6 @@ Wallet.prototype.__defineGetter__('state', function() {
   return this.txdb.state;
 });
 
-Wallet.prototype.__defineGetter__('balance', function() {
-  return this.txdb.balance;
-});
-
 /**
  * Convert the wallet to a more inspection-friendly object.
  * @returns {Object}

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1985,6 +1985,15 @@ Wallet.prototype.getTX = function getTX(hash) {
 };
 
 /**
+ * List blocks for the wallet.
+ * @returns {Promise} - Returns {@link BlockRecord}.
+ */
+
+Wallet.prototype.getBlocks = function getBlocks() {
+  return this.txdb.getBlocks();
+};
+
+/**
  * Get a block from the wallet.
  * @param {Number} height
  * @returns {Promise} - Returns {@link BlockRecord}.

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1985,6 +1985,16 @@ Wallet.prototype.getTX = function getTX(hash) {
 };
 
 /**
+ * Get a block from the wallet.
+ * @param {Number} height
+ * @returns {Promise} - Returns {@link BlockRecord}.
+ */
+
+Wallet.prototype.getBlock = function getBlock(height) {
+  return this.txdb.getBlock(height);
+};
+
+/**
  * Add a transaction to the wallets TX history.
  * @param {TX} tx
  * @returns {Promise}

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -68,6 +68,17 @@ var layout = {
   Pp: function Pp(key) {
     return key.toString('hex', 5);
   },
+  r: function r(wid, index, hash) {
+    var key = new Buffer(1 + 4 + 4 + (hash.length / 2));
+    key[0] = 0x72;
+    key.writeUInt32BE(wid, 1, true);
+    key.writeUInt32BE(index, 5, true);
+    key.write(hash, 9, 'hex');
+    return key;
+  },
+  rr: function rr(key) {
+    return key.toString('hex', 9);
+  },
   w: function w(wid) {
     var key = new Buffer(5);
     key[0] = 0x77;

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -470,115 +470,43 @@ WalletDB.prototype.backup = function backup(path) {
 
 WalletDB.prototype.wipe = co(function* wipe() {
   var batch = this.db.batch();
-  var dummy = new Buffer(0);
-  var i, keys, key, gte, lte;
+  var total = 0;
+  var iter, item;
 
   this.logger.warning('Wiping WalletDB TXDB...');
   this.logger.warning('I hope you know what you\'re doing.');
 
-  // All TXDB records
-  keys = yield this.db.keys({
-    gte: TXDB.layout.prefix(0x00000000, dummy),
-    lte: TXDB.layout.prefix(0xffffffff, dummy)
+  iter = db.iterator({
+    gte: new Buffer([0x00]),
+    lte: new Buffer([0xff])
   });
 
-  for (i = 0; i < keys.length; i++) {
-    key = keys[i];
-    batch.del(key);
+  for (;;) {
+    item = yield iter.next();
+
+    if (!item)
+      break;
+
+    try {
+      switch (item.key[0]) {
+        case 0x62: // b
+        case 0x63: // c
+        case 0x65: // e
+        case 0x74: // t
+        case 0x6f: // o
+        case 0x68: // h
+        case 0x52: // R
+          batch.del(item.key);
+          total++;
+          break;
+      }
+    } catch (e) {
+      yield iter.end();
+      throw e;
+    }
   }
 
-  // All recent block hashes
-  keys = yield this.db.keys({
-    gte: layout.h(0),
-    lte: layout.h(0xffffffff)
-  });
-
-  for (i = 0; i < keys.length; i++) {
-    key = keys[i];
-    batch.del(key);
-  }
-
-  // The state record
-  batch.del(layout.R);
-
-  // All block maps
-  keys = yield this.db.keys({
-    gte: layout.b(0),
-    lte: layout.b(0xffffffff)
-  });
-
-  for (i = 0; i < keys.length; i++) {
-    key = keys[i];
-    batch.del(key);
-  }
-
-  // All outpoint maps
-  keys = yield this.db.keys({
-    gte: layout.o(constants.NULL_HASH, 0),
-    lte: layout.o(constants.HIGH_HASH, 0xffffffff)
-  });
-
-  for (i = 0; i < keys.length; i++) {
-    key = keys[i];
-    batch.del(key);
-  }
-
-  // All TX maps (e -- old)
-  gte = new Buffer(33);
-  gte.fill(0);
-  gte[0] = 0x65;
-
-  lte = new Buffer(33);
-  lte.fill(255);
-  lte[0] = 0x65;
-
-  keys = yield this.db.keys({
-    gte: gte,
-    lte: lte
-  });
-
-  for (i = 0; i < keys.length; i++) {
-    key = keys[i];
-    batch.del(key);
-  }
-
-  // All block maps (b -- 32 byte old)
-  gte = new Buffer(33);
-  gte.fill(0);
-  gte[0] = 0x62;
-
-  lte = new Buffer(33);
-  lte.fill(255);
-  lte[0] = 0x62;
-
-  keys = yield this.db.keys({
-    gte: gte,
-    lte: lte
-  });
-
-  for (i = 0; i < keys.length; i++) {
-    key = keys[i];
-    batch.del(key);
-  }
-
-  // All block records (c -- old)
-  gte = new Buffer(5);
-  gte.fill(0);
-  gte[0] = 0x63;
-
-  lte = new Buffer(5);
-  lte.fill(255);
-  lte[0] = 0x63;
-
-  keys = yield this.db.keys({
-    gte: gte,
-    lte: lte
-  });
-
-  for (i = 0; i < keys.length; i++) {
-    key = keys[i];
-    batch.del(key);
-  }
+  this.logger.warning('Wiped %d txdb records.', total);
 
   yield batch.write();
 });

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -972,19 +972,15 @@ WalletDB.prototype.getAccount = co(function* getAccount(wid, index) {
  * @returns {Promise} - Returns Array.
  */
 
-WalletDB.prototype.getAccounts = co(function* getAccounts(wid) {
-  var i, items;
-
-  items = yield this.db.values({
+WalletDB.prototype.getAccounts = function getAccounts(wid) {
+  return this.db.values({
     gte: layout.n(wid, 0x00000000),
-    lte: layout.n(wid, 0xffffffff)
-  });
-
-  for (i = 0; i < items.length; i++)
-    items[i] = items[i].toString('ascii');
-
-  return items;
-});
+    lte: layout.n(wid, 0xffffffff),
+    parse: function(data) {
+      return data.toString('ascii');
+    }
+  }
+};
 
 /**
  * Lookup the corresponding account name's index.
@@ -1176,19 +1172,6 @@ WalletDB.prototype.getHashes = function getHashes() {
     gte: layout.p(constants.NULL_HASH),
     lte: layout.p(constants.HIGH_HASH),
     parse: layout.pp
-  });
-};
-
-/**
- * Get all tx hashes.
- * @returns {Promise}
- */
-
-WalletDB.prototype.getTXHashes = function getTXHashes() {
-  return this.db.keys({
-    gte: layout.e(constants.NULL_HASH),
-    lte: layout.e(constants.HIGH_HASH),
-    parse: layout.ee
   });
 };
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -1176,7 +1176,7 @@ WalletDB.prototype.getHashes = function getHashes() {
 };
 
 /**
- * Get all tx hashes.
+ * Get all outpoints.
  * @returns {Promise}
  */
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -476,7 +476,7 @@ WalletDB.prototype.wipe = co(function* wipe() {
   this.logger.warning('Wiping WalletDB TXDB...');
   this.logger.warning('I hope you know what you\'re doing.');
 
-  iter = db.iterator({
+  iter = this.db.iterator({
     gte: new Buffer([0x00]),
     lte: new Buffer([0xff])
   });
@@ -2002,15 +2002,15 @@ WalletDB.prototype.addTX = co(function* addTX(tx) {
       block = yield this.getBlock(tx.height);
 
       if (!block)
-        throw new Error('WDB: Inserting confirmed transaction.');
+        throw new Error('WDB: Cannot insert tx from unknown chain.');
 
       if (tx.block !== block.hash)
-        throw new Error('WDB: Inserting confirmed transaction.');
+        throw new Error('WDB: Cannot insert tx from alternate chain.');
 
       this.logger.warning('WalletDB is inserting confirmed transaction.');
     }
 
-    return yield this._insert(tx);
+    return yield this._insert(tx, block);
   } finally {
     unlock();
   }

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -1648,7 +1648,7 @@ WalletDB.prototype.resetState = co(function* resetState(tip) {
 WalletDB.prototype.syncState = co(function* syncState(tip) {
   var batch = this.db.batch();
   var state = this.state.clone();
-  var i, state, height, blocks;
+  var i, height, blocks;
 
   if (tip.height < state.height) {
     // Hashes ahead of our new tip
@@ -1852,16 +1852,16 @@ WalletDB.prototype.rollback = co(function* rollback(height) {
 
 /**
  * Revert TXDB to an older state.
- * @param {Number} height
+ * @param {Number} target
  * @returns {Promise}
  */
 
-WalletDB.prototype.revert = co(function* revert(height) {
+WalletDB.prototype.revert = co(function* revert(target) {
   var total = 0;
   var i, iter, item, height, block, tx;
 
   iter = this.db.iterator({
-    gte: layout.b(height + 1),
+    gte: layout.b(target + 1),
     lte: layout.b(0xffffffff),
     reverse: true,
     values: true

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -333,7 +333,6 @@ WalletDB.prototype._sync = co(function* connect() {
 
 /**
  * Force a rescan.
- * @param {ChainClient} chain
  * @param {Number} height
  * @returns {Promise}
  */
@@ -359,10 +358,9 @@ WalletDB.prototype._rescan = co(function* rescan(height) {
 });
 
 /**
- * Sync with the chain server (without a lock).
+ * Rescan blockchain from a given height.
  * @private
  * @param {Number} height
- * @param {Hashes[]} hashes
  * @returns {Promise}
  */
 
@@ -377,9 +375,6 @@ WalletDB.prototype.scan = co(function* scan(height) {
     height = this.state.startHeight;
 
   assert(utils.isUInt32(height), 'WDB: Must pass in a height.');
-
-  if (height > this.state.height)
-    throw new Error('WDB: Cannot rescan future blocks.');
 
   yield this.rollback(height);
 
@@ -1541,7 +1536,6 @@ WalletDB.prototype.init = co(function* init() {
 
   if (this.client) {
     tip = yield this.client.getTip();
-    assert(tip);
     tip = BlockMeta.fromEntry(tip);
   } else {
     tip = BlockMeta.fromEntry(this.network.genesis);
@@ -1569,7 +1563,7 @@ WalletDB.prototype.getState = co(function* getState() {
 });
 
 /**
- * Write the connecting block immediately.
+ * Reset the chain state to a tip/start-block.
  * @param {BlockMeta} tip
  * @returns {Promise}
  */
@@ -1612,7 +1606,7 @@ WalletDB.prototype.resetState = co(function* resetState(tip) {
 });
 
 /**
- * Write the connecting block immediately.
+ * Sync the current chain state to tip.
  * @param {BlockMeta} tip
  * @returns {Promise}
  */
@@ -1657,10 +1651,25 @@ WalletDB.prototype.syncState = co(function* syncState(tip) {
 });
 
 /**
- * Connect a block.
- * @param {Wallet} wallet
- * @param {BlockMapRecord} block
+ * Get a block->wallet map.
+ * @param {Number} height
  * @returns {Promise}
+ */
+
+WalletDB.prototype.getBlockMap = co(function* getBlockMap(height) {
+  var data = yield this.db.get(layout.b(height));
+
+  if (!data)
+    return;
+
+  return BlockMapRecord.fromRaw(height, data);
+});
+
+/**
+ * Add block to the global block map.
+ * @param {Wallet} wallet
+ * @param {Number} height
+ * @param {BlockMapRecord} block
  */
 
 WalletDB.prototype.writeBlockMap = function writeBlockMap(wallet, height, block) {
@@ -1669,10 +1678,9 @@ WalletDB.prototype.writeBlockMap = function writeBlockMap(wallet, height, block)
 };
 
 /**
- * Connect a block.
+ * Remove a block from the global block map.
  * @param {Wallet} wallet
- * @param {BlockMapRecord} block
- * @returns {Promise}
+ * @param {Number} height
  */
 
 WalletDB.prototype.unwriteBlockMap = function unwriteBlockMap(wallet, height) {
@@ -1681,12 +1689,27 @@ WalletDB.prototype.unwriteBlockMap = function unwriteBlockMap(wallet, height) {
 };
 
 /**
+ * Get a Unspent->Wallet map.
+ * @param {Hash} hash
+ * @param {Number} index
+ * @returns {Promise}
+ */
+
+WalletDB.prototype.getOutpointMap = co(function* getOutpointMap(hash, i) {
+  var data = yield this.db.get(layout.o(hash, i));
+
+  if (!data)
+    return;
+
+  return OutpointMapRecord.fromRaw(hash, i, data);
+});
+
+/**
  * Add an outpoint to global unspent map.
  * @param {Wallet} wallet
  * @param {Hash} hash
  * @param {Number} index
  * @param {OutpointMapRecord} map
- * @returns {Promise}
  */
 
 WalletDB.prototype.writeOutpointMap = function writeOutpointMap(wallet, hash, i, map) {
@@ -1702,28 +1725,12 @@ WalletDB.prototype.writeOutpointMap = function writeOutpointMap(wallet, hash, i,
  * @param {Wallet} wallet
  * @param {Hash} hash
  * @param {Number} index
- * @returns {Promise}
  */
 
 WalletDB.prototype.unwriteOutpointMap = function unwriteOutpointMap(wallet, hash, i) {
   var batch = this.batch(wallet);
   batch.del(layout.o(hash, i));
 };
-
-/**
- * Get a wallet block (with hashes).
- * @param {Hash} hash
- * @returns {Promise}
- */
-
-WalletDB.prototype.getBlockMap = co(function* getBlockMap(height) {
-  var data = yield this.db.get(layout.b(height));
-
-  if (!data)
-    return;
-
-  return BlockMapRecord.fromRaw(height, data);
-});
 
 /**
  * Get a wallet block meta.
@@ -1761,22 +1768,6 @@ WalletDB.prototype.getTip = co(function* getTip() {
 });
 
 /**
- * Get a Unspent->Wallet map.
- * @param {Hash} hash
- * @param {Number} index
- * @returns {Promise}
- */
-
-WalletDB.prototype.getOutpointMap = co(function* getOutpointMap(hash, i) {
-  var data = yield this.db.get(layout.o(hash, i));
-
-  if (!data)
-    return;
-
-  return OutpointMapRecord.fromRaw(hash, i, data);
-});
-
-/**
  * Sync with chain height.
  * @param {Number} height
  * @returns {Promise}
@@ -1785,8 +1776,13 @@ WalletDB.prototype.getOutpointMap = co(function* getOutpointMap(hash, i) {
 WalletDB.prototype.rollback = co(function* rollback(height) {
   var tip;
 
-  if (this.state.height <= height)
+  if (height > this.state.height)
+    throw new Error('WDB: Cannot rollback to the future.');
+
+  if (height === this.state.height) {
+    this.logger.debug('Rolled back to same height (%d).', height);
     return;
+  }
 
   this.logger.info(
     'Rolling back %d WalletDB blocks to height %d.',
@@ -1808,7 +1804,7 @@ WalletDB.prototype.rollback = co(function* rollback(height) {
 
     this.logger.warning(
       'Rolling back WalletDB to start block (%d).',
-      this.state.tip.height);
+      tip.height);
   } else {
     tip.height = 0;
     tip.hash = this.network.genesis.hash;

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -1535,7 +1535,13 @@ WalletDB.prototype.init = co(function* init() {
   }
 
   if (this.client) {
-    tip = yield this.client.getTip();
+    if (this.options.startHeight != null) {
+      tip = yield this.client.getEntry(this.options.startHeight);
+      if (!tip)
+        throw new Error('WDB: Could not find start block.');
+    } else {
+      tip = yield this.client.getTip();
+    }
     tip = BlockMeta.fromEntry(tip);
   } else {
     tip = BlockMeta.fromEntry(this.network.genesis);

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -24,6 +24,7 @@ var Bloom = require('../utils/bloom');
 var Logger = require('../node/logger');
 var TX = require('../primitives/tx');
 var records = require('./records');
+var SyncState = records.SyncState;
 var BlockMapRecord = records.BlockMapRecord;
 var HeaderRecord = records.HeaderRecord;
 var PathMapRecord = records.PathMapRecord;
@@ -165,10 +166,11 @@ function WalletDB(options) {
   this.logger = options.logger || Logger.global;
   this.client = options.client;
 
-  this.tip = null;
-  this.height = -1;
+  this.state = new SyncState();
   this.depth = 0;
   this.wallets = {};
+  this.genesis = HeaderRecord.fromEntry(this.network.genesis);
+  this.keepBlocks = this.network.block.keepBlocks;
 
   // We need one read lock for `get` and `create`.
   // It will hold locks specific to wallet ids.
@@ -195,11 +197,13 @@ function WalletDB(options) {
     writeBufferSize: 4 << 20,
     bufferKeys: !utils.isBrowser
   });
-
-  this._init();
 }
 
 utils.inherits(WalletDB, AsyncObject);
+
+WalletDB.prototype.__defineGetter__('height', function() {
+  return this.state.tip.height;
+});
 
 /**
  * Database layout.
@@ -207,15 +211,6 @@ utils.inherits(WalletDB, AsyncObject);
  */
 
 WalletDB.layout = layout;
-
-/**
- * Initialize wallet db.
- * @private
- */
-
-WalletDB.prototype._init = function _init() {
-  ;
-};
 
 /**
  * Open the walletdb, wait for the database to load.
@@ -226,19 +221,20 @@ WalletDB.prototype._init = function _init() {
 WalletDB.prototype._open = co(function* open() {
   yield this.db.open();
   yield this.db.checkVersion('V', 5);
-  yield this.writeGenesis();
+
+  this.depth = yield this.getDepth();
 
   if (this.options.wipeNoReally)
     yield this.wipe();
 
-  this.depth = yield this.getDepth();
+  yield this.init();
+  yield this.watch();
+  yield this.sync();
+  yield this.resend();
 
   this.logger.info(
     'WalletDB loaded (depth=%d, height=%d).',
-    this.depth, this.height);
-
-  yield this.connect();
-  yield this.resend();
+    this.depth, this.state.tip.height);
 });
 
 /**
@@ -261,14 +257,28 @@ WalletDB.prototype._close = co(function* close() {
 });
 
 /**
+ * Connect and sync with the chain server (without a lock).
+ * @private
+ * @returns {Promise}
+ */
+
+WalletDB.prototype.watch = co(function* watch() {
+  var hashes = yield this.getFilterHashes();
+
+  this.logger.info('Adding %d hashes to filter.', hashes.length);
+
+  this.addFilter(hashes);
+});
+
+/**
  * Connect and sync with the chain server.
  * @returns {Promise}
  */
 
-WalletDB.prototype.connect = co(function* connect() {
+WalletDB.prototype.sync = co(function* sync() {
   var unlock = yield this.txLock.lock();
   try {
-    return yield this._connect();
+    return yield this._sync();
   } finally {
     unlock();
   }
@@ -280,36 +290,36 @@ WalletDB.prototype.connect = co(function* connect() {
  * @returns {Promise}
  */
 
-WalletDB.prototype._connect = co(function* connect() {
-  var hashes = yield this.getFilterHashes();
-  var tip, height;
-
-  this.logger.info('Adding %d hashes to filter.', hashes.length);
-
-  this.addFilter(hashes);
+WalletDB.prototype._sync = co(function* connect() {
+  var height = this.state.tip.height;
+  var tip, entry;
 
   if (!this.client)
     return;
 
-  if (this.options.noScan) {
-    tip = yield this.client.getTip();
+  while (height >= 0) {
+    tip = yield this.getHeader(height);
 
     if (!tip)
-      throw new Error('Could not get chain tip.');
+      break;
 
-    yield this.forceTip(tip);
+    entry = yield this.client.getEntry(tip.hash);
 
-    return;
+    if (entry)
+      break;
+
+    height--;
   }
 
-  assert(this.network.block.keepBlocks > 36);
+  if (!entry) {
+    height = this.state.start.height;
+    entry = yield this.client.getEntry(this.state.start.hash);
 
-  height = this.height - 36;
+    if (!entry)
+      height = 0;
+  }
 
-  if (height < 0)
-    height = 0;
-
-  yield this.scan(height, hashes);
+  yield this.scan(height);
 });
 
 /**
@@ -336,10 +346,7 @@ WalletDB.prototype.rescan = co(function* rescan(height) {
  */
 
 WalletDB.prototype._rescan = co(function* rescan(height) {
-  if (!this.client)
-    return;
-
-  yield this.scan(height);
+  return yield this.scan(height);
 });
 
 /**
@@ -352,26 +359,20 @@ WalletDB.prototype._rescan = co(function* rescan(height) {
 
 WalletDB.prototype.scan = co(function* scan(height) {
   var self = this;
-  var blocks;
 
   if (!this.client)
     return;
 
-  assert(utils.isNumber(height), 'Must pass in a height.');
+  assert(utils.isUInt32(height), 'Must pass in a height.');
 
-  blocks = this.height - height;
-
-  if (blocks < 0)
+  if (height > this.state.tip.height)
     throw new Error('Cannot rescan future blocks.');
-
-  if (blocks > this.network.block.keepBlocks)
-    throw new Error('Cannot roll back beyond keepBlocks.');
 
   yield this.rollback(height);
 
-  this.logger.info('Scanning for blocks.');
+  this.logger.info('Scanning %d blocks.', this.state.tip.height - height);
 
-  yield this.client.scan(this.tip.hash, this.filter, function(block, txs) {
+  yield this.client.scan(this.state.tip.hash, this.filter, function(block, txs) {
     return self._addBlock(block, txs);
   });
 });
@@ -503,7 +504,6 @@ WalletDB.prototype.wipe = co(function* wipe() {
   batch.del(layout.R);
 
   yield batch.write();
-  yield this.writeGenesis();
 });
 
 /**
@@ -540,21 +540,6 @@ WalletDB.prototype.getDepth = co(function* getDepth() {
   depth = layout.ww(item.key);
 
   return depth + 1;
-});
-
-/**
- * Get current block height.
- * @private
- * @returns {Promise}
- */
-
-WalletDB.prototype.getHeight = co(function* getHeight() {
-  var data = yield this.db.get(layout.R);
-
-  if (!data)
-    return -1;
-
-  return data.readUInt32LE(0, true);
 });
 
 /**
@@ -1534,26 +1519,24 @@ WalletDB.prototype.getWalletsByInsert = co(function* getWalletsByInsert(tx) {
  * @returns {Promise}
  */
 
-WalletDB.prototype.writeGenesis = co(function* writeGenesis() {
-  var tip = yield this.getTip();
+WalletDB.prototype.init = co(function* init() {
+  var state = yield this.getState();
+  var tip;
 
-  if (tip) {
-    this.tip = tip;
-    this.height = tip.height;
+  if (state) {
+    this.state = state;
     return;
   }
 
-  yield this.forceTip(this.network.genesis);
-});
+  if (this.client) {
+    tip = yield this.client.getTip();
+    assert(tip);
+    tip = HeaderRecord.fromEntry(tip);
+  } else {
+    tip = this.genesis;
+  }
 
-/**
- * Write the genesis block as the best hash.
- * @returns {Promise}
- */
-
-WalletDB.prototype.forceTip = co(function* forceTip(entry) {
-  var tip = HeaderRecord.fromEntry(entry);
-  yield this.setTip(tip);
+  yield this.syncState(tip, true);
 });
 
 /**
@@ -1561,13 +1544,13 @@ WalletDB.prototype.forceTip = co(function* forceTip(entry) {
  * @returns {Promise}
  */
 
-WalletDB.prototype.getTip = co(function* getTip() {
-  var height = yield this.getHeight();
+WalletDB.prototype.getState = co(function* getState() {
+  var data = yield this.db.get(layout.R);
 
-  if (height === -1)
+  if (!data)
     return;
 
-  return yield this.getHeader(height);
+  return SyncState.fromRaw(data);
 });
 
 /**
@@ -1576,23 +1559,41 @@ WalletDB.prototype.getTip = co(function* getTip() {
  * @returns {Promise}
  */
 
-WalletDB.prototype.setTip = co(function* setTip(tip) {
+WalletDB.prototype.syncState = co(function* syncState(tip, start) {
   var batch = this.db.batch();
-  var height;
+  var state = this.state.clone();
+  var height = this.state.tip.height;
+  var i, blocks;
 
-  batch.del(layout.c(tip.height + 1));
-  batch.put(layout.c(tip.height), tip.toRaw());
-  batch.put(layout.R, U32(tip.height));
+  if (start)
+    state.start = tip;
 
-  height = tip.height - this.network.block.keepBlocks;
+  state.tip = tip;
 
+  // Blocks ahead of our new tip that we need to delete.
+  if (height !== -1) {
+    blocks = height - tip.height;
+    if (blocks > 0) {
+      blocks = Math.min(blocks, this.keepBlocks);
+      for (i = 0; i < blocks; i++) {
+        batch.del(layout.c(height));
+        height--;
+      }
+    }
+  }
+
+  // Prune old blocks.
+  height = tip.height - this.keepBlocks;
   if (height >= 0)
     batch.del(layout.c(height));
 
+  // Save tip and state.
+  batch.put(layout.c(tip.height), tip.toRaw());
+  batch.put(layout.R, state.toRaw());
+
   yield batch.write();
 
-  this.tip = tip;
-  this.height = tip.height;
+  this.state = state;
 });
 
 /**
@@ -1697,24 +1698,34 @@ WalletDB.prototype.getTXMap = co(function* getTXMap(hash) {
  */
 
 WalletDB.prototype.rollback = co(function* rollback(height) {
-  var tip;
+  var tip, start;
 
-  if (this.height > height) {
-    this.logger.info(
-      'Rolling back %d blocks to height %d.',
-      this.height - height, height);
-  }
+  if (this.state.tip.height <= height)
+    return;
 
-  while (this.height > height) {
-    tip = yield this.getHeader(this.height);
+  this.logger.info(
+    'Rolling back %d blocks to height %d.',
+    this.state.tip.height - height, height);
 
-    if (!tip) {
-      yield this.forceTip(this.network.genesis);
-      throw new Error('Wallet reorgd beyond safe height. Rescan required.');
+  tip = yield this.getHeader(height);
+
+  if (!tip) {
+    if (height >= this.state.start.height) {
+      yield this.revert(this.state.start.height);
+      yield this.syncState(this.state.start, true);
+      this.logger.warning(
+        'Wallet rolled back to start block (%d).',
+        this.state.tip.height);
+    } else {
+      yield this.revert(0);
+      yield this.syncState(this.genesis, true);
+      this.logger.warning('Wallet rolled back to genesis block.');
     }
-
-    yield this._removeBlock(tip);
+    return;
   }
+
+  yield this.revert(height);
+  yield this.syncState(tip);
 });
 
 /**
@@ -1724,6 +1735,7 @@ WalletDB.prototype.rollback = co(function* rollback(height) {
  */
 
 WalletDB.prototype.revert = co(function* revert(height) {
+  var total = 0;
   var i, iter, item, block, tx;
 
   iter = this.db.iterator({
@@ -1740,6 +1752,7 @@ WalletDB.prototype.revert = co(function* revert(height) {
 
     try {
       block = BlockMapRecord.fromRaw(item.value);
+      total += block.txs.length;
 
       for (i = block.txs.length - 1; i >= 0; i--) {
         tx = block.txs[i];
@@ -1750,6 +1763,8 @@ WalletDB.prototype.revert = co(function* revert(height) {
       throw e;
     }
   }
+
+  this.logger.info('Rolled back %d transactions.', total);
 });
 
 /**
@@ -1778,17 +1793,20 @@ WalletDB.prototype._addBlock = co(function* addBlock(entry, txs) {
   var total = 0;
   var i, tip, tx;
 
-  if (entry.height <= this.height) {
+  if (entry.height < this.state.tip.height) {
     this.logger.warning('Wallet is connecting low blocks.');
     return total;
   }
 
-  if (entry.height !== this.height + 1)
+  if (entry.height === this.state.tip.height) {
+    this.logger.warning('Wallet is connecting low blocks.');
+  } else if (entry.height !== this.state.tip.height + 1) {
     throw new Error('Bad connection (height mismatch).');
+  }
 
   tip = HeaderRecord.fromEntry(entry);
 
-  yield this.setTip(tip);
+  yield this.syncState(tip);
 
   if (this.options.useCheckpoints) {
     if (tip.height <= this.network.checkpoints.lastHeight)
@@ -1835,12 +1853,12 @@ WalletDB.prototype.removeBlock = co(function* removeBlock(entry) {
 WalletDB.prototype._removeBlock = co(function* removeBlock(entry) {
   var i, tx, tip, prev, block;
 
-  if (entry.height > this.height) {
+  if (entry.height > this.state.tip.height) {
     this.logger.warning('Wallet is disconnecting high blocks.');
     return 0;
   }
 
-  if (entry.height !== this.height)
+  if (entry.height !== this.state.tip.height)
     throw new Error('Bad disconnection (height mismatch).');
 
   tip = yield this.getHeader(entry.height);
@@ -1856,7 +1874,7 @@ WalletDB.prototype._removeBlock = co(function* removeBlock(entry) {
   block = yield this.getBlockMap(tip.height);
 
   if (!block) {
-    yield this.setTip(prev);
+    yield this.syncState(prev);
     return 0;
   }
 
@@ -1865,7 +1883,7 @@ WalletDB.prototype._removeBlock = co(function* removeBlock(entry) {
     yield this._unconfirm(tx, tip);
   }
 
-  yield this.setTip(prev);
+  yield this.syncState(prev);
 
   this.logger.warning('Disconnected block %s (tx=%d).',
     utils.revHex(tip.hash), block.txs.length);
@@ -1956,14 +1974,14 @@ WalletDB.prototype._insert = co(function* insert(tx, block) {
  * @returns {Promise}
  */
 
-WalletDB.prototype._unconfirm = co(function* unconfirm(tx, block) {
+WalletDB.prototype._unconfirm = co(function* unconfirm(tx) {
   var i, wid, wallet;
 
   for (i = 0; i < tx.wids.length; i++) {
     wid = tx.wids[i];
     wallet = yield this.get(wid);
     assert(wallet);
-    yield wallet.unconfirm(tx.hash, block);
+    yield wallet.unconfirm(tx.hash);
   }
 });
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -1164,8 +1164,8 @@ WalletDB.prototype.getPathMap = co(function* getPathMap(hash) {
 
 /**
  * Save an address to the path map.
- * @param {WalletID} wid
- * @param {KeyRing[]} ring
+ * @param {Wallet} wallet
+ * @param {WalletKey} ring
  * @returns {Promise}
  */
 
@@ -1177,11 +1177,12 @@ WalletDB.prototype.saveKey = function saveKey(wallet, ring) {
  * Save a path to the path map.
  *
  * The path map exists in the form of:
- *   - `p[address-hash] -> wids`
- *   - `P[wid][address-hash] -> path`
+ *   - `p[address-hash] -> wid map`
+ *   - `P[wid][address-hash] -> path data`
+ *   - `r[wid][account-index][address-hash] -> dummy`
  *
- * @param {WalletID} wid
- * @param {Path[]} path
+ * @param {Wallet} wallet
+ * @param {Path} path
  * @returns {Promise}
  */
 
@@ -1204,8 +1205,13 @@ WalletDB.prototype.savePath = co(function* savePath(wallet, path) {
   this.pathMapCache.set(hash, map);
   wallet.pathCache.push(hash, path);
 
+  // Address Hash -> Wallet Map
   batch.put(layout.p(hash), map.toRaw());
+
+  // Wallet ID + Address Hash -> Path Data
   batch.put(layout.P(wid, hash), path.toRaw());
+
+  // Wallet ID + Account Index + Address Hash -> Dummy
   batch.put(layout.r(wid, path.account, hash), DUMMY);
 });
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -23,12 +23,14 @@ var ldb = require('../db/ldb');
 var Bloom = require('../utils/bloom');
 var Logger = require('../node/logger');
 var TX = require('../primitives/tx');
+var Outpoint = require('../primitives/outpoint');
 var records = require('./records');
 var ChainState = records.ChainState;
 var BlockMapRecord = records.BlockMapRecord;
-var HeaderRecord = records.HeaderRecord;
+var BlockMeta = records.BlockMeta;
 var PathMapRecord = records.PathMapRecord;
 var TXMapRecord = records.TXMapRecord;
+var OutpointMapRecord = records.OutpointMapRecord;
 var TXDB = require('./txdb');
 var U32 = utils.U32;
 
@@ -133,6 +135,16 @@ var layout = {
   },
   ee: function ee(key) {
     return key.toString('hex', 1);
+  },
+  o: function o(hash, index) {
+    var key = new Buffer(37);
+    key[0] = 0x01;
+    key.write(hash, 1, 'hex');
+    key.writeUInt32BE(index, 33, true);
+    return key;
+  },
+  oo: function oo(key) {
+    return [key.toString('hex', 1, 33), key.readUInt32BE(33, true)];
   }
 };
 
@@ -169,7 +181,6 @@ function WalletDB(options) {
   this.state = new ChainState();
   this.depth = 0;
   this.wallets = {};
-  this.genesis = HeaderRecord.fromEntry(this.network.genesis);
   this.keepBlocks = this.network.block.keepBlocks;
 
   // We need one read lock for `get` and `create`.
@@ -201,10 +212,6 @@ function WalletDB(options) {
 
 utils.inherits(WalletDB, AsyncObject);
 
-WalletDB.prototype.__defineGetter__('height', function() {
-  return this.state.tip.height;
-});
-
 /**
  * Database layout.
  * @type {Object}
@@ -235,8 +242,8 @@ WalletDB.prototype._open = co(function* open() {
   this.logger.info(
     'WalletDB loaded (depth=%d, height=%d, start=%d).',
     this.depth,
-    this.state.tip.height,
-    this.state.start.height);
+    this.state.height,
+    this.state.startHeight);
 });
 
 /**
@@ -265,11 +272,11 @@ WalletDB.prototype._close = co(function* close() {
  */
 
 WalletDB.prototype.watch = co(function* watch() {
-  var hashes = yield this.getFilterHashes();
+  var data = yield this.getFilterData();
 
-  this.logger.info('Adding %d hashes to WalletDB filter.', hashes.length);
+  this.logger.info('Adding %d hashes to WalletDB filter.', data.length);
 
-  this.addFilter(hashes);
+  this.addFilter(data);
 });
 
 /**
@@ -293,14 +300,14 @@ WalletDB.prototype.sync = co(function* sync() {
  */
 
 WalletDB.prototype._sync = co(function* connect() {
-  var height = this.state.tip.height;
+  var height = this.state.height;
   var tip, entry;
 
   if (!this.client)
     return;
 
   while (height >= 0) {
-    tip = yield this.getHeader(height);
+    tip = yield this.getBlock(height);
 
     if (!tip)
       break;
@@ -314,8 +321,8 @@ WalletDB.prototype._sync = co(function* connect() {
   }
 
   if (!entry) {
-    height = this.state.start.height;
-    entry = yield this.client.getEntry(this.state.start.hash);
+    height = this.state.startHeight;
+    entry = yield this.client.getEntry(this.state.startHash);
 
     if (!entry)
       height = 0;
@@ -361,39 +368,45 @@ WalletDB.prototype._rescan = co(function* rescan(height) {
 
 WalletDB.prototype.scan = co(function* scan(height) {
   var self = this;
+  var tip;
 
   if (!this.client)
     return;
 
+  if (height == null)
+    height = this.state.startHeight;
+
   assert(utils.isUInt32(height), 'WDB: Must pass in a height.');
 
-  if (height > this.state.tip.height)
+  if (height > this.state.height)
     throw new Error('WDB: Cannot rescan future blocks.');
 
   yield this.rollback(height);
 
   this.logger.info(
     'WalletDB is scanning %d blocks.',
-    this.state.tip.height - height + 1);
+    this.state.height - height + 1);
 
-  yield this.client.scan(this.state.tip.hash, this.filter, function(block, txs) {
+  tip = yield this.getTip();
+
+  yield this.client.scan(tip.hash, this.filter, function(block, txs) {
     return self._addBlock(block, txs);
   });
 });
 
 /**
- * Add address or tx hashes to chain server filter.
- * @param {Hashes[]} hashes
+ * Add address or outpoints to chain server filter.
+ * @param {Hashes[]} chunks
  * @returns {Promise}
  */
 
-WalletDB.prototype.watchHash = co(function* watchHash(hashes) {
+WalletDB.prototype.watchData = co(function* watchData(chunks) {
   if (!this.client) {
-    this.emit('watch hash', hashes);
+    this.emit('watch data', chunks);
     return;
   }
 
-  yield this.client.watchHash(hashes);
+  yield this.client.watchData(chunks);
 });
 
 /**
@@ -630,8 +643,8 @@ WalletDB.prototype.commit = co(function* commit(wallet) {
  * @returns {Boolean}
  */
 
-WalletDB.prototype.testFilter = function testFilter(hash) {
-  return this.filter.test(hash, 'hex');
+WalletDB.prototype.testFilter = function testFilter(data) {
+  return this.filter.test(data, 'hex');
 };
 
 /**
@@ -640,18 +653,18 @@ WalletDB.prototype.testFilter = function testFilter(hash) {
  * @param {Hash} hash
  */
 
-WalletDB.prototype.addFilter = function addFilter(hashes) {
-  var i, hash;
+WalletDB.prototype.addFilter = function addFilter(chunks) {
+  var i, data;
 
-  if (!Array.isArray(hashes))
-    hashes = [hashes];
+  if (!Array.isArray(chunks))
+    chunks = [chunks];
 
   if (this.client)
-    this.client.watchHash(hashes);
+    this.client.watchData(chunks);
 
-  for (i = 0; i < hashes.length; i++) {
-    hash = hashes[i];
-    this.filter.add(hash, 'hex');
+  for (i = 0; i < chunks.length; i++) {
+    data = chunks[i];
+    this.filter.add(data, 'hex');
   }
 };
 
@@ -1173,27 +1186,43 @@ WalletDB.prototype.getTXHashes = function getTXHashes() {
 };
 
 /**
+ * Get all tx hashes.
+ * @returns {Promise}
+ */
+
+WalletDB.prototype.getOutpoints = function getOutpoints() {
+  return this.db.keys({
+    gte: layout.o(constants.NULL_HASH, 0),
+    lte: layout.o(constants.HIGH_HASH, 0xffffffff),
+    parse: function(key) {
+      var items = layout.oo(key);
+      return new Outpoint(items[0], items[1]);
+    }
+  });
+};
+
+/**
  * Get hashes required for rescan filter.
  * @returns {Promise}
  */
 
-WalletDB.prototype.getFilterHashes = co(function* getFilterHashes() {
-  var hashes = [];
-  var addr = yield this.getHashes();
-  var tx = yield this.getTXHashes();
-  var i, hash;
+WalletDB.prototype.getFilterData = co(function* getFilterData() {
+  var chunks = [];
+  var hashes = yield this.getHashes();
+  var unspent = yield this.getOutpoints();
+  var i, hash, outpoint;
 
-  for (i = 0; i < addr.length; i++) {
-    hash = addr[i];
-    hashes.push(hash);
+  for (i = 0; i < hashes.length; i++) {
+    hash = hashes[i];
+    chunks.push(hash);
   }
 
-  for (i = 0; i < tx.length; i++) {
-    hash = tx[i];
-    hashes.push(hash);
+  for (i = 0; i < unspent.length; i++) {
+    outpoint = unspent[i];
+    chunks.push(outpoint.toRaw());
   }
 
-  return hashes;
+  return chunks;
 });
 
 /**
@@ -1485,10 +1514,10 @@ WalletDB.prototype.getWalletsByInsert = co(function* getWalletsByInsert(tx) {
     input = tx.inputs[i];
     prevout = input.prevout;
 
-    if (!this.testFilter(prevout.hash))
+    if (!this.testFilter(prevout.toRaw()))
       continue;
 
-    map = yield this.getTXMap(prevout.hash);
+    map = yield this.getOutpointMap(prevout.hash, prevout.index);
 
     if (!map)
       continue;
@@ -1535,16 +1564,16 @@ WalletDB.prototype.init = co(function* init() {
   if (this.client) {
     tip = yield this.client.getTip();
     assert(tip);
-    tip = HeaderRecord.fromEntry(tip);
+    tip = BlockMeta.fromEntry(tip);
   } else {
-    tip = this.genesis;
+    tip = BlockMeta.fromEntry(this.network.genesis);
   }
 
   this.logger.info(
     'Initializing WalletDB chain state at %s (%d).',
     utils.revHex(tip.hash), tip.height);
 
-  yield this.syncState(tip, true);
+  yield this.resetState(tip);
 });
 
 /**
@@ -1563,40 +1592,85 @@ WalletDB.prototype.getState = co(function* getState() {
 
 /**
  * Write the connecting block immediately.
- * @param {HeaderRecord} tip
+ * @param {BlockMeta} tip
  * @returns {Promise}
  */
 
-WalletDB.prototype.syncState = co(function* syncState(tip, start) {
+WalletDB.prototype.resetState = co(function* resetState(tip) {
   var batch = this.db.batch();
   var state = this.state.clone();
-  var height = this.state.tip.height;
-  var i, blocks;
+  var iter, item;
 
-  if (start)
-    state.start = tip;
+  iter = this.db.iterator({
+    gte: layout.c(0),
+    lte: layout.c(0xffffffff),
+    values: false
+  });
 
-  state.tip = tip;
+  for (;;) {
+    item = yield iter.next();
 
-  // Blocks ahead of our new tip that we need to delete.
-  if (height !== -1) {
-    blocks = height - tip.height;
-    if (blocks > 0) {
-      blocks = Math.min(blocks, this.keepBlocks);
-      for (i = 0; i < blocks; i++) {
-        batch.del(layout.c(height));
-        height--;
-      }
+    if (!item)
+      break;
+
+    try {
+      batch.del(item.key);
+    } catch (e) {
+      yield iter.end();
+      throw e;
     }
   }
 
-  // Prune old blocks.
-  height = tip.height - this.keepBlocks;
-  if (height >= 0)
-    batch.del(layout.c(height));
+  state.startHeight = tip.height;
+  state.startHash = tip.hash;
+  state.height = tip.height;
+
+  batch.put(layout.c(tip.height), tip.toHash());
+  batch.put(layout.R, state.toRaw());
+
+  yield batch.write();
+
+  this.state = state;
+});
+
+/**
+ * Write the connecting block immediately.
+ * @param {BlockMeta} tip
+ * @returns {Promise}
+ */
+
+WalletDB.prototype.syncState = co(function* syncState(tip) {
+  var batch = this.db.batch();
+  var state = this.state.clone();
+  var i, state, height, blocks;
+
+  if (tip.height < state.height) {
+    // Hashes ahead of our new tip
+    // that we need to delete.
+    height = state.height;
+    blocks = height - tip.height;
+
+    if (blocks > this.keepBlocks)
+      blocks = this.keepBlocks;
+
+    for (i = 0; i < blocks; i++) {
+      batch.del(layout.c(height));
+      height--;
+    }
+  } else if (tip.height > state.height) {
+    // Prune old hashes.
+    assert(tip.height === state.height + 1, 'Bad chain sync.');
+
+    height = tip.height - this.keepBlocks;
+
+    if (height >= 0)
+      batch.del(layout.c(height));
+  }
+
+  state.height = tip.height;
 
   // Save tip and state.
-  batch.put(layout.c(tip.height), tip.toRaw());
+  batch.put(layout.c(tip.height), tip.toHash());
   batch.put(layout.R, state.toRaw());
 
   yield batch.write();
@@ -1629,7 +1703,7 @@ WalletDB.prototype.unwriteBlockMap = function unwriteBlockMap(wallet, height) {
 };
 
 /**
- * Connect a transaction.
+ * Add a transaction to global tx map.
  * @param {Wallet} wallet
  * @param {Hash} hash
  * @param {TXMapRecord} map
@@ -1643,7 +1717,7 @@ WalletDB.prototype.writeTXMap = function writeTXMap(wallet, hash, map) {
 };
 
 /**
- * Connect a transaction.
+ * Remove a transaction from global tx map.
  * @param {Wallet} wallet
  * @param {Hash} hash
  * @returns {Promise}
@@ -1652,6 +1726,34 @@ WalletDB.prototype.writeTXMap = function writeTXMap(wallet, hash, map) {
 WalletDB.prototype.unwriteTXMap = function unwriteTXMap(wallet, hash) {
   var batch = this.batch(wallet);
   batch.del(layout.e(hash));
+};
+
+/**
+ * Add an outpoint to global unspent map.
+ * @param {Wallet} wallet
+ * @param {Hash} hash
+ * @param {Number} index
+ * @param {OutpointMapRecord} map
+ * @returns {Promise}
+ */
+
+WalletDB.prototype.writeOutpointMap = function writeOutpointMap(wallet, hash, i, map) {
+  var batch = this.batch(wallet);
+  batch.put(layout.o(hash, i), map.toRaw());
+  this.addFilter(new Outpoint(hash, i).toRaw());
+};
+
+/**
+ * Remove an outpoint from global unspent map.
+ * @param {Wallet} wallet
+ * @param {Hash} hash
+ * @param {Number} index
+ * @returns {Promise}
+ */
+
+WalletDB.prototype.unwriteOutpointMap = function unwriteOutpointMap(wallet, hash, i) {
+  var batch = this.batch(wallet);
+  batch.del(layout.o(hash, i));
 };
 
 /**
@@ -1670,18 +1772,38 @@ WalletDB.prototype.getBlockMap = co(function* getBlockMap(height) {
 });
 
 /**
- * Get a wallet block (with hashes).
+ * Get a wallet block meta.
  * @param {Hash} hash
  * @returns {Promise}
  */
 
-WalletDB.prototype.getHeader = co(function* getHeader(height) {
+WalletDB.prototype.getBlock = co(function* getBlock(height) {
   var data = yield this.db.get(layout.c(height));
+  var block;
 
   if (!data)
     return;
 
-  return HeaderRecord.fromRaw(data);
+  block = new BlockMeta();
+  block.hash = data.toString('hex');
+  block.height = height;
+
+  return block;
+});
+
+/**
+ * Get wallet tip.
+ * @param {Hash} hash
+ * @returns {Promise}
+ */
+
+WalletDB.prototype.getTip = co(function* getTip() {
+  var tip = yield this.getBlock(this.state.height);
+
+  if (!tip)
+    throw new Error('WDB: Tip not found!');
+
+  return tip;
 });
 
 /**
@@ -1700,46 +1822,63 @@ WalletDB.prototype.getTXMap = co(function* getTXMap(hash) {
 });
 
 /**
+ * Get a Unspent->Wallet map.
+ * @param {Hash} hash
+ * @param {Number} index
+ * @returns {Promise}
+ */
+
+WalletDB.prototype.getOutpointMap = co(function* getOutpointMap(hash, i) {
+  var data = yield this.db.get(layout.o(hash, i));
+
+  if (!data)
+    return;
+
+  return OutpointMapRecord.fromRaw(hash, i, data);
+});
+
+/**
  * Sync with chain height.
  * @param {Number} height
  * @returns {Promise}
  */
 
 WalletDB.prototype.rollback = co(function* rollback(height) {
-  var tip, blocks;
+  var tip;
 
-  if (this.state.tip.height <= height)
+  if (this.state.height <= height)
     return;
 
   this.logger.info(
     'Rolling back %d WalletDB blocks to height %d.',
-    this.state.tip.height - height, height);
+    this.state.height - height, height);
 
-  tip = yield this.getHeader(height);
+  tip = yield this.getBlock(height);
 
-  if (!tip) {
-    blocks = this.state.tip.height - height;
-
-    if (blocks < this.keepBlocks)
-      throw new Error('WDB: Block not found for rollback.');
-
-    if (height >= this.state.start.height) {
-      yield this.revert(this.state.start.height);
-      yield this.syncState(this.state.start, true);
-      this.logger.warning(
-        'WalletDB rolled back to start block (%d).',
-        this.state.tip.height);
-    } else {
-      yield this.revert(0);
-      yield this.syncState(this.genesis, true);
-      this.logger.warning('WalletDB rolled back to genesis block.');
-    }
-
+  if (tip) {
+    yield this.revert(tip.height);
+    yield this.syncState(tip);
     return;
   }
 
-  yield this.revert(height);
-  yield this.syncState(tip);
+  tip = new BlockMeta();
+
+  if (height >= this.state.startHeight) {
+    tip.height = this.state.startHeight;
+    tip.hash = this.state.startHash;
+
+    this.logger.warning(
+      'Rolling back WalletDB to start block (%d).',
+      this.state.tip.height);
+  } else {
+    tip.height = 0;
+    tip.hash = this.network.genesis.hash;
+
+    this.logger.warning('Rolling back WalletDB to genesis block.');
+  }
+
+  yield this.revert(tip.height);
+  yield this.resetState(tip);
 });
 
 /**
@@ -1804,35 +1943,34 @@ WalletDB.prototype.addBlock = co(function* addBlock(entry, txs) {
  */
 
 WalletDB.prototype._addBlock = co(function* addBlock(entry, txs) {
+  var tip = BlockMeta.fromEntry(entry);
   var total = 0;
-  var i, tip, tx;
+  var i, tx;
 
-  if (entry.height < this.state.tip.height) {
+  if (tip.height < this.state.height) {
     this.logger.warning(
       'WalletDB is connecting low blocks (%d).',
-      entry.height);
+      tip.height);
     return total;
   }
 
-  if (entry.height === this.state.tip.height) {
+  if (tip.height === this.state.height) {
     // We let blocks of the same height
     // through specifically for rescans:
     // we always want to rescan the last
     // block since the state may have
     // updated before the block was fully
     // processed (in the case of a crash).
-    this.logger.warning('Duplicate connection for %d.', entry.height);
-  } else if (entry.height !== this.state.tip.height + 1) {
+    this.logger.warning('Already saw WalletDB block (%d).', tip.height);
+  } else if (tip.height !== this.state.height + 1) {
     throw new Error('WDB: Bad connection (height mismatch).');
   }
-
-  tip = HeaderRecord.fromEntry(entry);
 
   yield this.syncState(tip);
 
   if (this.options.useCheckpoints) {
     if (tip.height <= this.network.checkpoints.lastHeight)
-      return 0;
+      return total;
   }
 
   for (i = 0; i < txs.length; i++) {
@@ -1873,24 +2011,25 @@ WalletDB.prototype.removeBlock = co(function* removeBlock(entry) {
  */
 
 WalletDB.prototype._removeBlock = co(function* removeBlock(entry) {
+  var tip = BlockMeta.fromEntry(entry);
   var i, tx, prev, block;
 
-  if (entry.height > this.state.tip.height) {
+  if (tip.height > this.state.height) {
     this.logger.warning(
       'WalletDB is disconnecting high blocks (%d).',
-      entry.height);
+      tip.height);
     return 0;
   }
 
-  if (entry.height !== this.state.tip.height)
+  if (tip.height !== this.state.height)
     throw new Error('WDB: Bad disconnection (height mismatch).');
 
-  prev = yield this.getHeader(entry.height - 1);
+  prev = yield this.getBlock(tip.height - 1);
 
   if (!prev)
     throw new Error('WDB: Bad disconnection (no previous block).');
 
-  block = yield this.getBlockMap(entry.height);
+  block = yield this.getBlockMap(tip.height);
 
   if (!block) {
     yield this.syncState(prev);
@@ -1905,7 +2044,7 @@ WalletDB.prototype._removeBlock = co(function* removeBlock(entry) {
   yield this.syncState(prev);
 
   this.logger.warning('Disconnected wallet block %s (tx=%d).',
-    utils.revHex(entry.hash), block.txs.length);
+    utils.revHex(tip.hash), block.txs.length);
 
   return block.txs.length;
 });
@@ -1920,17 +2059,17 @@ WalletDB.prototype._removeBlock = co(function* removeBlock(entry) {
 
 WalletDB.prototype.addTX = co(function* addTX(tx) {
   var unlock = yield this.txLock.lock();
-  var entry;
+  var block;
 
   try {
     if (tx.height !== -1) {
-      entry = yield this.getHeader(tx.height);
+      block = yield this.getBlock(tx.height);
 
-      if (!entry)
-        throw new Error('WDB: Inserting unconfirmed transaction.');
+      if (!block)
+        throw new Error('WDB: Inserting confirmed transaction.');
 
-      if (tx.block !== entry.hash)
-        throw new Error('WDB: Inserting unconfirmed transaction.');
+      if (tx.block !== block.hash)
+        throw new Error('WDB: Inserting confirmed transaction.');
 
       this.logger.warning('WalletDB is inserting confirmed transaction.');
     }
@@ -1945,7 +2084,7 @@ WalletDB.prototype.addTX = co(function* addTX(tx) {
  * Add a transaction to the database without a lock.
  * @private
  * @param {TX} tx
- * @param {HeaderRecord} block
+ * @param {BlockMeta} block
  * @returns {Promise}
  */
 
@@ -1989,7 +2128,7 @@ WalletDB.prototype._insert = co(function* insert(tx, block) {
  * relevant wallets without a lock.
  * @private
  * @param {TXHash} hash
- * @param {HeaderRecord} block
+ * @param {BlockMeta} block
  * @returns {Promise}
  */
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -1071,7 +1071,7 @@ WalletDB.prototype.getAccounts = co(function* getAccounts(wid) {
 /**
  * Lookup the corresponding account name's index.
  * @param {WalletID} wid
- * @param {String|Number} name - Account name/index.
+ * @param {String} name - Account name/index.
  * @returns {Promise} - Returns Number.
  */
 
@@ -1082,6 +1082,22 @@ WalletDB.prototype.getAccountIndex = co(function* getAccountIndex(wid, name) {
     return -1;
 
   return index.readUInt32LE(0, true);
+});
+
+/**
+ * Lookup the corresponding account index's name.
+ * @param {WalletID} wid
+ * @param {Number} index
+ * @returns {Promise} - Returns Number.
+ */
+
+WalletDB.prototype.getAccountName = co(function* getAccountName(wid, index) {
+  var name = yield this.db.get(layout.n(wid, index));
+
+  if (!name)
+    return;
+
+  return name.toString('ascii');
 });
 
 /**

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -235,7 +235,7 @@ WalletDB.layout = layout;
 
 WalletDB.prototype._open = co(function* open() {
   yield this.db.open();
-  yield this.db.checkVersion('V', 5);
+  yield this.db.checkVersion('V', 6);
 
   this.depth = yield this.getDepth();
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -38,10 +38,12 @@ var DUMMY = new Buffer([0]);
  * Database Layout:
  *  p[addr-hash] -> wallet ids
  *  P[wid][addr-hash] -> path data
+ *  r[wid][index][hash] -> path account index
  *  w[wid] -> wallet
  *  l[id] -> wid
  *  a[wid][index] -> account
  *  i[wid][name] -> account index
+ *  n[wid][index] -> account name
  *  t[wid]* -> txdb
  *  R -> chain sync state
  *  h[height] -> recent block hash
@@ -118,6 +120,13 @@ var layout = {
   },
   ii: function ii(key) {
     return [key.readUInt32BE(1, true), key.toString('ascii', 5)];
+  },
+  n: function n(wid, index) {
+    var key = new Buffer(9);
+    key[0] = 0x6e;
+    key.writeUInt32BE(wid, 1, true);
+    key.writeUInt32BE(index, 5, true);
+    return key;
   },
   R: new Buffer([0x52]),
   h: function h(height) {
@@ -1088,8 +1097,14 @@ WalletDB.prototype.saveAccount = function saveAccount(account) {
   var name = account.name;
   var batch = this.batch(wallet);
 
+  // Account data
   batch.put(layout.a(wid, index), account.toRaw());
+
+  // Name->Index lookups
   batch.put(layout.i(wid, name), U32(index));
+
+  // Index->Name lookups
+  batch.put(layout.n(wid, index), new Buffer(name, 'ascii'));
 
   wallet.accountCache.push(index, account);
 };

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -190,6 +190,7 @@ function WalletDB(options) {
   this.depth = 0;
   this.wallets = {};
   this.keepBlocks = this.network.block.keepBlocks;
+  this.rescanning = false;
 
   // We need one read lock for `get` and `create`.
   // It will hold locks specific to wallet ids.
@@ -387,6 +388,7 @@ WalletDB.prototype._rescan = co(function* rescan(height) {
 
 WalletDB.prototype.scan = co(function* scan(height) {
   var self = this;
+  var iter = this._addBlock.bind(this);
   var tip;
 
   if (!this.client)
@@ -405,9 +407,13 @@ WalletDB.prototype.scan = co(function* scan(height) {
 
   tip = yield this.getTip();
 
-  yield this.client.scan(tip.hash, this.filter, function(block, txs) {
-    return self._addBlock(block, txs);
-  });
+  this.rescanning = true;
+
+  try {
+    yield this.client.scan(tip.hash, this.filter, iter);
+  } finally {
+    this.rescanning = false;
+  }
 });
 
 /**

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -541,11 +541,11 @@ WalletDB.prototype.wipe = co(function* wipe() {
   }
 
   // All block records (c -- old)
-  gte = new Buffer(33);
+  gte = new Buffer(5);
   gte.fill(0);
   gte[0] = 0x63;
 
-  lte = new Buffer(33);
+  lte = new Buffer(5);
   lte.fill(255);
   lte[0] = 0x63;
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -1456,66 +1456,52 @@ WalletDB.prototype.resend = co(function* resend() {
 });
 
 /**
- * Get all wallet ids by multiple address hashes.
+ * Get all wallet ids by output addresses and outpoints.
  * @param {Hash[]} hashes
  * @returns {Promise}
  */
 
-WalletDB.prototype.getWalletsByHashes = co(function* getWalletsByHashes(tx) {
+WalletDB.prototype.getWalletsByTX = co(function* getWalletsByTX(tx) {
+  var hashes = tx.getOutputHashes('hex');
   var result = [];
-  var hashes = tx.getHashes('hex');
-  var i, j, hash, map;
+  var i, j, input, prevout, hash, map;
 
-  for (i = 0; i < hashes.length; i++) {
-    hash = hashes[i];
+  if (!tx.isCoinbase()) {
+    for (i = 0; i < tx.inputs.length; i++) {
+      input = tx.inputs[i];
+      prevout = input.prevout;
 
-    if (!this.testFilter(hash))
-      continue;
+      if (!this.testFilter(prevout.toRaw())) {
+        // Special behavior for SPV.
+        if (this.options.resolution) {
+          hash = input.getHash('hex');
 
-    map = yield this.getPathMap(hash);
+          if (!hash)
+            continue;
 
-    if (!map)
-      continue;
+          if (!this.testFilter(hash))
+            continue;
 
-    for (j = 0; j < map.wids.length; j++)
-      utils.binaryInsert(result, map.wids[j], cmp, true);
-  }
+          map = yield this.getPathMap(hash);
 
-  if (result.length === 0)
-    return;
+          if (!map)
+            continue;
 
-  return result;
-});
+          for (j = 0; j < map.wids.length; j++)
+            utils.binaryInsert(result, map.wids[j], cmp, true);
+        }
 
-/**
- * Get all wallet ids by multiple address hashes.
- * @param {Hash[]} hashes
- * @returns {Promise}
- */
+        continue;
+      }
 
-WalletDB.prototype.getWalletsByInsert = co(function* getWalletsByInsert(tx) {
-  var i, j, result, hashes, input, prevout, hash, map;
+      map = yield this.getOutpointMap(prevout.hash, prevout.index);
 
-  if (this.options.resolution)
-    return yield this.getWalletsByHashes(tx);
+      if (!map)
+        continue;
 
-  result = [];
-  hashes = tx.getOutputHashes('hex');
-
-  for (i = 0; i < tx.inputs.length; i++) {
-    input = tx.inputs[i];
-    prevout = input.prevout;
-
-    if (!this.testFilter(prevout.toRaw()))
-      continue;
-
-    map = yield this.getOutpointMap(prevout.hash, prevout.index);
-
-    if (!map)
-      continue;
-
-    for (j = 0; j < map.wids.length; j++)
-      utils.binaryInsert(result, map.wids[j], cmp, true);
+      for (j = 0; j < map.wids.length; j++)
+        utils.binaryInsert(result, map.wids[j], cmp, true);
+    }
   }
 
   for (i = 0; i < hashes.length; i++) {
@@ -2049,7 +2035,7 @@ WalletDB.prototype._insert = co(function* insert(tx, block) {
 
   assert(!tx.mutable, 'WDB: Cannot add mutable TX.');
 
-  wids = yield this.getWalletsByInsert(tx);
+  wids = yield this.getWalletsByTX(tx);
 
   if (!wids)
     return;
@@ -2082,8 +2068,7 @@ WalletDB.prototype._insert = co(function* insert(tx, block) {
  * Unconfirm a transaction from all
  * relevant wallets without a lock.
  * @private
- * @param {TXHash} hash
- * @param {BlockMeta} block
+ * @param {TXMapRecord} tx
  * @returns {Promise}
  */
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -32,6 +32,7 @@ var PathMapRecord = records.PathMapRecord;
 var OutpointMapRecord = records.OutpointMapRecord;
 var TXDB = require('./txdb');
 var U32 = utils.U32;
+var DUMMY = new Buffer([0]);
 
 /*
  * Database Layout:
@@ -1174,6 +1175,7 @@ WalletDB.prototype.savePath = co(function* savePath(wallet, path) {
 
   batch.put(layout.p(hash), map.toRaw());
   batch.put(layout.P(wid, hash), path.toRaw());
+  batch.put(layout.r(wid, path.account, hash), DUMMY);
 });
 
 /**
@@ -1262,6 +1264,21 @@ WalletDB.prototype.getWalletHashes = function getWalletHashes(wid) {
     gte: layout.P(wid, constants.NULL_HASH),
     lte: layout.P(wid, constants.HIGH_HASH),
     parse: layout.Pp
+  });
+};
+
+/**
+ * Get all account address hashes.
+ * @param {WalletID} wid
+ * @param {Number} account
+ * @returns {Promise}
+ */
+
+WalletDB.prototype.getAccountHashes = function getAccountHashes(wid, account) {
+  return this.db.keys({
+    gte: layout.r(wid, account, constants.NULL_HASH),
+    lte: layout.r(wid, account, constants.HIGH_HASH),
+    parse: layout.rr
   });
 };
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -846,8 +846,11 @@ WalletDB.prototype._rename = co(function* _rename(wallet, id) {
 WalletDB.prototype.renameAccount = function renameAccount(account, name) {
   var wallet = account.wallet;
   var batch = this.batch(wallet);
+
   batch.del(layout.i(account.wid, account.name));
+
   account.name = name;
+
   this.saveAccount(account);
 };
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -970,30 +970,17 @@ WalletDB.prototype.getAccount = co(function* getAccount(wid, index) {
  */
 
 WalletDB.prototype.getAccounts = co(function* getAccounts(wid) {
-  var map = [];
-  var i, items, item, name, index, accounts;
+  var i, items;
 
-  items = yield this.db.range({
-    gte: layout.i(wid, '\x00'),
-    lte: layout.i(wid, '\xff')
+  items = yield this.db.values({
+    gte: layout.n(wid, 0x00000000),
+    lte: layout.n(wid, 0xffffffff)
   });
 
-  for (i = 0; i < items.length; i++) {
-    item = items[i];
-    name = layout.ii(item.key)[1];
-    index = item.value.readUInt32LE(0, true);
-    map[index] = name;
-  }
+  for (i = 0; i < items.length; i++)
+    items[i] = items[i].toString('ascii');
 
-  // Get it out of hash table mode.
-  accounts = [];
-
-  for (i = 0; i < map.length; i++) {
-    assert(map[i] != null);
-    accounts.push(map[i]);
-  }
-
-  return accounts;
+  return items;
 });
 
 /**
@@ -1291,6 +1278,7 @@ WalletDB.prototype.getWallets = function getWallets() {
 /**
  * Encrypt all imported keys for a wallet.
  * @param {WalletID} wid
+ * @param {Buffer} key
  * @returns {Promise}
  */
 
@@ -1324,6 +1312,7 @@ WalletDB.prototype.encryptKeys = co(function* encryptKeys(wallet, key) {
 /**
  * Decrypt all imported keys for a wallet.
  * @param {WalletID} wid
+ * @param {Buffer} key
  * @returns {Promise}
  */
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -29,7 +29,6 @@ var ChainState = records.ChainState;
 var BlockMapRecord = records.BlockMapRecord;
 var BlockMeta = records.BlockMeta;
 var PathMapRecord = records.PathMapRecord;
-var TXMapRecord = records.TXMapRecord;
 var OutpointMapRecord = records.OutpointMapRecord;
 var TXDB = require('./txdb');
 var U32 = utils.U32;
@@ -43,10 +42,10 @@ var U32 = utils.U32;
  *  a[wid][index] -> account
  *  i[wid][name] -> account index
  *  t[wid]* -> txdb
- *  R -> tip height
- *  c[height] -> chain header
+ *  R -> chain sync state
+ *  h[height] -> recent block hash
  *  b[height] -> block->wid map
- *  e[hash] -> tx->wid map
+ *  o[hash][index] -> outpoint->wid map
  */
 
 var layout = {
@@ -109,14 +108,11 @@ var layout = {
     return [key.readUInt32BE(1, true), key.toString('ascii', 5)];
   },
   R: new Buffer([0x52]),
-  c: function c(height) {
+  h: function h(height) {
     var key = new Buffer(5);
-    key[0] = 0x63;
+    key[0] = 0x68;
     key.writeUInt32BE(height, 1, true);
     return key;
-  },
-  cc: function cc(key) {
-    return key.readUInt32BE(1, true);
   },
   b: function b(height) {
     var key = new Buffer(5);
@@ -127,18 +123,9 @@ var layout = {
   bb: function bb(key) {
     return key.readUInt32BE(1, true);
   },
-  e: function e(hash) {
-    var key = new Buffer(33);
-    key[0] = 0x65;
-    key.write(hash, 1, 'hex');
-    return key;
-  },
-  ee: function ee(key) {
-    return key.toString('hex', 1);
-  },
   o: function o(hash, index) {
     var key = new Buffer(37);
-    key[0] = 0x01;
+    key[0] = 0x6f;
     key.write(hash, 1, 'hex');
     key.writeUInt32BE(index, 33, true);
     return key;
@@ -266,17 +253,30 @@ WalletDB.prototype._close = co(function* close() {
 });
 
 /**
- * Connect and sync with the chain server (without a lock).
+ * Watch addresses and outpoints.
  * @private
  * @returns {Promise}
  */
 
 WalletDB.prototype.watch = co(function* watch() {
-  var data = yield this.getFilterData();
+  var hashes = yield this.getHashes();
+  var outpoints = yield this.getOutpoints();
+  var chunks = [];
+  var i, hash, outpoint;
 
-  this.logger.info('Adding %d hashes to WalletDB filter.', data.length);
+  for (i = 0; i < hashes.length; i++) {
+    hash = hashes[i];
+    chunks.push(hash);
+  }
 
-  this.addFilter(data);
+  for (i = 0; i < outpoints.length; i++) {
+    outpoint = outpoints[i];
+    chunks.push(outpoint.toRaw());
+  }
+
+  this.logger.info('Adding %d chunks to WalletDB filter.', chunks.length);
+
+  this.addFilter(chunks);
 });
 
 /**
@@ -460,6 +460,7 @@ WalletDB.prototype.wipe = co(function* wipe() {
   this.logger.warning('Wiping WalletDB TXDB...');
   this.logger.warning('I hope you know what you\'re doing.');
 
+  // All TXDB records
   keys = yield this.db.keys({
     gte: TXDB.layout.prefix(0x00000000, dummy),
     lte: TXDB.layout.prefix(0xffffffff, dummy)
@@ -470,6 +471,62 @@ WalletDB.prototype.wipe = co(function* wipe() {
     batch.del(key);
   }
 
+  // All recent block hashes
+  keys = yield this.db.keys({
+    gte: layout.h(0),
+    lte: layout.h(0xffffffff)
+  });
+
+  for (i = 0; i < keys.length; i++) {
+    key = keys[i];
+    batch.del(key);
+  }
+
+  // The state record
+  batch.del(layout.R);
+
+  // All block maps
+  keys = yield this.db.keys({
+    gte: layout.b(0),
+    lte: layout.b(0xffffffff)
+  });
+
+  for (i = 0; i < keys.length; i++) {
+    key = keys[i];
+    batch.del(key);
+  }
+
+  // All outpoint maps
+  keys = yield this.db.keys({
+    gte: layout.o(constants.NULL_HASH, 0),
+    lte: layout.o(constants.HIGH_HASH, 0xffffffff)
+  });
+
+  for (i = 0; i < keys.length; i++) {
+    key = keys[i];
+    batch.del(key);
+  }
+
+  // All TX maps (e -- old)
+  gte = new Buffer(33);
+  gte.fill(0);
+  gte[0] = 0x65;
+
+  lte = new Buffer(33);
+  lte.fill(255);
+  lte[0] = 0x65;
+
+  keys = yield this.db.keys({
+    gte: gte,
+    lte: lte
+  });
+
+  for (i = 0; i < keys.length; i++) {
+    key = keys[i];
+    batch.del(key);
+  }
+
+  // All block maps (b -- 32 byte old)
   gte = new Buffer(33);
   gte.fill(0);
   gte[0] = 0x62;
@@ -488,37 +545,24 @@ WalletDB.prototype.wipe = co(function* wipe() {
     batch.del(key);
   }
 
+  // All block records (c -- old)
+  gte = new Buffer(33);
+  gte.fill(0);
+  gte[0] = 0x63;
+
+  lte = new Buffer(33);
+  lte.fill(255);
+  lte[0] = 0x63;
+
   keys = yield this.db.keys({
-    gte: layout.b(0),
-    lte: layout.b(0xffffffff)
+    gte: gte,
+    lte: lte
   });
 
   for (i = 0; i < keys.length; i++) {
     key = keys[i];
     batch.del(key);
   }
-
-  keys = yield this.db.keys({
-    gte: layout.c(0),
-    lte: layout.c(0xffffffff)
-  });
-
-  for (i = 0; i < keys.length; i++) {
-    key = keys[i];
-    batch.del(key);
-  }
-
-  keys = yield this.db.keys({
-    gte: layout.e(constants.NULL_HASH),
-    lte: layout.e(constants.HIGH_HASH)
-  });
-
-  for (i = 0; i < keys.length; i++) {
-    key = keys[i];
-    batch.del(key);
-  }
-
-  batch.del(layout.R);
 
   yield batch.write();
 });
@@ -1202,30 +1246,6 @@ WalletDB.prototype.getOutpoints = function getOutpoints() {
 };
 
 /**
- * Get hashes required for rescan filter.
- * @returns {Promise}
- */
-
-WalletDB.prototype.getFilterData = co(function* getFilterData() {
-  var chunks = [];
-  var hashes = yield this.getHashes();
-  var unspent = yield this.getOutpoints();
-  var i, hash, outpoint;
-
-  for (i = 0; i < hashes.length; i++) {
-    hash = hashes[i];
-    chunks.push(hash);
-  }
-
-  for (i = 0; i < unspent.length; i++) {
-    outpoint = unspent[i];
-    chunks.push(outpoint.toRaw());
-  }
-
-  return chunks;
-});
-
-/**
  * Get all address hashes.
  * @param {WalletID} wid
  * @returns {Promise}
@@ -1358,7 +1378,7 @@ WalletDB.prototype.getPendingKeys = co(function* getPendingKeys() {
   var keys = [];
   var iter, item;
 
-  iter = yield this.db.iterator({
+  iter = this.db.iterator({
     gte: layout.prefix(0x00000000, dummy),
     lte: layout.prefix(0xffffffff, dummy)
   });
@@ -1402,34 +1422,6 @@ WalletDB.prototype.getPendingTX = co(function* getPendingTX() {
 
     key = layout.prefix(wid, layout.t(hash));
     result.push(key);
-  }
-
-  return result;
-});
-
-/**
- * Get all wallet IDs with pending txs in them.
- * @returns {Promise}
- */
-
-WalletDB.prototype.getPendingWallets = co(function* getPendingWallets() {
-  var layout = TXDB.layout;
-  var keys = yield this.getPendingKeys();
-  var uniq = {};
-  var result = [];
-  var i, key, wid;
-
-  for (i = 0; i < keys.length; i++) {
-    key = keys[i];
-
-    wid = layout.pre(key);
-
-    if (uniq[wid])
-      continue;
-
-    uniq[wid] = true;
-
-    result.push(wid);
   }
 
   return result;
@@ -1602,8 +1594,8 @@ WalletDB.prototype.resetState = co(function* resetState(tip) {
   var iter, item;
 
   iter = this.db.iterator({
-    gte: layout.c(0),
-    lte: layout.c(0xffffffff),
+    gte: layout.h(0),
+    lte: layout.h(0xffffffff),
     values: false
   });
 
@@ -1625,7 +1617,7 @@ WalletDB.prototype.resetState = co(function* resetState(tip) {
   state.startHash = tip.hash;
   state.height = tip.height;
 
-  batch.put(layout.c(tip.height), tip.toHash());
+  batch.put(layout.h(tip.height), tip.toHash());
   batch.put(layout.R, state.toRaw());
 
   yield batch.write();
@@ -1654,7 +1646,7 @@ WalletDB.prototype.syncState = co(function* syncState(tip) {
       blocks = this.keepBlocks;
 
     for (i = 0; i < blocks; i++) {
-      batch.del(layout.c(height));
+      batch.del(layout.h(height));
       height--;
     }
   } else if (tip.height > state.height) {
@@ -1664,13 +1656,13 @@ WalletDB.prototype.syncState = co(function* syncState(tip) {
     height = tip.height - this.keepBlocks;
 
     if (height >= 0)
-      batch.del(layout.c(height));
+      batch.del(layout.h(height));
   }
 
   state.height = tip.height;
 
   // Save tip and state.
-  batch.put(layout.c(tip.height), tip.toHash());
+  batch.put(layout.h(tip.height), tip.toHash());
   batch.put(layout.R, state.toRaw());
 
   yield batch.write();
@@ -1703,32 +1695,6 @@ WalletDB.prototype.unwriteBlockMap = function unwriteBlockMap(wallet, height) {
 };
 
 /**
- * Add a transaction to global tx map.
- * @param {Wallet} wallet
- * @param {Hash} hash
- * @param {TXMapRecord} map
- * @returns {Promise}
- */
-
-WalletDB.prototype.writeTXMap = function writeTXMap(wallet, hash, map) {
-  var batch = this.batch(wallet);
-  batch.put(layout.e(hash), map.toRaw());
-  this.addFilter(hash);
-};
-
-/**
- * Remove a transaction from global tx map.
- * @param {Wallet} wallet
- * @param {Hash} hash
- * @returns {Promise}
- */
-
-WalletDB.prototype.unwriteTXMap = function unwriteTXMap(wallet, hash) {
-  var batch = this.batch(wallet);
-  batch.del(layout.e(hash));
-};
-
-/**
  * Add an outpoint to global unspent map.
  * @param {Wallet} wallet
  * @param {Hash} hash
@@ -1739,8 +1705,10 @@ WalletDB.prototype.unwriteTXMap = function unwriteTXMap(wallet, hash) {
 
 WalletDB.prototype.writeOutpointMap = function writeOutpointMap(wallet, hash, i, map) {
   var batch = this.batch(wallet);
-  batch.put(layout.o(hash, i), map.toRaw());
+
   this.addFilter(new Outpoint(hash, i).toRaw());
+
+  batch.put(layout.o(hash, i), map.toRaw());
 };
 
 /**
@@ -1778,7 +1746,7 @@ WalletDB.prototype.getBlockMap = co(function* getBlockMap(height) {
  */
 
 WalletDB.prototype.getBlock = co(function* getBlock(height) {
-  var data = yield this.db.get(layout.c(height));
+  var data = yield this.db.get(layout.h(height));
   var block;
 
   if (!data)
@@ -1804,21 +1772,6 @@ WalletDB.prototype.getTip = co(function* getTip() {
     throw new Error('WDB: Tip not found!');
 
   return tip;
-});
-
-/**
- * Get a TX->Wallet map.
- * @param {Hash} hash
- * @returns {Promise}
- */
-
-WalletDB.prototype.getTXMap = co(function* getTXMap(hash) {
-  var data = yield this.db.get(layout.e(hash));
-
-  if (!data)
-    return;
-
-  return TXMapRecord.fromRaw(hash, data);
 });
 
 /**
@@ -1889,12 +1842,13 @@ WalletDB.prototype.rollback = co(function* rollback(height) {
 
 WalletDB.prototype.revert = co(function* revert(height) {
   var total = 0;
-  var i, iter, item, block, tx;
+  var i, iter, item, height, block, tx;
 
   iter = this.db.iterator({
     gte: layout.b(height + 1),
     lte: layout.b(0xffffffff),
-    reverse: true
+    reverse: true,
+    values: true
   });
 
   for (;;) {
@@ -1904,7 +1858,8 @@ WalletDB.prototype.revert = co(function* revert(height) {
       break;
 
     try {
-      block = BlockMapRecord.fromRaw(item.value);
+      height = layout.bb(item.key);
+      block = BlockMapRecord.fromRaw(height, item.value);
       total += block.txs.length;
 
       for (i = block.txs.length - 1; i >= 0; i--) {
@@ -2140,40 +2095,6 @@ WalletDB.prototype._unconfirm = co(function* unconfirm(tx) {
     wallet = yield this.get(wid);
     assert(wallet);
     yield wallet.unconfirm(tx.hash);
-  }
-});
-
-/**
- * Zap stale transactions.
- * @param {Number} age
- * @returns {Promise}
- */
-
-WalletDB.prototype.zap = co(function* zap(age) {
-  var unlock = yield this.txLock.lock();
-  try {
-    return yield this._zap(age);
-  } finally {
-    unlock();
-  }
-});
-
-/**
- * Zap stale transactions without a lock.
- * @private
- * @param {Number} age
- * @returns {Promise}
- */
-
-WalletDB.prototype._zap = co(function* zap(age) {
-  var wids = yield this.getPendingWallets();
-  var i, wid, wallet;
-
-  for (i = 0; i < wids.length; i++) {
-    wid = wids[i];
-    wallet = yield this.get(wid);
-    assert(wallet);
-    yield wallet.zap(age);
   }
 });
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -979,7 +979,7 @@ WalletDB.prototype.getAccounts = function getAccounts(wid) {
     parse: function(data) {
       return data.toString('ascii');
     }
-  }
+  });
 };
 
 /**

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -24,7 +24,7 @@ var Bloom = require('../utils/bloom');
 var Logger = require('../node/logger');
 var TX = require('../primitives/tx');
 var records = require('./records');
-var SyncState = records.SyncState;
+var ChainState = records.ChainState;
 var BlockMapRecord = records.BlockMapRecord;
 var HeaderRecord = records.HeaderRecord;
 var PathMapRecord = records.PathMapRecord;
@@ -166,7 +166,7 @@ function WalletDB(options) {
   this.logger = options.logger || Logger.global;
   this.client = options.client;
 
-  this.state = new SyncState();
+  this.state = new ChainState();
   this.depth = 0;
   this.wallets = {};
   this.genesis = HeaderRecord.fromEntry(this.network.genesis);
@@ -233,8 +233,10 @@ WalletDB.prototype._open = co(function* open() {
   yield this.resend();
 
   this.logger.info(
-    'WalletDB loaded (depth=%d, height=%d).',
-    this.depth, this.state.tip.height);
+    'WalletDB loaded (depth=%d, height=%d, start=%d).',
+    this.depth,
+    this.state.tip.height,
+    this.state.start.height);
 });
 
 /**
@@ -265,7 +267,7 @@ WalletDB.prototype._close = co(function* close() {
 WalletDB.prototype.watch = co(function* watch() {
   var hashes = yield this.getFilterHashes();
 
-  this.logger.info('Adding %d hashes to filter.', hashes.length);
+  this.logger.info('Adding %d hashes to WalletDB filter.', hashes.length);
 
   this.addFilter(hashes);
 });
@@ -363,14 +365,16 @@ WalletDB.prototype.scan = co(function* scan(height) {
   if (!this.client)
     return;
 
-  assert(utils.isUInt32(height), 'Must pass in a height.');
+  assert(utils.isUInt32(height), 'WDB: Must pass in a height.');
 
   if (height > this.state.tip.height)
-    throw new Error('Cannot rescan future blocks.');
+    throw new Error('WDB: Cannot rescan future blocks.');
 
   yield this.rollback(height);
 
-  this.logger.info('Scanning %d blocks.', this.state.tip.height - height);
+  this.logger.info(
+    'WalletDB is scanning %d blocks.',
+    this.state.tip.height - height + 1);
 
   yield this.client.scan(this.state.tip.hash, this.filter, function(block, txs) {
     return self._addBlock(block, txs);
@@ -440,7 +444,7 @@ WalletDB.prototype.wipe = co(function* wipe() {
   var dummy = new Buffer(0);
   var i, keys, key, gte, lte;
 
-  this.logger.warning('Wiping txdb...');
+  this.logger.warning('Wiping WalletDB TXDB...');
   this.logger.warning('I hope you know what you\'re doing.');
 
   keys = yield this.db.keys({
@@ -549,7 +553,7 @@ WalletDB.prototype.getDepth = co(function* getDepth() {
  */
 
 WalletDB.prototype.start = function start(wallet) {
-  assert(!wallet.current, 'Batch already started.');
+  assert(!wallet.current, 'WDB: Batch already started.');
   wallet.current = this.db.batch();
   wallet.accountCache.start();
   wallet.pathCache.start();
@@ -591,7 +595,7 @@ WalletDB.prototype.clear = function clear(wallet) {
  */
 
 WalletDB.prototype.batch = function batch(wallet) {
-  assert(wallet.current, 'Batch does not exist.');
+  assert(wallet.current, 'WDB: Batch does not exist.');
   return wallet.current;
 };
 
@@ -808,10 +812,10 @@ WalletDB.prototype._rename = co(function* _rename(wallet, id) {
   var i, paths, path, batch;
 
   if (!utils.isName(id))
-    throw new Error('Bad wallet ID.');
+    throw new Error('WDB: Bad wallet ID.');
 
   if (yield this.has(id))
-    throw new Error('ID not available.');
+    throw new Error('WDB: ID not available.');
 
   batch = this.start(wallet);
   batch.del(layout.l(old));
@@ -861,13 +865,13 @@ WalletDB.prototype.auth = co(function* auth(wid, token) {
 
   if (typeof token === 'string') {
     if (!utils.isHex256(token))
-      throw new Error('Authentication error.');
+      throw new Error('WDB: Authentication error.');
     token = new Buffer(token, 'hex');
   }
 
   // Compare in constant time:
   if (!crypto.ccmp(token, wallet.token))
-    throw new Error('Authentication error.');
+    throw new Error('WDB: Authentication error.');
 
   return wallet;
 });
@@ -903,7 +907,7 @@ WalletDB.prototype._create = co(function* create(options) {
   var wallet;
 
   if (exists)
-    throw new Error('Wallet already exists.');
+    throw new Error('WDB: Wallet already exists.');
 
   wallet = Wallet.fromOptions(this, options);
   wallet.wid = this.depth++;
@@ -912,7 +916,7 @@ WalletDB.prototype._create = co(function* create(options) {
 
   this.register(wallet);
 
-  this.logger.info('Created wallet %s.', wallet.id);
+  this.logger.info('Created wallet %s in WalletDB.', wallet.id);
 
   return wallet;
 });
@@ -1412,7 +1416,7 @@ WalletDB.prototype.resend = co(function* resend() {
   var i, key, data, tx;
 
   if (keys.length > 0)
-    this.logger.info('Rebroadcasting %d transactions.', keys.length);
+    this.logger.info('Rebroadcasting %d WalletDB transactions.', keys.length);
 
   for (i = 0; i < keys.length; i++) {
     key = keys[i];
@@ -1536,6 +1540,10 @@ WalletDB.prototype.init = co(function* init() {
     tip = this.genesis;
   }
 
+  this.logger.info(
+    'Initializing WalletDB chain state at %s (%d).',
+    utils.revHex(tip.hash), tip.height);
+
   yield this.syncState(tip, true);
 });
 
@@ -1550,7 +1558,7 @@ WalletDB.prototype.getState = co(function* getState() {
   if (!data)
     return;
 
-  return SyncState.fromRaw(data);
+  return ChainState.fromRaw(data);
 });
 
 /**
@@ -1698,29 +1706,35 @@ WalletDB.prototype.getTXMap = co(function* getTXMap(hash) {
  */
 
 WalletDB.prototype.rollback = co(function* rollback(height) {
-  var tip, start;
+  var tip, blocks;
 
   if (this.state.tip.height <= height)
     return;
 
   this.logger.info(
-    'Rolling back %d blocks to height %d.',
+    'Rolling back %d WalletDB blocks to height %d.',
     this.state.tip.height - height, height);
 
   tip = yield this.getHeader(height);
 
   if (!tip) {
+    blocks = this.state.tip.height - height;
+
+    if (blocks < this.keepBlocks)
+      throw new Error('WDB: Block not found for rollback.');
+
     if (height >= this.state.start.height) {
       yield this.revert(this.state.start.height);
       yield this.syncState(this.state.start, true);
       this.logger.warning(
-        'Wallet rolled back to start block (%d).',
+        'WalletDB rolled back to start block (%d).',
         this.state.tip.height);
     } else {
       yield this.revert(0);
       yield this.syncState(this.genesis, true);
-      this.logger.warning('Wallet rolled back to genesis block.');
+      this.logger.warning('WalletDB rolled back to genesis block.');
     }
+
     return;
   }
 
@@ -1729,7 +1743,7 @@ WalletDB.prototype.rollback = co(function* rollback(height) {
 });
 
 /**
- * Sync with chain height.
+ * Revert TXDB to an older state.
  * @param {Number} height
  * @returns {Promise}
  */
@@ -1764,7 +1778,7 @@ WalletDB.prototype.revert = co(function* revert(height) {
     }
   }
 
-  this.logger.info('Rolled back %d transactions.', total);
+  this.logger.info('Rolled back %d WalletDB transactions.', total);
 });
 
 /**
@@ -1794,14 +1808,22 @@ WalletDB.prototype._addBlock = co(function* addBlock(entry, txs) {
   var i, tip, tx;
 
   if (entry.height < this.state.tip.height) {
-    this.logger.warning('Wallet is connecting low blocks.');
+    this.logger.warning(
+      'WalletDB is connecting low blocks (%d).',
+      entry.height);
     return total;
   }
 
   if (entry.height === this.state.tip.height) {
-    this.logger.warning('Wallet is connecting low blocks.');
+    // We let blocks of the same height
+    // through specifically for rescans:
+    // we always want to rescan the last
+    // block since the state may have
+    // updated before the block was fully
+    // processed (in the case of a crash).
+    this.logger.warning('Duplicate connection for %d.', entry.height);
   } else if (entry.height !== this.state.tip.height + 1) {
-    throw new Error('Bad connection (height mismatch).');
+    throw new Error('WDB: Bad connection (height mismatch).');
   }
 
   tip = HeaderRecord.fromEntry(entry);
@@ -1820,7 +1842,7 @@ WalletDB.prototype._addBlock = co(function* addBlock(entry, txs) {
   }
 
   if (total > 0) {
-    this.logger.info('Connected block %s (tx=%d).',
+    this.logger.info('Connected WalletDB block %s (tx=%d).',
       utils.revHex(tip.hash), total);
   }
 
@@ -1851,27 +1873,24 @@ WalletDB.prototype.removeBlock = co(function* removeBlock(entry) {
  */
 
 WalletDB.prototype._removeBlock = co(function* removeBlock(entry) {
-  var i, tx, tip, prev, block;
+  var i, tx, prev, block;
 
   if (entry.height > this.state.tip.height) {
-    this.logger.warning('Wallet is disconnecting high blocks.');
+    this.logger.warning(
+      'WalletDB is disconnecting high blocks (%d).',
+      entry.height);
     return 0;
   }
 
   if (entry.height !== this.state.tip.height)
-    throw new Error('Bad disconnection (height mismatch).');
-
-  tip = yield this.getHeader(entry.height);
-
-  if (!tip)
-    throw new Error('Bad disconnection (block not found).');
+    throw new Error('WDB: Bad disconnection (height mismatch).');
 
   prev = yield this.getHeader(entry.height - 1);
 
   if (!prev)
-    throw new Error('Bad disconnection (no previous block).');
+    throw new Error('WDB: Bad disconnection (no previous block).');
 
-  block = yield this.getBlockMap(tip.height);
+  block = yield this.getBlockMap(entry.height);
 
   if (!block) {
     yield this.syncState(prev);
@@ -1880,13 +1899,13 @@ WalletDB.prototype._removeBlock = co(function* removeBlock(entry) {
 
   for (i = block.txs.length - 1; i >= 0; i--) {
     tx = block.txs[i];
-    yield this._unconfirm(tx, tip);
+    yield this._unconfirm(tx);
   }
 
   yield this.syncState(prev);
 
-  this.logger.warning('Disconnected block %s (tx=%d).',
-    utils.revHex(tip.hash), block.txs.length);
+  this.logger.warning('Disconnected wallet block %s (tx=%d).',
+    utils.revHex(entry.hash), block.txs.length);
 
   return block.txs.length;
 });
@@ -1908,12 +1927,12 @@ WalletDB.prototype.addTX = co(function* addTX(tx) {
       entry = yield this.getHeader(tx.height);
 
       if (!entry)
-        throw new Error('Inserting unconfirmed transaction.');
+        throw new Error('WDB: Inserting unconfirmed transaction.');
 
       if (tx.block !== entry.hash)
-        throw new Error('Inserting unconfirmed transaction.');
+        throw new Error('WDB: Inserting unconfirmed transaction.');
 
-      this.logger.warning('Retroactively inserting confirmed transaction.');
+      this.logger.warning('WalletDB is inserting confirmed transaction.');
     }
 
     return yield this._insert(tx);
@@ -1934,7 +1953,7 @@ WalletDB.prototype._insert = co(function* insert(tx, block) {
   var result = false;
   var i, wids, wid, wallet;
 
-  assert(!tx.mutable, 'Cannot add mutable TX to wallet.');
+  assert(!tx.mutable, 'WDB: Cannot add mutable TX.');
 
   wids = yield this.getWalletsByInsert(tx);
 
@@ -1942,7 +1961,7 @@ WalletDB.prototype._insert = co(function* insert(tx, block) {
     return;
 
   this.logger.info(
-    'Incoming transaction for %d wallets (%s).',
+    'Incoming transaction for %d wallets in WalletDB (%s).',
     wids.length, tx.rhash);
 
   for (i = 0; i < wids.length; i++) {
@@ -1953,7 +1972,7 @@ WalletDB.prototype._insert = co(function* insert(tx, block) {
 
     if (yield wallet.add(tx, block)) {
       this.logger.info(
-        'Added transaction to wallet: %s (%d).',
+        'Added transaction to wallet in WalletDB: %s (%d).',
         wallet.id, wid);
       result = true;
     }

--- a/lib/wallet/walletkey.js
+++ b/lib/wallet/walletkey.js
@@ -121,18 +121,18 @@ WalletKey.fromSecret = function fromSecret(data) {
 WalletKey.prototype.toJSON = function toJSON() {
   return {
     network: this.network.type,
-    witness: this.witness,
-    nested: this.nested,
-    publicKey: this.publicKey.toString('hex'),
-    script: this.script ? this.script.toRaw().toString('hex') : null,
-    program: this.program ? this.program.toRaw().toString('hex') : null,
-    type: constants.scriptTypesByVal[this.type].toLowerCase(),
     wid: this.wid,
     id: this.id,
     name: this.name,
     account: this.account,
     branch: this.branch,
     index: this.index,
+    witness: this.witness,
+    nested: this.nested,
+    publicKey: this.publicKey.toString('hex'),
+    script: this.script ? this.script.toRaw().toString('hex') : null,
+    program: this.program ? this.program.toRaw().toString('hex') : null,
+    type: constants.scriptTypesByVal[this.type].toLowerCase(),
     address: this.getAddress('base58')
   };
 };

--- a/migrate/walletdb5to6.js
+++ b/migrate/walletdb5to6.js
@@ -143,7 +143,7 @@ function serializeWallets(wids, writer) {
   var p = new BufferWriter(writer);
   var i, wid;
 
-  p.writeVarint(wids.length);
+  p.writeU32(wids.length);
 
   for (i = 0; i < wids.length; i++) {
     wid = wids[i];

--- a/migrate/walletdb5to6.js
+++ b/migrate/walletdb5to6.js
@@ -1,0 +1,203 @@
+var assert = require('assert');
+var bcoin = require('../');
+var constants = require('../lib/protocol/constants');
+var BufferWriter = require('../lib/utils/writer');
+var BufferReader = require('../lib/utils/reader');
+var utils = require('../lib/utils/utils');
+var co = bcoin.co;
+var file = process.argv[2];
+var db, batch;
+
+assert(typeof file === 'string', 'Please pass in a database path.');
+
+file = file.replace(/\.ldb\/?$/, '');
+
+db = bcoin.ldb({
+  location: file,
+  db: 'leveldb',
+  compression: true,
+  cacheSize: 16 << 20,
+  writeBufferSize: 8 << 20,
+  createIfMissing: false,
+  bufferKeys: true
+});
+
+var updateVersion = co(function* updateVersion() {
+  var bak = process.env.HOME + '/walletdb-bak-' + Date.now() + '.ldb';
+  var data, ver;
+
+  console.log('Checking version.');
+
+  data = yield db.get('V');
+  assert(data, 'No version.');
+
+  ver = data.readUInt32LE(0, true);
+
+  if (ver !== 5)
+    throw Error('DB is version ' + ver + '.');
+
+  console.log('Backing up DB to: %s.', bak);
+
+  yield db.backup(bak);
+
+  ver = new Buffer(4);
+  ver.writeUInt32LE(6, 0, true);
+  batch.put('V', ver);
+});
+
+var wipeTXDB = co(function* wipeTXDB() {
+  var total = 0;
+  var i, keys, key;
+
+  keys = yield db.keys({
+    gte: new Buffer([0x00]),
+    lte: new Buffer([0xff])
+  });
+
+  for (i = 0; i < keys.length; i++) {
+    key = keys[i];
+    switch (key[0]) {
+      case 0x62: // b
+      case 0x63: // c
+      case 0x65: // e
+      case 0x74: // t
+      case 0x6f: // o
+      case 0x68: // h
+        batch.del(key);
+        total++;
+        break;
+    }
+  }
+
+  batch.del(new Buffer([0x52])); // R
+
+  console.log('Wiped %d txdb records.', total);
+});
+
+var patchAccounts = co(function* patchAccounts() {
+  var i, items, item, wid, index, account;
+
+  items = yield db.range({
+    gte: new Buffer('610000000000000000', 'hex'), // a
+    lte: new Buffer('61ffffffffffffffff', 'hex')  // a
+  });
+
+  for (i = 0; i < items.length; i++) {
+    item = items[i];
+    wid = item.key.readUInt32BE(1, true);
+    index = item.key.readUInt32BE(5, true);
+    account = accountFromRaw(item.value);
+    console.log('a[%d][%d] -> lookahead=%d', wid, index, account.lookahead);
+    batch.put(item.key, accountToRaw(account));
+    console.log('n[%d][%d] -> %s', wid, index, account.name);
+    batch.put(n(wid, index), new Buffer(account.name, 'ascii'));
+  }
+});
+
+var indexPaths = co(function* indexPaths() {
+  var i, items, item, wid, index, hash;
+
+  items = yield db.range({
+    gte: new Buffer('5000000000' + constants.NULL_HASH, 'hex'), // P
+    lte: new Buffer('50ffffffff' + constants.HIGH_HASH, 'hex')  // P
+  });
+
+  for (i = 0; i < items.length; i++) {
+    item = items[i];
+    wid = item.key.readUInt32BE(1, true);
+    hash = item.key.toString('hex', 5);
+    index = item.value.readUInt32LE(0, true);
+    console.log('r[%d][%d][%s] -> NUL', wid, index, hash);
+    batch.put(r(wid, index, hash), new Buffer([0]));
+  }
+});
+
+function accountToRaw(account) {
+  var p = new BufferWriter();
+  var i, key;
+
+  p.writeVarString(account.name, 'ascii');
+  p.writeU8(account.initialized ? 1 : 0);
+  p.writeU8(account.witness ? 1 : 0);
+  p.writeU8(account.type);
+  p.writeU8(account.m);
+  p.writeU8(account.n);
+  p.writeU32(account.accountIndex);
+  p.writeU32(account.receiveDepth);
+  p.writeU32(account.changeDepth);
+  p.writeU32(account.nestedDepth);
+  p.writeU8(account.lookahead);
+  p.writeBytes(account.accountKey);
+  p.writeU8(account.keys.length);
+
+  for (i = 0; i < account.keys.length; i++) {
+    key = account.keys[i];
+    p.writeBytes(key);
+  }
+
+  return p.render();
+};
+
+function accountFromRaw(data) {
+  var account = {};
+  var p = new BufferReader(data);
+  var i, count, key;
+
+  account.name = p.readVarString('ascii');
+  account.initialized = p.readU8() === 1;
+  account.witness = p.readU8() === 1;
+  account.type = p.readU8();
+  account.m = p.readU8();
+  account.n = p.readU8();
+  account.accountIndex = p.readU32();
+  account.receiveDepth = p.readU32() + 5;
+  account.changeDepth = p.readU32() + 10;
+  account.nestedDepth = p.readU32() + (account.witness ? 5 : 0);
+  account.lookahead = 5;
+  account.accountKey = p.readBytes(82);
+  account.keys = [];
+
+  count = p.readU8();
+
+  for (i = 0; i < count; i++) {
+    key = p.readBytes(82);
+    account.keys.push(key);
+  }
+
+  return account;
+}
+
+function n(wid, index) {
+  var key = new Buffer(9);
+  key[0] = 0x6e;
+  key.writeUInt32BE(wid, 1, true);
+  key.writeUInt32BE(index, 5, true);
+  return key;
+}
+
+function r(wid, index, hash) {
+  var key = new Buffer(1 + 4 + 4 + (hash.length / 2));
+  key[0] = 0x72;
+  key.writeUInt32BE(wid, 1, true);
+  key.writeUInt32BE(index, 5, true);
+  key.write(hash, 9, 'hex');
+  return key;
+}
+
+co.spawn(function* () {
+  yield db.open();
+  batch = db.batch();
+  console.log('Opened %s.', file);
+  yield updateVersion();
+  yield wipeTXDB();
+  yield patchAccounts();
+  yield indexPaths();
+  yield batch.write();
+  yield db.close();
+}).then(function() {
+  console.log('Migration complete.');
+  console.log('Rescan is required...');
+  console.log('Start bcoin with `--start-height=[wallet-creation-height]`');
+  console.log('for a fast sync.');
+  process.exit(0);
+});

--- a/migrate/walletdb5to6.js
+++ b/migrate/walletdb5to6.js
@@ -194,10 +194,10 @@ function accountFromRaw(data) {
   account.m = p.readU8();
   account.n = p.readU8();
   account.accountIndex = p.readU32();
-  account.receiveDepth = p.readU32() + 5;
-  account.changeDepth = p.readU32() + 10;
-  account.nestedDepth = p.readU32() + (account.witness ? 5 : 0);
-  account.lookahead = 5;
+  account.receiveDepth = p.readU32();
+  account.changeDepth = p.readU32();
+  account.nestedDepth = p.readU32();
+  account.lookahead = 10;
   account.accountKey = p.readBytes(82);
   account.keys = [];
 

--- a/migrate/walletdb5to6.js
+++ b/migrate/walletdb5to6.js
@@ -275,12 +275,11 @@ co.spawn(function* () {
   yield patchPathMaps();
   yield batch.write();
   yield db.close();
-  yield updateLookahead();
-  yield unstate();
+  // yield updateLookahead();
+  // yield unstate();
 }).then(function() {
   console.log('Migration complete.');
   console.log('Rescan is required...');
-  console.log('Start bcoin with `--start-height=[wallet-creation-height]`');
-  console.log('for a fast sync.');
+  console.log('Start bcoin with `--start-height=[wallet-creation-height]`.');
   process.exit(0);
 });

--- a/migrate/walletdb5to6.js
+++ b/migrate/walletdb5to6.js
@@ -124,7 +124,7 @@ var patchPathMaps = co(function* patchPathMaps() {
     item = items[i];
     hash = item.key.toString('hex', 1);
     wids = parseWallets(item.value);
-    console.log('p[%s] -> varint(%d)', hash, wids.length);
+    console.log('p[%s] -> u32(%d)', hash, wids.length);
     batch.put(item.key, serializeWallets(wids));
   }
 });

--- a/test/chain-test.js
+++ b/test/chain-test.js
@@ -128,7 +128,7 @@ describe('Chain', function() {
   it('should handle a reorg', cob(function* () {
     var entry, block, forked;
 
-    assert.equal(walletdb.height, chain.height);
+    assert.equal(walletdb.state.height, chain.height);
     assert.equal(chain.height, 10);
 
     entry = yield chain.db.get(tip2.hash);
@@ -227,8 +227,7 @@ describe('Chain', function() {
     assert(wallet.account.receiveDepth >= 8);
     assert(wallet.account.changeDepth >= 7);
 
-    assert.equal(walletdb.height, chain.height);
-    assert.equal(walletdb.state.tip.hash, chain.tip.hash);
+    assert.equal(walletdb.state.height, chain.height);
 
     txs = yield wallet.getHistory();
     assert.equal(txs.length, 44);

--- a/test/chain-test.js
+++ b/test/chain-test.js
@@ -236,7 +236,7 @@ describe('Chain', function() {
   it('should rescan for transactions', cob(function* () {
     var total = 0;
 
-    yield chain.db.scan(null, walletdb.filter, function(block, txs) {
+    yield chain.db.scan(0, walletdb.filter, function(block, txs) {
       total += txs.length;
       return Promise.resolve();
     });

--- a/test/chain-test.js
+++ b/test/chain-test.js
@@ -228,7 +228,7 @@ describe('Chain', function() {
     assert(wallet.account.changeDepth >= 7);
 
     assert.equal(walletdb.height, chain.height);
-    assert.equal(walletdb.tip.hash, chain.tip.hash);
+    assert.equal(walletdb.state.tip.hash, chain.tip.hash);
 
     txs = yield wallet.getHistory();
     assert.equal(txs.length, 44);

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -146,7 +146,7 @@ describe('HTTP', function() {
   }));
 
   it('should get a tx', cob(function* () {
-    var tx = yield wallet.getTX('default', hash);
+    var tx = yield wallet.getTX(hash);
     assert(tx);
     assert.equal(tx.hash, hash);
   }));

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -170,7 +170,7 @@ describe('Wallet', function() {
 
     k = bcoin.hd.fromMnemonic().deriveAccount44(0).hdPublicKey;
 
-    yield w.addKey(k);
+    yield w.addSharedKey(k);
 
     keys = [
       w.getPublicKey(),
@@ -681,12 +681,12 @@ describe('Wallet', function() {
     w3 = yield walletdb.create(options);
     receive = yield walletdb.create();
 
-    yield w1.addKey(w2.accountKey);
-    yield w1.addKey(w3.accountKey);
-    yield w2.addKey(w1.accountKey);
-    yield w2.addKey(w3.accountKey);
-    yield w3.addKey(w1.accountKey);
-    yield w3.addKey(w2.accountKey);
+    yield w1.addSharedKey(w2.accountKey);
+    yield w1.addSharedKey(w3.accountKey);
+    yield w2.addSharedKey(w1.accountKey);
+    yield w2.addSharedKey(w3.accountKey);
+    yield w3.addSharedKey(w1.accountKey);
+    yield w3.addSharedKey(w2.accountKey);
 
     // Our p2sh address
     b58 = w1[rec].getAddress('base58');


### PR DESCRIPTION
Features:

- Better chain syncing. Maintains a start block to avoid rolling back to the genesis block for rescans. Looks for a block in the main chain on boot to handle crashes during reorgs instead of rescanning back 36 blocks.
- Outpoint maps - necessary for any block scanner that has no access to the coin addresses.
- Block records - each wallet will record every txid of theirs that made it into a block. Exposed on the api `$ bcoin wallet blocks` and `$ bcoin wallet block [height]`.
- Account address indexing - faster address by account iteration.
- Account index->name indexing - faster account name lookups for tx details.
- A `client` object is now passed in to resemble an API client once we separate the walletdb from the node.

Migration is in `migrate/walletdb5to6.js`. Requires a rescan. Set `--start-height=[wallet-creation-height]` on next boot.