### PR TITLE
Update node engine requirement to >=7.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "wallet"
   ],
   "engines": {
-    "node": ">=7.0.0"
+    "node": ">=7.6.0"
   },
   "dependencies": {
     "bn.js": "4.11.7",


### PR DESCRIPTION
Async/await support comes by default in node version 7.6.0 so using earlier 7 versions fails to run bin/node.