### PR TITLE
Invalid address: report all errors, don't try to detect invalid base58 vs invalid bech32

### DIFF
--- a/lib/primitives/address.js
+++ b/lib/primitives/address.js
@@ -244,14 +244,15 @@ class Address {
     assert(addr.length > 0);
     assert(addr.length <= 100);
 
-    // If the address is mixed case,
-    // it can only ever be base58.
-    if (isMixedCase(addr))
-      return this.fromBase58(addr, network);
-
-    // Otherwise, it's most likely bech32.
-    // if it's not a valid bech32, this will throw
-    return this.fromBech32(addr, network);
+  try{
+    return this.fromBase58(addr, network);
+  } catch(e1) {
+      try{
+        return this.fromBech32(addr, network);
+      } catch(e2) {
+          throw new Error('Invalid address:\n' + e1 + '\n' + e2);
+        }
+      }
   }
 
   /**

--- a/lib/primitives/address.js
+++ b/lib/primitives/address.js
@@ -250,11 +250,8 @@ class Address {
       return this.fromBase58(addr, network);
 
     // Otherwise, it's most likely bech32.
-    try {
-      return this.fromBech32(addr, network);
-    } catch (e) {
-      return this.fromBase58(addr, network);
-    }
+    // if it's not a valid bech32, this will throw
+    return this.fromBech32(addr, network);
   }
 
   /**


### PR DESCRIPTION
I discovered starting bcoin with `--coinbase-address` in regtest mode with an invalid bech32 address would result in a misleading error:
```
$ bcoin --coinbase-address=rb1qal4ym23xqm8egfj26nwmk88z8w2c90le66w3y --prune
/home/ec2-user/bcoin/node_modules/bstring/lib/base58-browser.js:113
      throw new Error('Non-base58 character.');
      ^

Error: Non-base58 character.
...
...
```
This PR (for now) doesn't try to decide if a user entered an invalid bech32 address or an invalid base58 address. It just reports Invalid address and (for now) reports the errors from both functions, why not? It's better at least than entering a bad bech32 address and getting a base58 error. New behavior is like this:

**Invalid bech32 address:**
```
$ bwallet-cli send rb1qmajutxea8x995dnrlt6dqf0msddtu8p29pae2 0.1
Error: Invalid address:
Error: Non-base58 character.
Error: Invalid bech32 checksum.
    at WalletClient.request (/home/ec2-user/node-v8.11.1-linux-x64/lib/node_modules/bclient/node_modules/bcurl/lib/client.js:203:19)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```
**Invalid base58 address:**
```
$ bwallet-cli send RLt4qdtNjDR6k7yQy1seE91sAB4JKZyer 0.1
Error: Invalid address:
Error: Network mismatch for base58 address.
Error: Invalid bech32 character.
    at WalletClient.request (/home/ec2-user/node-v8.11.1-linux-x64/lib/node_modules/bclient/node_modules/bcurl/lib/client.js:203:19)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```
**Correct bech32 address:**
```
$ bwallet-cli send rb1qmajutxea8x995dnrlt6dqf0msddtu8p29pae2x 0.1
{
  "hash": "55bd2f891dc7c9f0998d9eed8f371e9039f6726c088b2841bbec98c011dd2eb4",
...
```
**Correct base58 address:**
```
$ bwallet-cli send RLt4qdtNjDR6k7yQy1seE91sAB4JKZyerJ 0.1
{
  "hash": "1ad977b04d8f7aa5a31fb39f8a7d80d61a2744f0556b48ff07fcb791d85eb9af",
...
```