### PR TITLE
Fix webpack config incompatibility with uglify-js

### DIFF
--- a/webpack.browser.js
+++ b/webpack.browser.js
@@ -28,8 +28,10 @@ module.exports = {
         str(env.BCOIN_WORKER_FILE || '/bcoin-worker.js')
     }),
     new UglifyJsPlugin({
-      compress: {
-        warnings: true
+      uglifyOptions: {
+        compress: {
+          warnings: true
+        }
       }
     })
   ]

--- a/webpack.compat.js
+++ b/webpack.compat.js
@@ -35,8 +35,10 @@ module.exports = {
         str(env.BCOIN_WORKER_FILE || '/bcoin-worker.js')
     }),
     new UglifyJsPlugin({
-      compress: {
-        warnings: false
+      uglifyOptions: {
+        compress: {
+          warnings: true
+        }
       }
     })
   ]

--- a/webpack.node.js
+++ b/webpack.node.js
@@ -41,8 +41,10 @@ module.exports = {
     }),
     new webpack.IgnorePlugin(/^utf-8-validate|bufferutil$/),
     new UglifyJsPlugin({
-      compress: {
-        warnings: true
+      uglifyOptions: {
+        compress: {
+          warnings: true
+        }
       }
     })
   ]


### PR DESCRIPTION

This patch fixes the following error:

```
bcoin/node_modules/schema-utils/dist/validateOptions.js:40
    throw new _ValidationError2.default(ajv.errors, name);
```

when running

```Shell
npm run webpack
```