### PR TITLE
Fix res.write and res.end

### DIFF
--- a/lib/http/base.js
+++ b/lib/http/base.js
@@ -106,7 +106,7 @@ HTTPBase.prototype._initRouter = function _initRouter() {
       req.pause();
       await this.handleRequest(req, res);
     } catch (e) {
-      res.error(e.statusCode || 500, e);
+      await res.error(e.statusCode || 500, e);
       this.emit('error', e);
     }
   });
@@ -170,7 +170,7 @@ HTTPBase.prototype.cors = function cors() {
 
     if (req.method === 'OPTIONS') {
       res.setStatus(200);
-      res.end();
+      await res.end();
       return;
     }
   };
@@ -205,10 +205,10 @@ HTTPBase.prototype.basicAuth = function basicAuth(options) {
 
   assert(typeof realm === 'string');
 
-  function fail(res) {
+  async function fail(res) {
     res.setHeader('WWW-Authenticate', `Basic realm="${realm}"`);
     res.setStatus(401);
-    res.end();
+    await res.end();
   }
 
   return async (req, res) => {
@@ -216,15 +216,15 @@ HTTPBase.prototype.basicAuth = function basicAuth(options) {
     let parts, username, password, hash;
 
     if (!auth)
-      return fail(res);
+      return await fail(res);
 
     parts = auth.split(' ');
 
     if (parts.length !== 2)
-      return fail(res);
+      return await fail(res);
 
     if (parts[0] !== 'Basic')
-      return fail(res);
+      return await fail(res);
 
     auth = Buffer.from(parts[1], 'base64').toString('utf8');
     parts = auth.split(':');
@@ -237,14 +237,14 @@ HTTPBase.prototype.basicAuth = function basicAuth(options) {
       hash = digest.hash256(hash);
 
       if (!ccmp(hash, user))
-        return fail(res);
+        return await fail(res);
     }
 
     hash = Buffer.from(password, 'utf8');
     hash = digest.hash256(hash);
 
     if (!ccmp(hash, pass))
-      return fail(res);
+      return await fail(res);
 
     req.username = username;
   };
@@ -418,7 +418,7 @@ HTTPBase.prototype.jsonRPC = function jsonRPC(rpc) {
 
     res.setHeader('X-Long-Polling', '/?longpoll=1');
 
-    res.send(200, json, 'json');
+    await res.send(200, json, 'json');
   };
 };
 
@@ -1395,22 +1395,26 @@ Response.prototype.writeHead = function writeHead(code, headers) {
 };
 
 Response.prototype.write = function write(data, enc) {
-  return this.res.write(data, enc);
+  return new Promise((resolve, reject) => {
+    this.res.write(data, enc, co.wrap(resolve, reject));
+  });
 };
 
 Response.prototype.end = function end(data, enc) {
-  this.sent = true;
-  return this.res.end(data, enc);
+  return new Promise((resolve, reject) => {
+    this.sent = true;
+    this.res.end(data, enc, co.wrap(resolve, reject));
+  });
 };
 
-Response.prototype.error = function error(code, err) {
+Response.prototype.error = async function error(code, err) {
   if (this.sent)
     return;
 
   if (!code)
     code = 400;
 
-  this.send(code, {
+  await this.send(code, {
     error: {
       type: err.type || 'Error',
       message: err.message,
@@ -1426,7 +1430,7 @@ Response.prototype.error = function error(code, err) {
   }
 };
 
-Response.prototype.redirect = function redirect(code, url) {
+Response.prototype.redirect = async function redirect(code, url) {
   if (!url) {
     url = code;
     code = 301;
@@ -1434,10 +1438,10 @@ Response.prototype.redirect = function redirect(code, url) {
 
   this.setStatus(code);
   this.setHeader('Location', url);
-  this.end();
+  await this.end();
 };
 
-Response.prototype.send = function send(code, msg, type) {
+Response.prototype.send = async function send(code, msg, type) {
   if (this.sent)
     return;
 
@@ -1471,8 +1475,8 @@ Response.prototype.send = function send(code, msg, type) {
     let len = Buffer.byteLength(msg, 'utf8');
     this.setHeader('Content-Length', len + '');
     try {
-      this.write(msg, 'utf8');
-      this.end();
+      await this.write(msg, 'utf8');
+      await this.end();
     } catch (e) {
       ;
     }
@@ -1482,8 +1486,8 @@ Response.prototype.send = function send(code, msg, type) {
   if (Buffer.isBuffer(msg)) {
     this.setHeader('Content-Length', msg.length + '');
     try {
-      this.write(msg);
-      this.end();
+      await this.write(msg);
+      await this.end();
     } catch (e) {
       ;
     }

--- a/lib/http/server.js
+++ b/lib/http/server.js
@@ -109,7 +109,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     if (!addr)
       addr = this.pool.hosts.address;
 
-    res.send(200, {
+    await res.send(200, {
       version: pkg.version,
       network: this.network.type,
       chain: {
@@ -154,7 +154,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     for (let coin of coins)
       result.push(coin.getJSON(this.network));
 
-    res.send(200, result);
+    await res.send(200, result);
   });
 
   // UTXO by id
@@ -171,11 +171,11 @@ HTTPServer.prototype.initRouter = function initRouter() {
     coin = await this.node.getCoin(hash, index);
 
     if (!coin) {
-      res.send(404);
+      await res.send(404);
       return;
     }
 
-    res.send(200, coin.getJSON(this.network));
+    await res.send(200, coin.getJSON(this.network));
   });
 
   // Bulk read UTXOs
@@ -193,7 +193,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     for (let coin of coins)
       result.push(coin.getJSON(this.network));
 
-    res.send(200, result);
+    await res.send(200, result);
   });
 
   // TX by hash
@@ -208,13 +208,13 @@ HTTPServer.prototype.initRouter = function initRouter() {
     meta = await this.node.getMeta(hash);
 
     if (!meta) {
-      res.send(404);
+      await res.send(404);
       return;
     }
 
     view = await this.node.getMetaView(meta);
 
-    res.send(200, meta.getJSON(this.network, view));
+    await res.send(200, meta.getJSON(this.network, view));
   });
 
   // TX by address
@@ -234,7 +234,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
       result.push(meta.getJSON(this.network, view));
     }
 
-    res.send(200, result);
+    await res.send(200, result);
   });
 
   // Bulk read TXs
@@ -254,7 +254,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
       result.push(meta.getJSON(this.network, view));
     }
 
-    res.send(200, result);
+    await res.send(200, result);
   });
 
   // Block by hash/height
@@ -274,20 +274,20 @@ HTTPServer.prototype.initRouter = function initRouter() {
     block = await this.chain.db.getBlock(hash);
 
     if (!block) {
-      res.send(404);
+      await res.send(404);
       return;
     }
 
     view = await this.chain.db.getBlockView(block);
 
     if (!view) {
-      res.send(404);
+      await res.send(404);
       return;
     }
 
     height = await this.chain.db.getHeight(hash);
 
-    res.send(200, block.getJSON(this.network, view, height));
+    await res.send(200, block.getJSON(this.network, view, height));
   });
 
   // Mempool snapshot
@@ -302,7 +302,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     for (let hash of hashes)
       result.push(util.revHex(hash));
 
-    res.send(200, result);
+    await res.send(200, result);
   });
 
   // Broadcast TX
@@ -317,7 +317,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
 
     await this.node.sendTX(tx);
 
-    res.send(200, { success: true });
+    await res.send(200, { success: true });
   });
 
   // Estimate fee
@@ -327,13 +327,13 @@ HTTPServer.prototype.initRouter = function initRouter() {
     let fee;
 
     if (!this.fees) {
-      res.send(200, { rate: this.network.feeRate });
+      await res.send(200, { rate: this.network.feeRate });
       return;
     }
 
     fee = this.fees.estimateFee(blocks);
 
-    res.send(200, { rate: fee });
+    await res.send(200, { rate: fee });
   });
 
   // Reset chain
@@ -345,7 +345,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
 
     await this.chain.reset(height);
 
-    res.send(200, { success: true });
+    await res.send(200, { success: true });
   });
 };
 

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -126,7 +126,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
       wallet = await this.walletdb.get(id);
 
       if (!wallet) {
-        res.send(404);
+        await res.send(404);
         return;
       }
 
@@ -144,7 +144,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     }
 
     if (!wallet) {
-      res.send(404);
+      await res.send(404);
       return;
     }
 
@@ -158,7 +158,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     let valid = req.valid();
     let height = valid.u32('height');
 
-    res.send(200, { success: true });
+    await res.send(200, { success: true });
 
     await this.walletdb.rescan(height);
   });
@@ -166,7 +166,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
   // Resend
   this.post('/_admin/resend', async (req, res) => {
     await this.walletdb.resend();
-    res.send(200, { success: true });
+    await res.send(200, { success: true });
   });
 
   // Backup WalletDB
@@ -178,23 +178,23 @@ HTTPServer.prototype.initRouter = function initRouter() {
 
     await this.walletdb.backup(path);
 
-    res.send(200, { success: true });
+    await res.send(200, { success: true });
   });
 
   // List wallets
   this.get('/_admin/wallets', async (req, res) => {
     let wallets = await this.walletdb.getWallets();
-    res.send(200, wallets);
+    await res.send(200, wallets);
   });
 
   // Get wallet
-  this.get('/:id', (req, res) => {
-    res.send(200, req.wallet.toJSON());
+  this.get('/:id', async (req, res) => {
+    await res.send(200, req.wallet.toJSON());
   });
 
   // Get wallet master key
-  this.get('/:id/master', (req, res) => {
-    res.send(200, req.wallet.master.toJSON(true));
+  this.get('/:id/master', async (req, res) => {
+    await res.send(200, req.wallet.master.toJSON(true));
   });
 
   // Create wallet (compat)
@@ -215,7 +215,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
       watchOnly: valid.bool('watchOnly')
     });
 
-    res.send(200, wallet.toJSON());
+    await res.send(200, wallet.toJSON());
   });
 
   // Create wallet
@@ -236,13 +236,13 @@ HTTPServer.prototype.initRouter = function initRouter() {
       watchOnly: valid.bool('watchOnly')
     });
 
-    res.send(200, wallet.toJSON());
+    await res.send(200, wallet.toJSON());
   });
 
   // List accounts
   this.get('/:id/account', async (req, res) => {
     let accounts = await req.wallet.getAccounts();
-    res.send(200, accounts);
+    await res.send(200, accounts);
   });
 
   // Get account
@@ -252,11 +252,11 @@ HTTPServer.prototype.initRouter = function initRouter() {
     let account = await req.wallet.getAccount(acct);
 
     if (!account) {
-      res.send(404);
+      await res.send(404);
       return;
     }
 
-    res.send(200, account.toJSON());
+    await res.send(200, account.toJSON());
   });
 
   // Create account (compat)
@@ -279,11 +279,11 @@ HTTPServer.prototype.initRouter = function initRouter() {
     account = await req.wallet.createAccount(options, passphrase);
 
     if (!account) {
-      res.send(404);
+      await res.send(404);
       return;
     }
 
-    res.send(200, account.toJSON());
+    await res.send(200, account.toJSON());
   });
 
   // Create account
@@ -306,11 +306,11 @@ HTTPServer.prototype.initRouter = function initRouter() {
     account = await req.wallet.createAccount(options, passphrase);
 
     if (!account) {
-      res.send(404);
+      await res.send(404);
       return;
     }
 
-    res.send(200, account.toJSON());
+    await res.send(200, account.toJSON());
   });
 
   // Change passphrase
@@ -320,7 +320,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     let new_ = valid.str('new');
     enforce(old || new_, 'Passphrase is required.');
     await req.wallet.setPassphrase(old, new_);
-    res.send(200, { success: true });
+    await res.send(200, { success: true });
   });
 
   // Unlock wallet
@@ -330,13 +330,13 @@ HTTPServer.prototype.initRouter = function initRouter() {
     let timeout = valid.u32('timeout');
     enforce(passphrase, 'Passphrase is required.');
     await req.wallet.unlock(passphrase, timeout);
-    res.send(200, { success: true });
+    await res.send(200, { success: true });
   });
 
   // Lock wallet
   this.post('/:id/lock', async (req, res) => {
     await req.wallet.lock();
-    res.send(200, { success: true });
+    await res.send(200, { success: true });
   });
 
   // Import key
@@ -349,19 +349,19 @@ HTTPServer.prototype.initRouter = function initRouter() {
 
     if (pub) {
       await req.wallet.importKey(acct, pub);
-      res.send(200, { success: true });
+      await res.send(200, { success: true });
       return;
     }
 
     if (priv) {
       await req.wallet.importKey(acct, priv);
-      res.send(200, { success: true });
+      await res.send(200, { success: true });
       return;
     }
 
     if (address) {
       await req.wallet.importAddress(acct, address);
-      res.send(200, { success: true });
+      await res.send(200, { success: true });
       return;
     }
 
@@ -373,7 +373,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     let valid = req.valid();
     let passphrase = valid.str('passphrase');
     let token = await req.wallet.retoken(passphrase);
-    res.send(200, { token: token.toString('hex') });
+    await res.send(200, { token: token.toString('hex') });
   });
 
   // Send TX
@@ -414,7 +414,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
 
     details = await req.wallet.getDetails(tx.hash('hex'));
 
-    res.send(200, details.toJSON());
+    await res.send(200, details.toJSON());
   });
 
   // Create TX
@@ -452,7 +452,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
 
     tx = await req.wallet.createTX(options);
     await req.wallet.sign(tx, passphrase);
-    res.send(200, tx.getJSON(this.network));
+    await res.send(200, tx.getJSON(this.network));
   });
 
   // Sign TX
@@ -468,7 +468,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
 
     await req.wallet.sign(tx, passphrase);
 
-    res.send(200, tx.getJSON(this.network));
+    await res.send(200, tx.getJSON(this.network));
   });
 
   // Zap Wallet TXs
@@ -478,7 +478,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     let age = valid.u32('age');
     enforce(age, 'Age is required.');
     await req.wallet.zap(acct, age);
-    res.send(200, { success: true });
+    await res.send(200, { success: true });
   });
 
   // Abandon Wallet TX
@@ -487,13 +487,13 @@ HTTPServer.prototype.initRouter = function initRouter() {
     let hash = valid.hash('hash');
     enforce(hash, 'Hash is required.');
     await req.wallet.abandon(hash);
-    res.send(200, { success: true });
+    await res.send(200, { success: true });
   });
 
   // List blocks
   this.get('/:id/block', async (req, res) => {
     let heights = await req.wallet.getBlocks();
-    res.send(200, heights);
+    await res.send(200, heights);
   });
 
   // Get Block Record
@@ -507,11 +507,11 @@ HTTPServer.prototype.initRouter = function initRouter() {
     block = await req.wallet.getBlock(height);
 
     if (!block) {
-      res.send(404);
+      await res.send(404);
       return;
     }
 
-    res.send(200, block.toJSON());
+    await res.send(200, block.toJSON());
   });
 
   // Add key
@@ -521,7 +521,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     let key = valid.str('accountKey');
     enforce(key, 'Key is required.');
     await req.wallet.addSharedKey(acct, key);
-    res.send(200, { success: true });
+    await res.send(200, { success: true });
   });
 
   // Remove key
@@ -531,7 +531,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     let key = valid.str('accountKey');
     enforce(key, 'Key is required.');
     await req.wallet.removeSharedKey(acct, key);
-    res.send(200, { success: true });
+    await res.send(200, { success: true });
   });
 
   // Get key by address
@@ -545,11 +545,11 @@ HTTPServer.prototype.initRouter = function initRouter() {
     key = await req.wallet.getKey(address);
 
     if (!key) {
-      res.send(404);
+      await res.send(404);
       return;
     }
 
-    res.send(200, key.toJSON());
+    await res.send(200, key.toJSON());
   });
 
   // Get private key
@@ -564,11 +564,11 @@ HTTPServer.prototype.initRouter = function initRouter() {
     key = await req.wallet.getPrivateKey(address, passphrase);
 
     if (!key) {
-      res.send(404);
+      await res.send(404);
       return;
     }
 
-    res.send(200, { privateKey: key.toSecret() });
+    await res.send(200, { privateKey: key.toSecret() });
   });
 
   // Create address
@@ -576,7 +576,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     let valid = req.valid();
     let acct = valid.str('account');
     let address = await req.wallet.createReceive(acct);
-    res.send(200, address.toJSON());
+    await res.send(200, address.toJSON());
   });
 
   // Create change address
@@ -584,7 +584,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     let valid = req.valid();
     let acct = valid.str('account');
     let address = await req.wallet.createChange(acct);
-    res.send(200, address.toJSON());
+    await res.send(200, address.toJSON());
   });
 
   // Create nested address
@@ -592,7 +592,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     let valid = req.valid();
     let acct = valid.str('account');
     let address = await req.wallet.createNested(acct);
-    res.send(200, address.toJSON());
+    await res.send(200, address.toJSON());
   });
 
   // Wallet Balance
@@ -602,11 +602,11 @@ HTTPServer.prototype.initRouter = function initRouter() {
     let balance = await req.wallet.getBalance(acct);
 
     if (!balance) {
-      res.send(404);
+      await res.send(404);
       return;
     }
 
-    res.send(200, balance.toJSON());
+    await res.send(200, balance.toJSON());
   });
 
   // Wallet UTXOs
@@ -621,7 +621,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     for (let coin of coins)
       result.push(coin.getJSON(this.network));
 
-    res.send(200, result);
+    await res.send(200, result);
   });
 
   // Locked coins
@@ -632,7 +632,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     for (let outpoint of locked)
       result.push(outpoint.toJSON());
 
-    res.send(200, result);
+    await res.send(200, result);
   });
 
   // Lock coin
@@ -678,11 +678,11 @@ HTTPServer.prototype.initRouter = function initRouter() {
     coin = await req.wallet.getCoin(hash, index);
 
     if (!coin) {
-      res.send(404);
+      await res.send(404);
       return;
     }
 
-    res.send(200, coin.getJSON(this.network));
+    await res.send(200, coin.getJSON(this.network));
   });
 
   // Wallet TXs
@@ -700,7 +700,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     for (let item of details)
       result.push(item.toJSON());
 
-    res.send(200, result);
+    await res.send(200, result);
   });
 
   // Wallet Pending TXs
@@ -718,7 +718,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     for (let item of details)
       result.push(item.toJSON());
 
-    res.send(200, result);
+    await res.send(200, result);
   });
 
   // Wallet TXs within time range
@@ -742,7 +742,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     for (let item of details)
       result.push(item.toJSON());
 
-    res.send(200, result);
+    await res.send(200, result);
   });
 
   // Last Wallet TXs
@@ -757,7 +757,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     for (let item of details)
       result.push(item.toJSON());
 
-    res.send(200, result);
+    await res.send(200, result);
   });
 
   // Wallet TX
@@ -771,19 +771,19 @@ HTTPServer.prototype.initRouter = function initRouter() {
     tx = await req.wallet.getTX(hash);
 
     if (!tx) {
-      res.send(404);
+      await res.send(404);
       return;
     }
 
     details = await req.wallet.toDetails(tx);
 
-    res.send(200, details.toJSON());
+    await res.send(200, details.toJSON());
   });
 
   // Resend
   this.post('/:id/resend', async (req, res) => {
     await req.wallet.resend();
-    res.send(200, { success: true });
+    await res.send(200, { success: true });
   });
 };
 


### PR DESCRIPTION
Both `res.write` and `res.end` only truly succeed when Callbacks are called. 

This causes problems on [error function](https://github.com/bcoin-org/bcoin/blob/17443593b2b7189f9d3918be28b0f8571433aa1a/lib/http/base.js#L1406):
 Sockets are destroyed before Data is written or ended, so if I request incorrect path or pass invalid data I end up with:
```
curl http://localhost:18332/coin/4692772a73ea834c836915089acf97f2c790380a2b8fd32f82729da72545d8c5/f
curl: (52) Empty reply from server
```

On the server you can see following errors:
```
[error] (node) index must be a number.
Error: { Error: index must be a number.
    at Validator.num (/Users/nd/Work/bcoin-org/bcoin/lib/utils/validator.js:146:11)
    at Validator.u32 (/Users/nd/Work/bcoin-org/bcoin/lib/utils/validator.js:197:20)
    at HTTPServer.get (/Users/nd/Work/bcoin-org/bcoin/lib/http/server.js:164:23)
    at Route.call (/Users/nd/Work/bcoin-org/bcoin/lib/http/base.js:1123:22)
    at HTTPServer.handleRequest (/Users/nd/Work/bcoin-org/bcoin/lib/http/base.js:150:21)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7) type: 'ValidationError', message: 'index must be a number.' }
[error] (node) This socket is closed
Error: Error: This socket is closed
    at Socket._writeGeneric (net.js:721:18)
    at Socket._write (net.js:781:8)
    at doWrite (_stream_writable.js:371:12)
    at clearBuffer (_stream_writable.js:497:7)
    at Socket.Writable.uncork (_stream_writable.js:297:7)
    at connectionCorkNT (_http_outgoing.js:695:8)
    at _combinedTickCallback (internal/process/next_tick.js:135:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```

`This socket is closed` message is coming from the error function, when the error `index must be a number` should be propagated to the user.

p.s. This happens on every error.