### PR TITLE
Use standard isNaN function instead of self-comparison

### DIFF
--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -215,7 +215,7 @@ RequestOptions.prototype.isOverflow = function isOverflow(length) {
 
   length = parseInt(length, 10);
 
-  if (length !== length)
+  if (isNaN(length))
     return true;
 
   return length > this.limit;

--- a/lib/utils/ip.js
+++ b/lib/utils/ip.js
@@ -386,7 +386,7 @@ IP.parseV6 = function parseV6(str, raw, offset) {
 
     word = parseInt(word, 16);
 
-    assert(word === word, 'Non-number in IPv6 address.');
+    assert(!isNaN(word), 'Non-number in IPv6 address.');
 
     raw[offset++] = (word >> 8) & 0xff;
     raw[offset++] = word & 0xff;


### PR DESCRIPTION
I hope this is the right way to contribute.

This PR replaces uses of self comparison to determine if a value is `NaN` with the standard function `isNaN()`. This Also fixes two alert results of type "Comparison of Identical Values" on lgtm.com (@lgtmhq) : https://lgtm.com/projects/g/bcoin-org/bcoin/alerts/ There are a number of other alerts that are probably worth looking into.

You can also [set up PR checks](https://lgtm.com/projects/g/bcoin-org/bcoin/ci/) for free that report changes in alerts.

Full disclosure: I am one of the core developers for lgtm.com