### PR TITLE
Fix bcoin.http.Client errors

### DIFF
--- a/lib/http/client.js
+++ b/lib/http/client.js
@@ -225,9 +225,6 @@ HTTPClient.prototype._request = async function _request(method, endpoint, json) 
   if (res.statusCode === 401)
     throw new Error('Unauthorized (bad API key).');
 
-  if (res.statusCode !== 200)
-    throw new Error(`Status code: ${res.statusCode}.`);
-
   if (res.type !== 'json')
     throw new Error('Bad response (wrong content-type).');
 
@@ -241,6 +238,9 @@ HTTPClient.prototype._request = async function _request(method, endpoint, json) 
 
   if (res.body.error)
     throw new Error(res.body.error.message);
+
+  if (res.statusCode !== 200)
+    throw new Error(`Status code: ${res.statusCode}.`);
 
   return res.body;
 };

--- a/lib/http/client.js
+++ b/lib/http/client.js
@@ -231,16 +231,16 @@ HTTPClient.prototype._request = async function _request(method, endpoint, json) 
   if (!res.body)
     throw new Error('Bad response (no body).');
 
-  const network = res.headers['x-bcoin-network'];
-
-  if (network && network !== this.network.type)
-    throw new Error('Bad response (wrong network).');
-
   if (res.body.error)
     throw new Error(res.body.error.message);
 
   if (res.statusCode !== 200)
     throw new Error(`Status code: ${res.statusCode}.`);
+
+  const network = res.headers['x-bcoin-network'];
+
+  if (network && network !== this.network.type)
+    throw new Error('Bad response (wrong network).');
 
   return res.body;
 };

--- a/lib/http/rpcclient.js
+++ b/lib/http/rpcclient.js
@@ -62,9 +62,6 @@ RPCClient.prototype.execute = async function execute(method, params) {
   if (res.statusCode === 401)
     throw new RPCError('Unauthorized (bad API key).', -1);
 
-  if (res.statusCode !== 200)
-    throw new Error(`Status code: ${res.statusCode}.`);
-
   if (res.type !== 'json')
     throw new Error('Bad response (wrong content-type).');
 
@@ -73,6 +70,9 @@ RPCClient.prototype.execute = async function execute(method, params) {
 
   if (res.body.error)
     throw new RPCError(res.body.error.message, res.body.error.code);
+
+  if (res.statusCode !== 200)
+    throw new Error(`Status code: ${res.statusCode}.`);
 
   return res.body.result;
 };


### PR DESCRIPTION
When you receive error from the API, you would always see `Status Code: Number`.
If `body.error` is present, we should return it first and only after that check status code.