### PR TITLE
fix malleability check in mempool

### DIFF
--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -1021,7 +1021,7 @@ class Mempool extends EventEmitter {
 
       // If it succeeded, segwit may be causing the
       // failure. Try with segwit but without cleanstack.
-      flags |= Script.flags.VERIFY_CLEANSTACK;
+      flags |= Script.flags.VERIFY_WITNESS;
 
       // Cleanstack was causing the failure.
       if (await this.verifyResult(tx, view, flags))


### PR DESCRIPTION
Checks in verify in this block are related to `witness` malleability.
Discussion: https://github.com/bitcoin/bitcoin/issues/8279

> // SCRIPT_VERIFY_CLEANSTACK requires SCRIPT_VERIFY_WITNESS, so we
> // need to turn both off, and compare against just turning off CLEANSTACK
> // to see if the failure is specifically due to witness validation.
> -- Bitcoin Core reference https://github.com/bitcoin/bitcoin/blob/5039e4b61beb937bad33ac4300cc784642782589/src/validation.cpp#L906

Summary of the issue:
  We may have received witness transaction from old node (without witness) or even with malleated witness, but we don't want to reject those transactions in the mempool. But we still want to detect non standard transactions, that are non-witness.

In case of witness transaction, `verifyResult` will fail because there is no witness. But if there's no error with VERIFY_WITNESS, it means we have CLEANSTACK issue and transaction is not standard one.

Without this check, it would not reject non-standard P2SH from the mempool reject cache.