### PR TITLE
Validator: str

### DIFF
--- a/lib/utils/validator.js
+++ b/lib/utils/validator.js
@@ -128,8 +128,12 @@ Validator.prototype.str = function str(key, fallback) {
   if (value === null)
     return fallback;
 
-  if (typeof value !== 'string')
-    throw new ValidationError(key, 'number');
+  if (typeof value !== 'string') {
+    if (typeof value.toString === 'function')
+      return value.toString();
+
+    throw new ValidationError(key, 'string');
+  }
 
   return value;
 };


### PR DESCRIPTION
Validator for string, doesn't try to convert to string (when int for example tries to).

Also error message was `number`.