### PR TITLE
fix SPV mode

### DIFF
--- a/bin/spvnode
+++ b/bin/spvnode
@@ -8,7 +8,7 @@ const assert = require('assert');
 const SPVNode = require('../lib/node/spvnode');
 const Outpoint = require('../lib/primitives/outpoint');
 
-const node = SPVNode({
+const node = new SPVNode({
   config: true,
   argv: true,
   env: true,

--- a/bin/spvnode
+++ b/bin/spvnode
@@ -16,6 +16,7 @@ const node = new SPVNode({
   logConsole: true,
   logLevel: 'debug',
   db: 'leveldb',
+  memory: false,
   persistent: true,
   workers: true,
   listen: true,


### PR DESCRIPTION
fixes fatal error trying to start with `bcoin --spv`

```
$ bcoin --spv
/home/ec2-user/bcoin/bin/spvnode:11
const node = SPVNode({
             ^

TypeError: Class constructor SPVNode cannot be invoked without 'new'
    at Object.<anonymous> (/home/ec2-user/bcoin/bin/spvnode:11:14)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)
    at startup (bootstrap_node.js:188:16)
    at bootstrap_node.js:609:3
```