### PR TITLE
Fix full node sendTX() bug and omission

### DIFF
--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -317,7 +317,7 @@ class FullNode extends Node {
     // We need to announce by hand if
     // we're running in selfish mode.
     if (this.pool.options.selfish)
-      this.pool.broadcast(tx);
+      this.broadcast(tx);
   }
 
   /**

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -289,6 +289,7 @@ class FullNode extends Node {
   /**
    * Add transaction to mempool, broadcast.
    * @param {TX} tx
+   * @returns {Promise}
    */
 
   async sendTX(tx) {


### PR DESCRIPTION
This PR correctly handles errors thrown by `broadcast()` in case a selfish node uses `sendTX()` and documents the return type of `sendTX()` (which is a `Promise`).