### PR TITLE
pool: skip gateway, ip discovery if required

### DIFF
--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -293,8 +293,11 @@ Pool.prototype._connect = async function _connect() {
   await this.hosts.open();
   await this.authdb.open();
 
-  await this.discoverGateway();
-  await this.discoverExternal();
+  if (this.options.listen && !this.options.selfish) {
+    await this.discoverGateway();
+    await this.discoverExternal();
+  }
+
   await this.discoverSeeds();
 
   this.fillOutbound();


### PR DESCRIPTION
As mentioned in #288 gateway, ip discovery is not really required when operating in selfish mode or if not listening.