### PR TITLE
expose xpubkey in request for wallet/master

### DIFF
--- a/lib/hd/private.js
+++ b/lib/hd/private.js
@@ -680,7 +680,8 @@ class HDPrivateKey {
 
   toJSON(network) {
     return {
-      xprivkey: this.xprivkey(network)
+      xprivkey: this.xprivkey(network),
+      xpubkey: this.xpubkey(network)
     };
   }
 


### PR DESCRIPTION
I think this is useful for users who want to "watch" their wallet from another client. But also, in testing RPC calls to create a wallet from an xpubkey (http://bcoin.io/api-docs/?shell--cli#create-a-wallet), I was in regtest mode and couldn't find a way to produce a regtest xpub key!