### PR TITLE
Add path to bcoin command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Try it in the browser: http://bcoin.io/browser.html
 $ git clone git://github.com/bcoin-org/bcoin.git
 $ cd bcoin
 $ npm install
-$ bcoin
+$ bin/bcoin
 ```
 
 See the [Beginner's Guide][guide] for more in-depth installation instructions.


### PR DESCRIPTION
After npm installing, running the command bcoin didn't work. It should be bin/bcoin instead

    Michaels-MacBook-Pro:bcoin michaelfolkson$ pwd
    /Users/michaelfolkson/bcoin
    Michaels-MacBook-Pro:bcoin michaelfolkson$ bcoin
    -bash: bcoin: command not found