### PR TITLE
txdb: fix getAccountBalance - do not count spent credits

### DIFF
--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -2454,17 +2454,14 @@ TXDB.prototype.getWalletBalance = async function getWalletBalance() {
  */
 
 TXDB.prototype.getAccountBalance = async function getAccountBalance(account) {
-  const credits = await this.getAccountCredits(account);
+  const coins = await this.getAccountCoins(account);
   const balance = new Balance(this.wallet.wid, this.wallet.id, account);
 
-  for (const credit of credits) {
-    const coin = credit.coin;
-
+  for (const coin of coins) {
     if (coin.height !== -1)
       balance.confirmed += coin.value;
 
-    if (!credit.spent)
-      balance.unconfirmed += coin.value;
+    balance.unconfirmed += coin.value;
   }
 
   return balance;


### PR DESCRIPTION
getAccountBalance() computes confirmed balance by summing up all the credits without taking into account if they credit was spent. This PR fixes the routine by only iterating over coins (unspent credits)