### PR TITLE
Add browser field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "webpack": "^3.5.4"
   },
   "main": "./lib/bcoin.js",
+  "browser": "./lib/bcoin-browser.js",
   "bin": {
     "bcoin": "./bin/bcoin",
     "bcoin-cli": "./bin/cli",


### PR DESCRIPTION
This field is a standard used by both [webpack](https://webpack.js.org/configuration/resolve/#resolve-mainfields) and [browserify](https://github.com/browserify/browserify-handbook#browser-field). It simplifies building webapps with bcoin significantly easier, and there's no real overhead. With this field, webpack will automatically bundle the native version for node and the browser version for the web, and I believe browserify exhibits similar behavior.