### PR TITLE
Fix the JSON representation of MasterKey when unencrypted.

### DIFF
--- a/lib/wallet/masterkey.js
+++ b/lib/wallet/masterkey.js
@@ -648,7 +648,7 @@ MasterKey.fromKey = function fromKey(key, mnemonic) {
  */
 
 MasterKey.prototype.toJSON = function toJSON(unsafe) {
-  if (this.encrypted) {
+  if (!this.key) {
     return {
       encrypted: true,
       until: this.until,


### PR DESCRIPTION
I came across this bug while building out a [ruby client](https://github.com/DanKnox-BitFS/bcoin-client) for the bcoin wallet API which uses the HTTP interface. I assume the behavior is different via the WebSocket API.

After creating a wallet with a passphrase, unlocking the wallet did not allow me to retrieve the decrypted master key and mnemonic. What I found was that the `_lock` and `_unlock` functions in `masterkey.js` were not setting `this.encrypted` to `false` or `true` respectively. When I updated those functions to properly set `this.encrypted`, it broke a few tests for `wallet.js`. I haven't had time to figure out wether or not the tests themselves are checking for incorrect functionality or if this is indicative of a larger issue with the logic.

My solution for now was to change the JSON representation for MasterKey to check for the existence of a decrypted `this.key` in memory instead of relying on the `this.encrypted` attribute to indicate state. This does feel a bit hackish but it is the path of least resistance right now which fixes this show stopping bug in relation to the HTTP API. Without this fix I am unable to retrieve the mnemonic and key.

I would be happy to apply a larger patch and update the tests though this is all I have time for now. Please let me know if I missed something.