### PR TITLE
Allow optional signing in createTX

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -465,6 +465,7 @@ class HTTP extends Server {
       const valid = Validator.fromRequest(req);
       const passphrase = valid.str('passphrase');
       const outputs = valid.array('outputs', []);
+      const sign = valid.bool('sign', true);
 
       const options = {
         rate: valid.u64('rate'),
@@ -499,7 +500,8 @@ class HTTP extends Server {
 
       const tx = await req.wallet.createTX(options);
 
-      await req.wallet.sign(tx, passphrase);
+      if (sign)
+        await req.wallet.sign(tx, passphrase);
 
       res.json(200, tx.getJSON(this.network));
     });


### PR DESCRIPTION
HTTP Endpoint for creating transaction is also signing the transaction.
We have another endpoint /sign which can be used for signing.

* Makes tx sign optional /wallet/:id/create (true by default for backwards compatibility)