### PR TITLE
bloom: fix minimum value of n

### DIFF
--- a/lib/utils/bloom.js
+++ b/lib/utils/bloom.js
@@ -166,7 +166,7 @@ Bloom.fromRate = function fromRate(items, rate, update) {
   if (update !== -1)
     size = Math.min(size, constants.bloom.MAX_BLOOM_FILTER_SIZE * 8);
 
-  n = (size / items * LN2) | 0;
+  n = ((size / items * LN2) | 0) || 1;
 
   if (update !== -1)
     n = Math.min(n, constants.bloom.MAX_HASH_FUNCS);


### PR DESCRIPTION
When constructing a bloom filter from number of items and a rate, if the number of items is too large the value of n was coming to zero. The minimum value of n should be 1, otherwise the bloom filter doesn't function correctly.

This was the case in spv mode where the walletdb was creating a bloom filter for 1million items:

`Bloom.fromRate(1000000, 0.001, 1);`