### PR TITLE
Set this.size in Bloom.prototype.fromReader()

### DIFF
--- a/lib/utils/bloom.js
+++ b/lib/utils/bloom.js
@@ -336,6 +336,7 @@ Bloom.prototype.toRaw = function toRaw() {
 Bloom.prototype.fromReader = function fromReader(br) {
   this.filter = br.readVarBytes();
   this.n = br.readU32();
+  this.size = this.filter.length * 8;
   this.tweak = br.readU32();
   this.update = br.readU8();
   assert(Bloom.flagsByVal[this.update] != null, 'Unknown update flag.');

--- a/test/bloom-test.js
+++ b/test/bloom-test.js
@@ -180,4 +180,29 @@ describe('Bloom', function() {
 
     assert(!filter.test('foobar 49', 'ascii'));
   });
+
+  // Regression test for missing filter.size setting
+  // in Bloom.prototype.fromReader
+  it('should serialize and inject properties from ' +
+          'serialized data correctly', () => {
+    // Hardcoded sample data for filter
+    const size = 32;
+    const filter = Buffer.from('deadbeef', 'hex');
+    const n = 9;
+    const tweak = 172012938;
+    const update = Bloom.flags.NONE;
+
+    const fooBloom = new Bloom(size, n, tweak, update);
+    fooBloom.filter = filter;
+    const serialized = fooBloom.toRaw();
+    const barBloom = Bloom.fromRaw(serialized);
+
+    for (let i = 0; i < fooBloom.filter.length; i++) {
+      assert.strictEqual(barBloom.filter[i], filter[i]);
+    }
+    assert.strictEqual(barBloom.size, 32);
+    assert.strictEqual(barBloom.n, 9);
+    assert.strictEqual(barBloom.tweak, 172012938);
+    assert.strictEqual(barBloom.update, Bloom.flags.NONE);
+  });
 });


### PR DESCRIPTION
For a Bloom object 'bloom' to function correctly, 'size' key must be equal to bloom.filter.length * 8. It is now properly set. Without this fix, a full node with SPV server responsibilities would fail to obtain the correct filter from 'filterload' packets.