### PR TITLE
pass passphrase for key import

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -434,12 +434,12 @@ CLI.prototype.backup = async function backup() {
 CLI.prototype.importKey = async function importKey() {
   const key = this.config.str(0);
   const account = this.config.str('account');
-
+  const passphrase = this.config.str('passphrase');
   if (!key)
     throw new Error('No key for import.');
 
   if (util.isBase58(key)) {
-    await this.wallet.importPrivate(account, key);
+    await this.wallet.importPrivate(account, key, passphrase);
     this.log('Imported private key.');
     return;
   }

--- a/lib/http/client.js
+++ b/lib/http/client.js
@@ -761,8 +761,8 @@ HTTPClient.prototype.removeSharedKey = function removeSharedKey(id, account, key
  * @returns {Promise}
  */
 
-HTTPClient.prototype.importPrivate = function importPrivate(id, account, key) {
-  const body = { account: account, privateKey: key };
+HTTPClient.prototype.importPrivate = function importPrivate(id, account, key, passphrase) {
+  const body = { account: account, privateKey: key, passphrase: passphrase };
   return this._post(`/wallet/${id}/import`, body);
 };
 

--- a/lib/http/wallet.js
+++ b/lib/http/wallet.js
@@ -360,8 +360,8 @@ HTTPWallet.prototype.retoken = async function retoken(passphrase) {
  * @returns {Promise}
  */
 
-HTTPWallet.prototype.importPrivate = function importPrivate(account, key) {
-  return this.client.importPrivate(this.id, account, key);
+HTTPWallet.prototype.importPrivate = function importPrivate(account, key, passphrase='') {
+  return this.client.importPrivate(this.id, account, key, passphrase);
 };
 
 /**

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -337,6 +337,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
   this.post('/:id/import', async (req, res) => {
     const valid = req.valid();
     const acct = valid.str('account');
+    const passphrase = valid.str('passphrase');
     const pub = valid.buf('publicKey');
     const priv = valid.str('privateKey');
     const b58 = valid.str('address');
@@ -350,7 +351,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
 
     if (priv) {
       const key = KeyRing.fromSecret(priv, this.network);
-      await req.wallet.importKey(acct, key);
+      await req.wallet.importKey(acct, key, passphrase);
       res.send(200, { success: true });
       return;
     }


### PR DESCRIPTION
If a wallet was protected by a passphrase, the server would throw a 500 error and log "No Passphrase" even if one was passed via CLI. This passes it if it is passed as argument.