### PR TITLE
netaddress: fix fromHost to include BLOOM service

### DIFF
--- a/lib/primitives/netaddress.js
+++ b/lib/primitives/netaddress.js
@@ -218,7 +218,7 @@ NetAddress.prototype.fromHost = function fromHost(host, port, network) {
 
   this.host = host;
   this.port = port || network.port;
-  this.services = constants.services.NETWORK | constants.services.WITNESS;
+  this.services = constants.services.NETWORK | constants.services.WITNESS | constants.services.BLOOM;
   this.ts = network.now();
 
   this.hostname = IP.hostname(this.host, this.port);


### PR DESCRIPTION
When a `pool` is created with spv enabled, the BLOOM service flag is set on `pool.needed` value.
This is resulting in no host passing the `addr.hasServices(this.needed)` test in `pool.getHost()` and as a result no hosts to connect to.

Fix: setting the BLOOM flag on the address `services` property when adding the host to the hostlist.

