### PR TITLE
Adding confirmations property to block and tx getJSON

### DIFF
--- a/lib/http/server.js
+++ b/lib/http/server.js
@@ -279,8 +279,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
     }
 
     const height = await this.chain.getHeight(hash);
-    const confirmations = this.chain.height - height;
-
+  
     res.send(200, block.getJSON(this.network, view, height, confirmations));
   });
 

--- a/lib/http/server.js
+++ b/lib/http/server.js
@@ -210,7 +210,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
 
     const view = await this.node.getMetaView(meta);
 
-    res.send(200, meta.getJSON(this.network, view));
+    res.send(200, meta.getJSON(this.network, view, this.chain.height));
   });
 
   // TX by address
@@ -226,7 +226,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
 
     for (const meta of metas) {
       const view = await this.node.getMetaView(meta);
-      result.push(meta.getJSON(this.network, view));
+      result.push(meta.getJSON(this.network, view, this.chain.height));
     }
 
     res.send(200, result);
@@ -245,7 +245,7 @@ HTTPServer.prototype.initRouter = function initRouter() {
 
     for (const meta of metas) {
       const view = await this.node.getMetaView(meta);
-      result.push(meta.getJSON(this.network, view));
+      result.push(meta.getJSON(this.network, view, this.chain.height));
     }
 
     res.send(200, result);

--- a/lib/http/server.js
+++ b/lib/http/server.js
@@ -279,8 +279,9 @@ HTTPServer.prototype.initRouter = function initRouter() {
     }
 
     const height = await this.chain.getHeight(hash);
+    const confirmations = this.chain.height - height;
 
-    res.send(200, block.getJSON(this.network, view, height));
+    res.send(200, block.getJSON(this.network, view, height, confirmations));
   });
 
   // Mempool snapshot

--- a/lib/primitives/block.js
+++ b/lib/primitives/block.js
@@ -575,11 +575,12 @@ Block.prototype.toJSON = function toJSON() {
  * @returns {Object}
  */
 
-Block.prototype.getJSON = function getJSON(network, view, height) {
+Block.prototype.getJSON = function getJSON(network, view, height, confirmations) {
   network = Network.get(network);
   return {
     hash: this.rhash(),
     height: height,
+    confirmations: confirmations,
     version: this.version,
     prevBlock: util.revHex(this.prevBlock),
     merkleRoot: util.revHex(this.merkleRoot),

--- a/lib/primitives/txmeta.js
+++ b/lib/primitives/txmeta.js
@@ -157,8 +157,10 @@ TXMeta.prototype.getJSON = function getJSON(network, view, chainheight) {
   json.height = this.height;
   json.block = this.block ? util.revHex(this.block) : null;
   json.time = this.time;
-  if (chainheight)
-    json.confirmations = chainheight - this.height;
+  if (this.block === null)
+    json.confirmations = 0;
+  else
+    json.confirmations = chainheight - this.height + 1;
   return json;
 };
 

--- a/lib/primitives/txmeta.js
+++ b/lib/primitives/txmeta.js
@@ -151,12 +151,14 @@ TXMeta.prototype.toJSON = function toJSON() {
  * @returns {Object}
  */
 
-TXMeta.prototype.getJSON = function getJSON(network, view) {
+TXMeta.prototype.getJSON = function getJSON(network, view, chainheight) {
   const json = this.tx.getJSON(network, view, null, this.index);
   json.mtime = this.mtime;
   json.height = this.height;
   json.block = this.block ? util.revHex(this.block) : null;
   json.time = this.time;
+  if (chainheight)
+    json.confirmations = chainheight - this.height;
   return json;
 };
 


### PR DESCRIPTION
Adds a `confirmations` property to the JSON returned by `cli tx [hash]` and `cli block [hash/height]` as
well as the REST `/tx/:hash` and `/block/:block` calls by subtracting TX/block height from chain height.

I'm new to this codebase but I tried to implement this as cleanly and sensibly as I could. It passed all mocha tests as well as some manual testing with regtest.

This addresses issue #320.