### PR TITLE
Fix typo in pubkey input

### DIFF
--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -2155,7 +2155,7 @@ Script.prototype.isPubkeyInput = function isPubkeyInput() {
     return false;
 
   return this.code.length === 1
-    && this.code[1].data
+    && this.code[0].data
     && common.isSignature(this.code[0].data);
 };
 


### PR DESCRIPTION
Hey there, I think this may be a typo. When only =<1 item is in the array this will throw undefined.