### PR TITLE
rpc: fix verifytxoutproof

### DIFF
--- a/lib/http/rpc.js
+++ b/lib/http/rpc.js
@@ -935,7 +935,7 @@ RPC.prototype.verifyTXOutProof = async function verifyTXOutProof(args, help) {
   const out = [];
 
   for (const hash of tree.matches)
-    out.push(util.revHex(hash));
+    out.push(util.revHex(hash.toString('hex')));
 
   return out;
 };


### PR DESCRIPTION
`tree.matches` contains Buffers instead of hex strings, we need to return hexes. (also `revHex` accepts only string)