### PR TITLE
Fix browser build, add browser resolution path to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "webpack": "^3.5.4"
   },
   "main": "./lib/bcoin.js",
+  "browser": "./browser/bcoin.js",
   "bin": {
     "bcoin": "./bin/bcoin",
     "bcoin-cli": "./bin/cli",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "level-js": "^2.2.4",
     "mocha": "^3.5.0",
     "node-loader": "^0.6.0",
-    "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+    "uglifyjs-webpack-plugin": "^1.0.1",
     "webpack": "^3.5.4"
   },
   "main": "./lib/bcoin.js",

--- a/webpack.browser.js
+++ b/webpack.browser.js
@@ -28,8 +28,10 @@ module.exports = {
         str(env.BCOIN_WORKER_FILE || '/bcoin-worker.js')
     }),
     new UglifyJsPlugin({
-      compress: {
-        warnings: true
+      uglifyOptions: {
+        compress: {
+          warnings: true
+        }
       }
     })
   ]

--- a/webpack.compat.js
+++ b/webpack.compat.js
@@ -35,8 +35,10 @@ module.exports = {
         str(env.BCOIN_WORKER_FILE || '/bcoin-worker.js')
     }),
     new UglifyJsPlugin({
-      compress: {
-        warnings: false
+      uglifyOptions: {
+        compress: {
+          warnings: false
+        }
       }
     })
   ]

--- a/webpack.node.js
+++ b/webpack.node.js
@@ -41,8 +41,10 @@ module.exports = {
     }),
     new webpack.IgnorePlugin(/^utf-8-validate|bufferutil$/),
     new UglifyJsPlugin({
-      compress: {
-        warnings: true
+      uglifyOptions: {
+        compress: {
+          warnings: true
+        }
       }
     })
   ]


### PR DESCRIPTION
`UglifyJsPlugin`'s `compress` option must be inside the `uglifyOptions` object.

Also, for other module/build systems (e.g. Typescript, Webpack, Rollup, Browserify, JSPM) to resolve the browser build properly, the `browser` field must be set in `package.json`.