### PR TITLE
More consistent behavior around setting passphrase on unencrypted wallet

### DIFF
--- a/lib/http/client.js
+++ b/lib/http/client.js
@@ -673,7 +673,7 @@ HTTPClient.prototype.retoken = async function retoken(id, passphrase) {
  */
 
 HTTPClient.prototype.setPassphrase = function setPassphrase(id, old, new_) {
-  const body = { old: old, passphrase: new_ };
+  const body = { old: old, new: new_ };
   return this._post(`/wallet/${id}/passphrase`, body);
 };
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -366,15 +366,10 @@ Wallet.prototype._removeSharedKey = async function _removeSharedKey(acct, key) {
  */
 
 Wallet.prototype.setPassphrase = async function setPassphrase(old, new_) {
-  if (new_ == null) {
-    new_ = old;
-    old = null;
-  }
-
-  if (old != null)
+  if (old)
     await this.decrypt(old);
 
-  if (new_ != null)
+  if (new_)
     await this.encrypt(new_);
 };
 


### PR DESCRIPTION
implement tux's fix for changing property name and more consistent behavior around setting passphrase on unencrypted wallet. 

Fixes #284 
Implements #300 by @tuxcanfly 