### PR TITLE
Updated packages with known security issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "bcoin-native": "0.0.14",
     "leveldown": "1.5.0",
     "secp256k1": "3.2.5",
-    "socket.io": "1.4.8",
-    "socket.io-client": "1.4.8"
+    "socket.io": "1.7.3",
+    "socket.io-client": "1.7.3"
   },
   "devDependencies": {
     "babelify": "7.3.0",


### PR DESCRIPTION
Updated socket.io and socket.io-client since the previous versions were dependent on modules with security vulnerabilities.

Those are the vulnerabilities according to a scan using NSP (https://github.com/nodesecurity/nsp)


│ DoS due to excessively large websocket message
│ Name          : ws
│ Installed     : 1.1.0
│ Vulnerable    : <=1.1.0
│ Patched       : >=1.1.1
│ Path          : bcoin@1.0.0-beta.12 > socket.io@1.4.8 > engine.io@1.6.11 > ws@1.1.0
│ More Info     : https://nodesecurity.io/advisories/120

│ Regular Expression Denial of Service
│ Name          : negotiator
│ Installed     : 0.4.9
│ Vulnerable    : <= 0.6.0
│ Patched       : >= 0.6.1
│ Path          : bcoin@1.0.0-beta.12 > socket.io@1.4.8 > engine.io@1.6.11 > accepts@1.1.4 > negotiator@0.4.9
│ More Info     : https://nodesecurity.io/advisories/106

│ DoS due to excessively large websocket message
│ Name          : ws
│ Installed     : 1.0.1
│ Vulnerable    : <=1.1.0
│ Patched       : >=1.1.1
│ Path          : bcoin@1.0.0-beta.12 > socket.io@1.4.8 > socket.io-client@1.4.8 > engine.io-client@1.6.11 > ws@1.0.1
│ More Info     : https://nodesecurity.io/advisories/120

│ DoS due to excessively large websocket message
│ Name          : ws
│ Installed     : 1.0.1
│ Vulnerable    : <=1.1.0
│ Patched       : >=1.1.1
│ Path          : bcoin@1.0.0-beta.12 > socket.io-client@1.4.8 > engine.io-client@1.6.11 > ws@1.0.1
│ More Info     : https://nodesecurity.io/advisories/120