### PR TITLE
wallet: allow configurable wallet port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,8 +72,8 @@ installed with the `bclient` package in npm.
 ### Wallet API Changes
 
 The main wallet API changes have to do with changes in the structure of the
-HTTP server itself. The bcoin wallet HTTP server will now always listen on it's
-own port. Standard ports are:
+HTTP server itself. The bcoin wallet HTTP server will now listen on it's own
+port. Standard ports are:
 
 ```
 main: 8334
@@ -81,6 +81,8 @@ testnet: 18334
 regtest: 48334
 simnet: 18558
 ```
+
+`wallet-port` option can be used to configure listening on a different port.
 
 The default account object is no longer present on the wallet. To retrieve it,
 request `/wallet/:id/account/default` instead. More minor changes to the JSON

--- a/etc/sample.conf
+++ b/etc/sample.conf
@@ -118,6 +118,7 @@ api-key: bikeshed
 # Wallet
 #
 
+# wallet-port: 8334
 wallet-witness: false
 wallet-checkpoints: true
 wallet-auth: false

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -142,6 +142,7 @@ class FullNode extends Node {
       certFile: this.config.path('ssl-cert'),
       host: this.config.str('http-host'),
       port: this.config.uint('http-port'),
+      walletPort: this.config.uint('wallet-port'),
       apiKey: this.config.str('api-key'),
       noAuth: this.config.bool('no-auth')
     });

--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -745,6 +745,12 @@ class HTTPOptions {
       this.port = options.port;
     }
 
+    if (options.walletPort != null) {
+      assert((options.walletPort & 0xffff) === options.walletPort,
+        'Wallet port must be a number.');
+      this.walletPort = options.walletPort;
+    }
+
     if (options.ssl != null) {
       assert(typeof options.ssl === 'boolean');
       this.ssl = options.ssl;

--- a/lib/node/spvnode.js
+++ b/lib/node/spvnode.js
@@ -90,6 +90,7 @@ class SPVNode extends Node {
       certFile: this.config.path('ssl-cert'),
       host: this.config.str('http-host'),
       port: this.config.uint('http-port'),
+      walletPort: this.config.uint('wallet-port'),
       apiKey: this.config.str('api-key'),
       noAuth: this.config.bool('no-auth')
     });

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1064,6 +1064,10 @@ class HTTPOptions {
     this.logger = options.node.logger;
     this.port = this.network.walletPort;
 
+    if (options.walletPort != null) {
+      this.port = options.walletPort;
+    }
+
     if (options.logger != null) {
       assert(typeof options.logger === 'object');
       this.logger = options.logger;

--- a/lib/wallet/node.js
+++ b/lib/wallet/node.js
@@ -66,6 +66,7 @@ class WalletNode extends Node {
       certFile: this.config.path('ssl-cert'),
       host: this.config.str('http-host'),
       port: this.config.uint('http-port'),
+      walletPort: this.config.uint('wallet-port'),
       apiKey: this.config.str('api-key'),
       walletAuth: this.config.bool('wallet-auth'),
       noAuth: this.config.bool('no-auth'),

--- a/lib/wallet/plugin.js
+++ b/lib/wallet/plugin.js
@@ -67,6 +67,8 @@ class Plugin extends EventEmitter {
       certFile: this.config.path('ssl-cert'),
       host: this.config.str('http-host'),
       port: this.config.uint('http-port'),
+      walletPort: this.config.uint('wallet-port',
+        node.config.uint('wallet-port')),
       apiKey: this.config.str('api-key', node.config.str('api-key')),
       walletAuth: this.config.bool('wallet-auth'),
       noAuth: this.config.bool('no-auth'),


### PR DESCRIPTION
This PR allows `wallet-port` to be a configurable similar to other server ports.