### PR TITLE
REST API fixes

### DIFF
--- a/lib/http/client.js
+++ b/lib/http/client.js
@@ -318,8 +318,8 @@ HTTPClient.prototype.getInfo = function getInfo() {
  * @returns {Promise} - Returns {@link Coin}[].
  */
 
-HTTPClient.prototype.getCoinsByAddress = function getCoinsByAddress(address) {
-  return this._post('/coin/address', { address });
+HTTPClient.prototype.getCoinsByAddress = function getCoinsByAddress(addresses) {
+  return this._post('/coin/address', { addresses });
 };
 
 /**
@@ -341,8 +341,8 @@ HTTPClient.prototype.getCoin = function getCoin(hash, index) {
  * @returns {Promise} - Returns {@link TX}[].
  */
 
-HTTPClient.prototype.getTXByAddress = function getTXByAddress(address) {
-  return this._post('/tx/address', { address });
+HTTPClient.prototype.getTXByAddress = function getTXByAddress(addresses) {
+  return this._post('/tx/address', { addresses });
 };
 
 /**

--- a/lib/http/client.js
+++ b/lib/http/client.js
@@ -318,7 +318,18 @@ HTTPClient.prototype.getInfo = function getInfo() {
  * @returns {Promise} - Returns {@link Coin}[].
  */
 
-HTTPClient.prototype.getCoinsByAddress = function getCoinsByAddress(addresses) {
+HTTPClient.prototype.getCoinsByAddress = function getCoinsByAddress(address) {
+  return this._get(`/coin/address/${address}`);
+};
+
+/**
+ * Get coins that pertain to addresses from the mempool or chain database.
+ * Takes into account spent coins in the mempool.
+ * @param {String[]} addresses
+ * @returns {Promise} - Returns {@link Coin}[].
+ */
+
+HTTPClient.prototype.getCoinsByAddresses = function getCoinsByAddresses(addresses) {
   return this._post('/coin/address', { addresses });
 };
 
@@ -341,7 +352,18 @@ HTTPClient.prototype.getCoin = function getCoin(hash, index) {
  * @returns {Promise} - Returns {@link TX}[].
  */
 
-HTTPClient.prototype.getTXByAddress = function getTXByAddress(addresses) {
+HTTPClient.prototype.getTXByAddress = function getTXByAddress(address) {
+  return this._get(`/tx/address/${address}`);
+};
+
+/**
+ * Retrieve transactions pertaining to
+ * addresses from the mempool or chain database.
+ * @param {String[]} addresses
+ * @returns {Promise} - Returns {@link TX}[].
+ */
+
+HTTPClient.prototype.getTXByAddresses = function getTXByAddresses(addresses) {
   return this._post('/tx/address', { addresses });
 };
 

--- a/lib/http/server.js
+++ b/lib/http/server.js
@@ -235,7 +235,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
   // Bulk read TXs
   this.post('/tx/address', async (req, res) => {
     const valid = req.valid();
-    const address = valid.array('address');
+    const address = valid.array('addresses');
 
     enforce(address, 'Address is required.');
     enforce(!this.chain.options.spv, 'Cannot get TX in SPV mode.');


### PR DESCRIPTION
Rest API for getting Coins by address(es) wasn't working.
getTxByAddress was accepting `address` on post. Changed `addresses` as in coins. (POST request on /coin/address, and /tx/address accepts multiple addresses)