### PR TITLE
Allow --watch without accountKey value for cli createWallet

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -58,7 +58,8 @@ CLI.prototype.createWallet = async function createWallet() {
 
   if (this.config.has('watch')) {
     options.watchOnly = true;
-    options.accountKey = this.config.str('watch');
+    if (this.config.str('watch') != 'true')
+      options.accountKey = this.config.str('watch');
   }
 
   const wallet = await this.client.createWallet(options);

--- a/bin/cli
+++ b/bin/cli
@@ -52,15 +52,9 @@ CLI.prototype.createWallet = async function createWallet() {
     n: this.config.uint('n'),
     witness: this.config.bool('witness'),
     passphrase: this.config.str('passphrase'),
-    watchOnly: false,
-    accountKey: null
+    watchOnly: this.config.has('key') ? true : this.config.bool('watch'),
+    accountKey: this.config.str('key')
   };
-
-  if (this.config.has('watch')) {
-    options.watchOnly = true;
-    if (this.config.str('watch') != 'true')
-      options.accountKey = this.config.str('watch');
-  }
 
   const wallet = await this.client.createWallet(options);
 
@@ -127,7 +121,7 @@ CLI.prototype.createAccount = async function createAccount() {
     m: this.config.uint('m'),
     n: this.config.uint('n'),
     witness: this.config.bool('witness'),
-    accountKey: this.config.str('watch')
+    accountKey: this.config.str('key')
   };
 
   const account = await this.wallet.createAccount(name, options);


### PR DESCRIPTION
Fixes a bug with `cli wallet create` where if no value is specified for the `--watch` option, the `accountKey` is assigned a value of `"true"` which is invalid and causes errors downstream. This fix leaves `accountKey` as `null`, and the resulting functionality appears to match wallet creation via HTTP request where `watchOnly` is true and `accountKey` is not given a value.

This addresses #285.