### PR TITLE
pass the passphrase to retoken

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -392,7 +392,8 @@ CLI.prototype.getWalletBlock = async function getWalletBlock() {
 };
 
 CLI.prototype.retoken = async function retoken() {
-  const result = await this.wallet.retoken();
+  const passphrase = this.config.str('passphrase');
+  const result = await this.wallet.retoken(passphrase);
   this.log(result);
 };
 


### PR DESCRIPTION
retoken wouldn't work for wallets that require a passphrase. Just needed to pass in the passphrase config from the CLI