### PR TITLE
if pool doesn't have a mempool, allow tx inv processing during sync

### DIFF
--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -1747,7 +1747,7 @@ Pool.prototype.handleBlockInv = async function handleBlockInv(peer, hashes) {
 Pool.prototype.handleTXInv = async function handleTXInv(peer, hashes) {
   assert(hashes.length > 0);
 
-  if (this.syncing && !this.chain.synced)
+  if (this.mempool && this.syncing && !this.chain.synced)
     return;
 
   this.ensureTX(peer, hashes);


### PR DESCRIPTION
For an SPV node which doesn't have a mempool, it seems acceptable to allow processing of incoming unconfirmed transactions and have them added to the wallet db during chain sync.

This allows user of the SPV wallet to be able to immediately starting funding and spending from the wallet before a full spvchain sync is completed.

Does this change make the spvnode/wallet any less secure or more susceptible to well known risks of SPV in general?