### PR TITLE
pass options on keyring creation

### DIFF
--- a/lib/primitives/keyring.js
+++ b/lib/primitives/keyring.js
@@ -63,6 +63,16 @@ KeyRing.prototype.fromOptions = function fromOptions(options, network) {
 
   let key = toKey(options);
 
+  if (options.witness != null) {
+    assert(typeof options.witness === 'boolean');
+    this.witness = options.witness;
+  }
+
+  if (options.nested != null) {
+    assert(typeof options.nested === 'boolean');
+    this.nested = options.nested;
+  }
+
   if (Buffer.isBuffer(key))
     return this.fromKey(key, network);
 
@@ -73,16 +83,6 @@ KeyRing.prototype.fromOptions = function fromOptions(options, network) {
 
   if (options.privateKey)
     key = toKey(options.privateKey);
-
-  if (options.witness != null) {
-    assert(typeof options.witness === 'boolean');
-    this.witness = options.witness;
-  }
-
-  if (options.nested != null) {
-    assert(typeof options.nested === 'boolean');
-    this.nested = options.nested;
-  }
 
   const script = options.script;
   const compress = options.compressed;


### PR DESCRIPTION
I was trying to create a multisig keyring outside of the walletdb and was losing the `witness` option. The options in `fromOptions` would get lost if the key was a buffer since it would return before the options were set. 