### PR TITLE
Remove watchOnly check from wallet fund

### DIFF
--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1101,9 +1101,6 @@ class Wallet extends EventEmitter {
     if (!options)
       options = {};
 
-    if (this.watchOnly)
-      throw new Error('Cannot fund from watch-only wallet.');
-
     const acct = options.account || 0;
     const change = await this.changeAddress(acct);
 


### PR DESCRIPTION
I don't see reason to block watchOnly wallets from funding transactions, there's another check in Sign which will throw error when signing.

So this PR removes watchOnly check in `wallet.fund/_fund`

`bmultisig` watchonly wallets or hardware wallets won't be able to fund/coinSelect transaction without this.

@chjj 