### PR TITLE
remove outputs from function signature

### DIFF
--- a/lib/http/wallet.js
+++ b/lib/http/wallet.js
@@ -248,7 +248,7 @@ HTTPWallet.prototype.zap = function zap(account, age) {
  * @see Wallet#createTX
  */
 
-HTTPWallet.prototype.createTX = function createTX(options, outputs) {
+HTTPWallet.prototype.createTX = function createTX(options) {
   return this.client.createTX(this.id, options);
 };
 

--- a/lib/http/wallet.js
+++ b/lib/http/wallet.js
@@ -249,7 +249,7 @@ HTTPWallet.prototype.zap = function zap(account, age) {
  */
 
 HTTPWallet.prototype.createTX = function createTX(options, outputs) {
-  return this.client.createTX(this.id, options, outputs);
+  return this.client.createTX(this.id, options);
 };
 
 /**


### PR DESCRIPTION
Since outputs are expected to be in the options argument