### PR TITLE
address: fromScript reject unknown progam version

### DIFF
--- a/lib/primitives/address.js
+++ b/lib/primitives/address.js
@@ -437,7 +437,7 @@ class Address {
 
     const program = script.getProgram();
 
-    if (program && !program.isMalformed()) {
+    if (program && !program.isUnknown()) {
       this.hash = program.data;
       this.type = Address.types.WITNESS;
       this.version = program.version;

--- a/test/address-test.js
+++ b/test/address-test.js
@@ -78,6 +78,17 @@ describe('Address', function() {
     assert.strictEqual(addr.toString('main'), expectedAddr);
   });
 
+  it('should not find address in testnet OP_1 script', () => {
+    const raw = Buffer.from(''
+      + '51280fcf24999d398c39224d239c89098a841a58'
+      + 'd5f4443b0c0faf7a8ccf676d73986c2435abb52e'
+      + '5b98', 'hex'
+    );
+    const script = Script.fromRaw(raw);
+    const addr = Address.fromScript(script);
+    assert.strictEqual(addr, null);
+  });
+
   it('should match testnet p2sh address', () => {
     const raw = 'c579342c2c4c9220205e2cdc285617040c924a0a';
     const p2sh = Buffer.from(raw, 'hex');


### PR DESCRIPTION
On testnet, tx with hash: `35d493412e379a562a87d1c883e0613d58c84239ac53e791bbe2edc0851fde75`
is incorrectly interpreted as a witness commitment because of similar structure (`OP_1`, `<42 byte data) etc leading to an error during address indexing.

This PR fixes the issue by making test for program more strict by  rejecting unknown program version from being considered as witness program.