### PR TITLE
HTTP: Fix DELETE requests

### DIFF
--- a/lib/http/base.js
+++ b/lib/http/base.js
@@ -739,7 +739,7 @@ Routes.prototype.getHandlers = function getHandlers(method) {
       return this.post;
     case 'PUT':
       return this.put;
-    case 'DEL':
+    case 'DELETE':
       return this.del;
     default:
       return;


### PR DESCRIPTION
Typo with DELETE requests looking for DEL keyword. Easy fix.

(Probably should add test cases to cover, but I didn't bother)