### PR TITLE
Test port configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ browser/bcoin*
 package-lock.json
 npm-debug.log
 coverage/
+*~

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -3566,7 +3566,6 @@ class PoolOptions {
 
     this.port = this.network.port;
     this.seeds = this.network.seeds;
-    this.port = this.network.port;
     this.publicPort = this.network.port;
 
     if (options.logger != null) {

--- a/test/pool-test.js
+++ b/test/pool-test.js
@@ -1,0 +1,34 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('./util/assert');
+const Network = require('../lib/protocol/network');
+const Pool = require('../lib/net/pool');
+
+describe('Pool', function() {
+  it('should listen on configured port', () => {
+    const chain = {
+      network: Network.primary,
+      options: {
+        checkpoints: true
+      },
+      on: (x) => {}
+    };
+
+    const logger = {
+      context: (x) => {}
+    };
+
+    const pool = new Pool({
+      network: Network.primary,
+      chain: chain,
+      host: '127.0.0.1',
+      port: 8080,
+      logger: logger
+    });
+
+    assert(pool.options.port === 8080);
+  });
+});


### PR DESCRIPTION
Debugging issues with port configuration, setting `bcoin.conf` port doesn't appear to being recognized with an error given startup, even though this isn't the port in the configuration file.

This ended up being confusion around which ports are being opened at startup, there are three ports opened by default, one for the peer-to-peer network, another for the http server, and another for the wallet. The conflicting port was for the wallet port and was resolved by using a `wallet.conf` file to set the port number.

It may be worthwhile to have the http server and wallet not enabled by default, and run minimally the bitcoin p2p port.