### PR TITLE
add option to disable bip69 in Wallet.send

### DIFF
--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1543,8 +1543,8 @@ Wallet.prototype.estimateSize = co(function* estimateSize(prev) {
 
 /**
  * Build a transaction, fill it with outputs and inputs,
- * sort the members according to BIP69, set locktime,
- * and template it.
+ * sort the members according to BIP69 (set options.noSorting
+ * to avoid sorting), set locktime, and template it.
  * @param {Object} options - See {@link Wallet#fund options}.
  * @param {Object[]} options.outputs - See {@link MTX#addOutput}.
  * @returns {Promise} - Returns {@link MTX}.
@@ -1572,7 +1572,8 @@ Wallet.prototype.createTX = co(function* createTX(options, force) {
   yield this.fund(mtx, options, force);
 
   // Sort members a la BIP69
-  mtx.sortMembers();
+  if(!options.noSorting)
+    mtx.sortMembers();
 
   // Set the locktime to target value.
   if (options.locktime != null)


### PR DESCRIPTION
It may be undesirable in some applications to automatically sort inputs and outputs when constructing a transaction. 

In this PR changing behaviour so `Wallet.createTX` will skip sorting if `noSorting` is set in options.
Default behaviour is unchanged, bip69 sorting is still applied.

To disable bip69 when calling `Wallet.send`
```
Wallet.send({
  noSorting: true,
  outputs: [ ... ]
})
```

