### PR TITLE
nodeclient: update addFilter and resetFilter

### DIFF
--- a/lib/node/nodeclient.js
+++ b/lib/node/nodeclient.js
@@ -146,6 +146,8 @@ NodeClient.prototype.setFilter = function setFilter(filter) {
  */
 
 NodeClient.prototype.addFilter = function addFilter(data) {
+  this.filter.add(data);
+  this.node.pool.setFilter(this.filter);
   return Promise.resolve();
 };
 
@@ -155,6 +157,8 @@ NodeClient.prototype.addFilter = function addFilter(data) {
  */
 
 NodeClient.prototype.resetFilter = function resetFilter() {
+  this.filter.reset();
+  this.node.pool.setFilter(this.filter);
   return Promise.resolve();
 };
 


### PR DESCRIPTION
Complete addFilter and resetFilter methods in NodeClient.

WalletDB requires addFilter when it adds a hash in savePath()

