### PR TITLE
spvnode: fix incorrect function call.

### DIFF
--- a/lib/node/spvnode.js
+++ b/lib/node/spvnode.js
@@ -126,7 +126,7 @@ util.inherits(SPVNode, Node);
 
 SPVNode.prototype._init = function _init() {
   var self = this;
-  var onError = this._error.bind(this);
+  var onError = this.error.bind(this);
 
   // Bind to errors
   this.chain.on('error', onError);
@@ -156,7 +156,7 @@ SPVNode.prototype._init = function _init() {
       try {
         yield self.watchBlock(entry, block);
       } catch (e) {
-        self._error(e);
+        self.error(e);
       }
       return;
     }


### PR DESCRIPTION
Broken here: https://github.com/bcoin-org/bcoin/commit/199699d7#diff-b00afaadd4f3e1b8c0f56c2f988566fdL172

Just need to remove the underscores.