### PR TITLE
http: disable cors if no-auth

### DIFF
--- a/lib/http/server.js
+++ b/lib/http/server.js
@@ -86,9 +86,8 @@ HTTPServer.prototype.init = function init() {
  */
 
 HTTPServer.prototype.initRouter = function initRouter() {
-  this.use(this.cors());
-
   if (!this.options.noAuth) {
+    this.use(this.cors());
     this.use(this.basicAuth({
       password: this.options.apiKey,
       realm: 'node'

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -93,9 +93,8 @@ HTTPServer.prototype.init = function init() {
  */
 
 HTTPServer.prototype.initRouter = function initRouter() {
-  this.use(this.cors());
-
   if (!this.options.noAuth) {
+    this.use(this.cors());
     this.use(this.basicAuth({
       password: this.options.apiKey,
       realm: 'wallet'


### PR DESCRIPTION
This PR disables cross origin requests to the JSON-RPC server if no `api-key` is set.