### PR TITLE
typo

### DIFF
--- a/lib/crypto/secp256k1.js
+++ b/lib/crypto/secp256k1.js
@@ -10,7 +10,7 @@ let native;
 
 if (Number(process.env.BCOIN_NO_SECP256K1) !== 1) {
   try {
-    native = require('secp256k1/bindings');
+    native = require('secp256k1');
   } catch (e) {
     ;
   }


### PR DESCRIPTION
so because of a typo, the native-node version of Secp256k1 was never in use