### PR TITLE
Fix Pool bip150 assert

### DIFF
--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -3853,7 +3853,7 @@ PoolOptions.prototype.fromOptions = function fromOptions(options) {
 
   if (options.bip150 != null) {
     assert(typeof options.bip150 === 'boolean');
-    assert(this.bip151, 'Cannot enable bip150 without bip151.');
+    assert(!(options.bip150 && !this.bip151), 'Cannot enable bip150 without bip151.');
 
     if (options.knownPeers) {
       assert(typeof options.knownPeers === 'object');


### PR DESCRIPTION
If you configure `bip150` to false, it still checks whether `bip151` is true.