### PR TITLE
Correct scriptVector() return value to {Stack}

### DIFF
--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -559,7 +559,7 @@ class MTX extends TX {
    * based on a previous script.
    * @param {Script} prev
    * @param {Buffer} ring
-   * @return {Boolean}
+   * @return {Stack}
    */
 
   scriptVector(prev, ring) {


### PR DESCRIPTION
The previously documented return value was {Boolean}, which remained by accident from when the function returned a success code: https://github.com/bcoin-org/bcoin/blob/9d90704b83763c05ce17afae3f940544b8c7ba0f/lib/primitives/mtx.js#L562