### PR TITLE
account: fix create methods

### DIFF
--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -321,29 +321,29 @@ class Account {
 
   /**
    * Create a new receiving address (increments receiveDepth).
-   * @returns {WalletKey}
+   * @returns {Promise} - Returns {@link WalletKey}
    */
 
-  createReceive() {
-    return this.createKey(0);
+  createReceive(b) {
+    return this.createKey(b, 0);
   }
 
   /**
    * Create a new change address (increments receiveDepth).
-   * @returns {WalletKey}
+   * @returns {Promise} - Returns {@link WalletKey}
    */
 
-  createChange() {
-    return this.createKey(1);
+  createChange(b) {
+    return this.createKey(b, 1);
   }
 
   /**
    * Create a new change address (increments receiveDepth).
-   * @returns {WalletKey}
+   * @returns {Promise} - Returns {@link WalletKey}
    */
 
-  createNested() {
-    return this.createKey(2);
+  createNested(b) {
+    return this.createKey(b, 2);
   }
 
   /**


### PR DESCRIPTION
Accounts create methods can't use `createKey` without passing `Batch`.

I would like to leave methods for increasing depth without database update, but then you need to keep track of last updates, so on next `createKey` you can save all other keys as well. So decided to just fix it with this for now.