### PR TITLE
Apply External Signature to Transaction

### DIFF
--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -715,6 +715,95 @@ class MTX extends TX {
 
     return true;
   }
+  
+  
+/**
+* Add a Signature.
+* @param {Number} index - Index of input being signed.
+* @param {Coin|Output} coin
+* @param {Buffer} sig
+* @param {KeyRing} ring
+* @returns {Boolean} Whether the input was able to be signed.
+*/
+
+addSig(index, coin, sig, ring) {
+  const input = this.inputs[index];
+  assert(input, 'Input does not exist.');
+  assert(coin, 'No coin passed.');
+  assert(sig, 'No signature passed.');
+
+  // Get the previous output's script
+  const value = coin.value;
+  let prev = coin.script;
+  let vector = input.script;
+  let version = 0;
+  let redeem = false;
+
+  // Grab regular p2sh redeem script.
+  if (prev.isScripthash()) {
+    prev = input.script.getRedeem();
+    if (!prev)
+      throw new Error('Input has not been templated.');
+    redeem = true;
+  }
+
+  // If the output script is a witness program,
+  // we have to switch the vector to the witness
+  // and potentially alter the length. Note that
+  // witnesses are stack items, so the `dummy`
+  // _has_ to be an empty buffer (what OP_0
+  // pushes onto the stack).
+  if (prev.isWitnessScripthash()) {
+    prev = input.witness.getRedeem();
+    if (!prev)
+      throw new Error('Input has not been templated.');
+    vector = input.witness;
+    redeem = true;
+    version = 1;
+  } else {
+    const wpkh = prev.getWitnessPubkeyhash();
+    if (wpkh) {
+      prev = Script.fromPubkeyhash(wpkh);
+      vector = input.witness;
+      redeem = false;
+      version = 1;
+    }
+  }
+
+  if (redeem) {
+    const stack = vector.toStack();
+    const redeem = stack.pop();
+
+    const result = this.signVector(prev, stack, sig, ring);
+
+    if (!result)
+      return false;
+
+    result.push(redeem);
+
+    vector.fromStack(result);
+
+    if (!this.checksig(index, prev, value, sig, ring.publicKey, version)) {
+      throw new Error('Invalid signature');
+    }
+
+    return true;
+  }
+
+  const stack = vector.toStack();
+  const result = this.signVector(prev, stack, sig, ring);
+
+  if (!result)
+    return false;
+
+  vector.fromStack(result);
+
+  if (!this.checksig(index, prev, value, sig, ring.publicKey, version)) {
+    throw new Error('Invalid signature');
+  }
+
+  return true;
+}
 
   /**
    * Add a signature to a vector


### PR DESCRIPTION
This PR introduces the ability to apply signatures generated elsewhere to a bcoin transaction. This functionality is similar to Bitcore's applySignature() method. See: https://bitcore.io/api/lib/transaction#Transaction+applySignature.

Here, the `addSig()` method augments existing signing functionality by applying signatures to a transaction when they're passed in from external sources. This is particularly needed for multisig transactions where signers are separated geographically, as well as in scenarios where hardware devices sign a transaction and output a raw signature. 

I've structured the method to closely follow the logic of `signInput()`. The biggest difference is this method doesn't create a signature. Rather, a signature is passed to it. Additionally, there are calls to `checkSig()` which serve to verify and associate the signature with the correct public key. The latter is helpful for tracking which m of n keys have already signed. 

Usage Example:

`addSig()` accepts a signature and makes it fairly trivial to find the corresponding public key. 

Simply loop over a multisig transaction's public keys:

1. For each pubic key, generate a `keyring` from it
2. Call `addSig()` passing the signature and that keyring to it
3. If the signature is valid for the given public key, `addSig()` returns true.
4. Otherwise, continue the loop to test the next public key