### PR TITLE
return coinbase scriptSig string in getblock requests 

### DIFF
--- a/lib/http/rpc.js
+++ b/lib/http/rpc.js
@@ -2594,6 +2594,7 @@ RPC.prototype.blockToJSON = co(function* blockToJSON(entry, block, details) {
     version: entry.version,
     versionHex: util.hex32(entry.version),
     merkleroot: util.revHex(entry.merkleRoot),
+    coinbase: block.txs[0].inputs[0].script,
     tx: txs,
     time: entry.ts,
     mediantime: mtp,

--- a/lib/primitives/block.js
+++ b/lib/primitives/block.js
@@ -623,6 +623,7 @@ Block.prototype.getJSON = function getJSON(network, view, height) {
     ts: this.ts,
     bits: this.bits,
     nonce: this.nonce,
+    coinbase: this.txs[0].inputs[0].script,
     txs: this.txs.map(function(tx, i) {
       return tx.getJSON(network, view, null, i);
     }, this)


### PR DESCRIPTION
Lots of exciting messages in the coinbase string these days! Getting this string currently requires a separate call for `getTransaction()`, and that won't even work (in Core anyway, not sure about bcoin) unless you have `txindex=1`.  I'm currently using the `bcoin rpc getblock ...` for this purpose and it's nice to have it as part of the return array. I haven't been able to test the `bcoin cli block ...` yet because of issue https://github.com/bcoin-org/bcoin/issues/208