### PR TITLE
net/http: correctly reject promise return by listen()

### DIFF
--- a/lib/http/base.js
+++ b/lib/http/base.js
@@ -812,10 +812,10 @@ HTTPBase.prototype.address = function address() {
 HTTPBase.prototype.listen = function listen(port, host) {
   return new Promise((resolve, reject) => {
     let addr;
-    this.server.listen(port, host, (err) => {
-      if (err)
-        return reject(err);
 
+    this.server.once('error', reject)
+
+    this.server.listen(port, host, () => {
       addr = this.address();
 
       this.emit('listening', addr);

--- a/lib/net/tcp.js
+++ b/lib/net/tcp.js
@@ -41,7 +41,8 @@ tcp.createServer = function createServer() {
 
   ee.listen = function listen(port, host) {
     return new Promise((resolve, reject) => {
-      server.listen(port, host, wrap(resolve, reject));
+      server.once('error', reject)
+      server.listen(port, host, resolve);
     });
   };
 


### PR DESCRIPTION
The callback provided to `listen` method on a tcp server (created with `net.createServer` and `http.createServer`)  is only called on success. 

So the promise returned was not correctly being rejected on error (eg. address/port in use). So it was only possible to "catch" this error in the 'error' events, when opening a node or connecting the network pool.

This PR is a simple fix that does the trick.
