### PR TITLE
script: use tx.checksig

### DIFF
--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -23,7 +23,6 @@ const ScriptError = require('./scripterror');
 const ScriptNum = require('./scriptnum');
 const common = require('./common');
 const encoding = require('../utils/encoding');
-const secp256k1 = require('../crypto/secp256k1');
 const Address = require('../primitives/address');
 const opcodes = common.opcodes;
 const scriptTypes = common.types;
@@ -1166,13 +1165,14 @@ Script.prototype.execute = function execute(stack, flags, tx, index, value, vers
         validateSignature(sig, flags);
         validateKey(key, flags, version);
 
-        let res = false;
-
-        if (sig.length > 0) {
-          const type = sig[sig.length - 1];
-          const hash = tx.signatureHash(index, subscript, value, type, version);
-          res = checksig(hash, sig, key);
-        }
+        const res = tx.checksig(
+          index,
+          subscript,
+          value,
+          sig,
+          key,
+          version
+        );
 
         if (!res && (flags & Script.flags.VERIFY_NULLFAIL)) {
           if (sig.length !== 0)
@@ -1248,20 +1248,18 @@ Script.prototype.execute = function execute(stack, flags, tx, index, value, vers
           validateSignature(sig, flags);
           validateKey(key, flags, version);
 
-          if (sig.length > 0) {
-            const type = sig[sig.length - 1];
-            const hash = tx.signatureHash(
-              index,
-              subscript,
-              value,
-              type,
-              version
-            );
+          const checksig = tx.checksig(
+            index,
+            subscript,
+            value,
+            sig,
+            key,
+            version
+          );
 
-            if (checksig(hash, sig, key)) {
-              isig += 1;
-              m -= 1;
-            }
+          if (checksig) {
+            isig += 1;
+            m -= 1;
           }
 
           ikey += 1;
@@ -3586,18 +3584,6 @@ function validateSignature(sig, flags) {
   }
 
   return true;
-}
-
-/**
- * Verify a signature, taking into account sighash type.
- * @param {Buffer} msg - Signature hash.
- * @param {Buffer} sig
- * @param {Buffer} key
- * @returns {Boolean}
- */
-
-function checksig(msg, sig, key) {
-  return secp256k1.verify(msg, sig.slice(0, -1), key);
 }
 
 /*


### PR DESCRIPTION
I noticed that tx.checksig wasn't used anywhere, so I checked the signature checks and found it could be used in Script instead of local `checksig`, signature checks require tx info so, I thought it makes sense..

Is there any reason not to use `tx.checksig` ?

@chjj