### PR TITLE
RPC method compatibility with bitcoin core.

### DIFF
--- a/lib/utils/validator.js
+++ b/lib/utils/validator.js
@@ -407,6 +407,14 @@ Validator.prototype.bool = function bool(key, fallback) {
   if (value === null)
     return fallback;
 
+  // bitcoin core mixes semantics of truthiness amoung rpc methods
+  // most "verbose" parameters are bools, but getrawtransaction is 1/0
+  if (value === 1)
+    return true;
+
+  if (value === 0)
+    return false;
+
   if (typeof value !== 'string') {
     if (typeof value !== 'boolean')
       throw new ValidationError(fmt(key) + ' must be a boolean.');

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -154,6 +154,11 @@ describe('HTTP', function() {
     assert.equal(info.blocks, 0);
   }));
 
+  it('should execute an rpc call with bool parameter', co(function* () {
+    var info = yield wallet.client.rpc.execute('getrawmempool', [true]);
+    assert.deepStrictEqual(info, {});
+  }));
+
   it('should create account', co(function* () {
     var info = yield wallet.createAccount('foo1');
     assert(info);

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -9,6 +9,7 @@ var crypto = require('../lib/crypto/crypto');
 var schnorr = require('../lib/crypto/schnorr');
 var Amount = require('../lib/btc/amount');
 var consensus = require('../lib/protocol/consensus');
+var Validator = require('../lib/utils/validator');
 
 describe('Utils', function() {
   var vectors, signed, unsigned;
@@ -327,5 +328,11 @@ describe('Utils', function() {
     var sig = schnorr.sign(msg, key);
     assert(schnorr.verify(msg, sig, pub));
     assert.deepEqual(schnorr.recover(sig, msg), pub);
+  });
+
+  it('should validate integers 0 and 1 as booleans', function() {
+    var validator = new Validator({shouldBeTrue: 1, shouldBeFalse: 0});
+    assert(validator.bool('shouldBeTrue') === true);
+    assert(validator.bool('shouldBeFalse') === false);
   });
 });


### PR DESCRIPTION
- RPC method param semantics, unfortunately, aren't consistent in bitcoin core, therefore bcoin can't be used as a drop in replacement if bcoin "fixes the glitch".
- To avoid breaking bcoin's current api, validation of bool includes integers 0 and 1 as false and true, respectively.
- The effect of this is to allow getRawTransaction to work with older client code.