### PR TITLE
Add TX size to tx.prototype.getJSON

### DIFF
--- a/lib/primitives/tx.js
+++ b/lib/primitives/tx.js
@@ -2164,6 +2164,7 @@ TX.prototype.getJSON = function getJSON(network, view, entry, index) {
   return {
     hash: this.txid(),
     witnessHash: this.wtxid(),
+    size: this.toRaw().length,
     fee: fee,
     rate: rate,
     mtime: util.now(),


### PR DESCRIPTION
Adds the size of the transaction to the getJSON method on the transaction primitive.