### PR TITLE
pool: --only - disable dns seed discover

### DIFF
--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -462,7 +462,7 @@ class Pool extends EventEmitter {
    */
 
   async discoverSeeds(checkPeers) {
-    if (!this.discover)
+    if (!this.options.discover)
       return;
 
     if (this.hosts.dnsSeeds.length === 0)

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -462,6 +462,9 @@ class Pool extends EventEmitter {
    */
 
   async discoverSeeds(checkPeers) {
+    if (!this.discover)
+      return;
+
     if (this.hosts.dnsSeeds.length === 0)
       return;
 
@@ -3548,6 +3551,7 @@ class PoolOptions {
     this.services = common.LOCAL_SERVICES;
     this.requiredServices = common.REQUIRED_SERVICES;
     this.memory = true;
+    this.discover = true;
 
     this.fromOptions(options);
   }
@@ -3735,7 +3739,13 @@ class PoolOptions {
       if (options.only.length > 0) {
         this.nodes = options.only;
         this.maxOutbound = options.only.length;
+        this.discover = false;
       }
+    }
+
+    if (options.discover != null) {
+      assert(typeof options.discover === 'boolean');
+      this.discover = options.discover;
     }
 
     if (options.invTimeout != null) {


### PR DESCRIPTION
As mentioned in #288 DNS discovery can be disabled when passing `--only`

The referenced issue also mentions `--nodes` when number of `--max-outbound` matches but I think that's an overkill. For instance, `btcd` disables DNS seeds only on `--connect`, not `--addpeer`.