### PR TITLE
walletdb: avoid duplicate rescan

### DIFF
--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -131,6 +131,8 @@ class WalletDB extends EventEmitter {
     });
 
     this.client.bind('block connect', async (entry, txs) => {
+      if (this.rescanning)
+        return;
       try {
         await this.addBlock(entry, txs);
       } catch (e) {
@@ -139,6 +141,8 @@ class WalletDB extends EventEmitter {
     });
 
     this.client.bind('block disconnect', async (entry) => {
+      if (this.rescanning)
+        return;
       try {
         await this.removeBlock(entry);
       } catch (e) {


### PR DESCRIPTION
If a lengthy rescan is already in progress, and a new block arrives, it would probably trigger a avoidable duplicate rescan.

```
    } else if (tip.height !== this.state.height + 1) {
      await this.scan(this.state.height);
      return 0;
    }
```

The ideal solution would be to somehow wait until the previous resync is actually finished (i.e. all event handlers are done), but this should do in the meanwhile.