### PR TITLE
http: add Authorization to allowed headers

### DIFF
--- a/lib/http/server.js
+++ b/lib/http/server.js
@@ -96,6 +96,7 @@ HTTPServer.prototype._init = function _init() {
     res.setHeader(
       'Access-Control-Allow-Methods',
       'GET,HEAD,PUT,PATCH,POST,DELETE');
+    res.setHeader("Access-Control-Allow-Headers", "Authorization");
 
     if (req.method === 'OPTIONS') {
       res.statusCode = 200;


### PR DESCRIPTION
When I try to make a cross-origin request to the REST API when an API token is set (i.e. when I am connecting using basic auth), I get an error: 

> Fetch API cannot load http://localhost:8334/. Request header field authorization is not allowed by Access-Control-Allow-Headers in preflight response.

Unless this is the intended behavior, I think this can be solved by changing the headers of the response, as shown.