### PR TITLE
pool: graceful disconnect

### DIFF
--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -352,9 +352,10 @@ Pool.prototype._disconnect = co(function* disconnect() {
     item.resolve();
   }
 
-  this.peers.destroy();
+  // prevent peer list from trying to refill
+  this.disconnecting = true;
 
-  this.nonces = new NonceList();
+  this.peers.destroy();
 
   this.requestMap.reset();
 
@@ -376,6 +377,7 @@ Pool.prototype._disconnect = co(function* disconnect() {
 
   yield this.unlisten();
 
+  this.disconnecting = false;
   this.syncing = false;
   this.connected = false;
 });
@@ -1154,7 +1156,8 @@ Pool.prototype.handleClose = co(function* handleClose(peer, connected) {
   if (!outbound)
     return;
 
-  this.refill();
+  if(!this.disconnecting)
+    this.refill();
 });
 
 /**
@@ -3722,22 +3725,10 @@ PeerList.prototype.has = function has(hostname) {
 PeerList.prototype.destroy = function destroy() {
   var peer, next;
 
-  this.map = {};
-  this.load = null;
-  this.inbound = 0;
-  this.outbound = 0;
-
   for (peer = this.list.head; peer; peer = next) {
     next = peer.next;
-
-    // stop processing peer events
-    peer.onPacket = null;
-    peer.removeAllListeners()
-
     peer.destroy();
   }
-
-  this.list = new List();
 };
 
 /**

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -354,6 +354,8 @@ Pool.prototype._disconnect = co(function* disconnect() {
 
   this.peers.destroy();
 
+  this.nonces = new NonceList();
+
   this.requestMap.reset();
 
   if (this.pendingFilter != null) {
@@ -3727,8 +3729,15 @@ PeerList.prototype.destroy = function destroy() {
 
   for (peer = this.list.head; peer; peer = next) {
     next = peer.next;
+
+    // stop processing peer events
+    peer.onPacket = null;
+    peer.removeAllListeners()
+
     peer.destroy();
   }
+
+  this.list = new List();
 };
 
 /**

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -1156,8 +1156,10 @@ Pool.prototype.handleClose = co(function* handleClose(peer, connected) {
   if (!outbound)
     return;
 
-  if(!this.disconnecting)
-    this.refill();
+  if(this.disconnecting)
+    return;
+
+  this.refill();
 });
 
 /**


### PR DESCRIPTION
When the pool disconnects, it destroys the peers list. As peers get destroyed when the underlying sockets are closed, pool.handleClose is invoked as the event handler for the peer 'close' event, which tries to remove the peer from the peers list again. Since it was destroyed this is resulting in [failed assert here](https://github.com/bcoin-org/bcoin/blob/bae2aa33ddba7092ca1bf8f205937218bdc29d41/lib/net/pool.js#L3681).

This fix ensures we stop processing all events from a peer if it is forcefully destroyed during pool shutdown, and resets the nonces and peers.list, to gracefully shutdown and disconnect the pool.

Calling pool.connect() again after shutdown tested to work correctly.

All unit tests are passing.