### PR TITLE
(bug-fix) httpWallet getMaster encrypted #335 resolution

### DIFF
--- a/lib/wallet/masterkey.js
+++ b/lib/wallet/masterkey.js
@@ -32,7 +32,7 @@ function MasterKey(options) {
   if (!(this instanceof MasterKey))
     return new MasterKey(options);
 
-  this.encrypted = false;
+  this.encrypted = true;
   this.iv = null;
   this.ciphertext = null;
   this.key = null;


### PR DESCRIPTION
line 34 had set encrypted to false: this would not encrypt the mastekey, I changed to encrypt = true