### PR TITLE
docs: replace unsupported option with supported

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -18,7 +18,7 @@ Will create a datadir of `~/.bcoin_spv`, containing a chain database, wallet dat
 ## Common Options
 
 - `config`: Points to a custom config file, not in the prefix directory.
-- `network`: Which network's chainparams to use for the node (main, testnet, regtest, or segnet4) (default: main).
+- `network`: Which network's chainparams to use for the node (main, testnet, regtest, or simnet) (default: main).
 - `workers`: Whether to use a worker process pool for transaction verification (default: true).
 - `workers-size`: Number of worker processes to spawn for transaction verification. By default, the worker pool will be sized based on the number of CPUs/cores in the machine.
 - `workers-timeout`: Worker process execution timeout in milliseconds (default: 120000).


### PR DESCRIPTION
There is a mismatch between the docs and what is in the code. Trying to start bcoin with `--network segnet4` results in an error.  Looking at the code here

- https://github.com/bcoin-org/bcoin/blob/v1.0.0-beta.15/lib/protocol/networks.js#L25

it shows 4 network types, `['main', 'testnet', 'regtest', 'simnet']`

This pull request reflects that in the documentation