### PR TITLE
client: use 'new' passphrase param

### DIFF
--- a/lib/http/client.js
+++ b/lib/http/client.js
@@ -673,7 +673,7 @@ HTTPClient.prototype.retoken = async function retoken(id, passphrase) {
  */
 
 HTTPClient.prototype.setPassphrase = function setPassphrase(id, old, new_) {
-  const body = { old: old, passphrase: new_ };
+  const body = { old: old, new: new_ };
   return this._post(`/wallet/${id}/passphrase`, body);
 };
 


### PR DESCRIPTION
The rpc endpoint `/wallet/:id/passphrase` expects the new passphrase to be named `new` rather than `passphrase`.