### PR TITLE
Various improvements to float parsing

### DIFF
--- a/lib/btc/amount.js
+++ b/lib/btc/amount.js
@@ -488,7 +488,7 @@ Amount.parse = function parse(value, exp, num) {
 Amount.parseUnsafe = function parseUnsafe(value, exp, num) {
   if (typeof value === 'string') {
     assert(util.isFloat(value), 'Non-BTC value for conversion.');
-    value = parseFloat(value, 10);
+    value = parseFloat(value);
   } else {
     assert(util.isNumber(value), 'Non-BTC value for conversion.');
     assert(num, 'Cannot parse number.');

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -392,6 +392,11 @@ util.isHex256 = function isHex256(hash) {
 
 /**
  * Test whether a string qualifies as a float.
+ *
+ * This is stricter than checking if the result of parseFloat() is NaN
+ * as, e.g. parseFloat successfully parses the string '1.2.3' as 1.2, and
+ * we also check that the value is a string.
+ *
  * @param {String?} value
  * @returns {Boolean}
  */


### PR DESCRIPTION
I thought this was going to be a simple fix after noticing the call to `parseFloat()` included an un-needed radix parameter (note that unlike `parseInt`, `parseFloat()` does not take a radix parameter). But after a bit of investigation I found that things were a little more nuanced.

(This started from an alert on lgtm here: https://lgtm.com/projects/g/bcoin-org/bcoin/snapshot/d074af8a28d105c4544053bb19cac83ae6438b29/files/lib/btc/amount.js#L491)

I was intending to replace calls to `util.isFloat()` with conversions using `parseFloat()` and checking if the result was `NaN` (given that we need to parse the value anyway), however I discovered that node's implementation of `parseFloat()` is not very strict, and in particular parses strings like `'1.2.3'` as `1.2`. So that would change behaviour (as it would be less strict than the regex) so i've left that function as is, and added a doc for clarification.

Next I was intending to just remove the radix parameter in the call to `parseFloat` in `parseUnsafe()`, but after a quick grep, it seems that `parseUnsafe()` is completely unused (and probably shouldn't really be used instead of parse()), so I've deleted this method.

All in all, this PR shouldn't actually change any of the behaviour, and hopefully it's acceptable.
