### PR TITLE
mempool: import indexAddress option.

### DIFF
--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -2154,6 +2154,11 @@ MempoolOptions.prototype.fromOptions = function fromOptions(options) {
     this.persistent = options.persistent;
   }
 
+  if (options.indexAddress != null) {
+    assert(typeof options.indexAddress === 'boolean');
+    this.indexAddress = options.indexAddress;
+  }
+
   return this;
 };
 


### PR DESCRIPTION
This option was not imported but expected in the following lines:

https://github.com/bcoin-org/bcoin/blob/master/lib/mempool/mempool.js#L133
https://github.com/bcoin-org/bcoin/blob/master/lib/mempool/mempool.js#L1831