### PR TITLE
RPC: Create/Sign Raw Transaction fix

### DIFF
--- a/lib/http/rpc.js
+++ b/lib/http/rpc.js
@@ -1644,7 +1644,7 @@ RPC.prototype.createRawTransaction = async function createRawTransaction(args, h
   if (locktime != null)
     tx.locktime = locktime;
 
-  for (const obj of tx.inputs) {
+  for (const obj of inputs) {
     const valid = new Validator([obj]);
     const hash = valid.hash('txid');
     const index = valid.u32('vout');

--- a/lib/http/rpc.js
+++ b/lib/http/rpc.js
@@ -1833,7 +1833,7 @@ RPC.prototype.signRawTransaction = async function signRawTransaction(args, help)
     for (const prev of prevout) {
       const valid = new Validator([prev]);
       const hash = valid.hash('txid');
-      const index = valid.u32('index');
+      const index = valid.u32('vout');
       const scriptRaw = valid.buf('scriptPubKey');
       const value = valid.ufixed('amount', 8);
       const redeemRaw = valid.buf('redeemScript');


### PR DESCRIPTION
Sign raw transaction should accept `vout` instead of `index`. 