### PR TITLE
WIP: Adding methods for sweeping wallet funds

### DIFF
--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1341,6 +1341,50 @@ class MTX extends TX {
   }
 
   /**
+   * Select and add coins to fill the transaction
+   * and set the output value to the total value minus fee
+   * @param {Coin[]} coins - list of coins to fill with
+   * @param {Object?} options - fill options
+   * @param {(Amount)?} options.threshold - highest coin value
+   * in satoshis that should be included in sweep
+   * @param {(Rate)?} options.rate - rate to pay for tx fee
+   * @returns {MTX} mtx - returns a filled mtx
+   */
+   async fill(coins, options) {
+    assert(coins.length, 'Must pass in coins to fill');
+    assert(options, 'Options are required');
+    assert(this.outputs.length, 'Must have at least 1 output');
+
+    // must set option to fill for coin selection
+    if (!options.fill)
+      options.fill = true;
+    // unless otherwise set, we want to sort and selct coins by value
+    // fill will automatically sort from lowest to highest value
+    if (!options.select)
+      options.select = 'value';
+
+    // Select necessary coins.
+    const select = await this.selectCoins(coins, options);
+
+    // Add coins to transaction.
+    for (const coin of select.chosen)
+      this.addCoin(coin);
+
+    // Naive implentation for output and fees-
+    // Send all swept coins to first output set on mtx.
+    // Later can add more sophisticated sweeping to
+    // multiple addresses and subtractFee support
+    this.outputs[0].value = this.getInputValue() - select.fee;
+    assert(
+      !this.outputs[0].getDustThreshold(),
+      'Output is dust. Not enough coins to fill tx.'
+    );
+    assert.strictEqual(this.getFee(), select.fee);
+
+    return select;
+   }
+
+  /**
    * Sort inputs and outputs according to BIP69.
    * @see https://github.com/bitcoin/bips/blob/master/bip-0069.mediawiki
    */
@@ -1581,6 +1625,8 @@ class CoinSelector {
     this.chosen = [];
     this.change = 0;
     this.fee = CoinSelector.MIN_FEE;
+    this.fill = false;
+    this.threshold = 0;
 
     this.selection = 'value';
     this.subtractFee = false;
@@ -1647,6 +1693,17 @@ class CoinSelector {
       assert(Number.isSafeInteger(options.depth));
       assert(options.depth >= -1);
       this.depth = options.depth;
+    }
+
+    if (options.fill != null) {
+      assert(typeof options.fill === 'boolean', 'fill must be boolean');
+      this.fill = options.fill;
+    }
+
+    if (options.threshold != null) {
+      assert(Number.isSafeInteger(options.threshold));
+      assert(options.threshold >= -1);
+      this.threshold = options.threshold;
     }
 
     if (options.hardFee != null) {
@@ -1825,7 +1882,16 @@ class CoinSelector {
   async select(coins) {
     this.init(coins);
 
-    if (this.hardFee !== -1) {
+    if (this.fill) {
+      // if sorting by value, reverse
+      // so smallest value is first
+      if (this.selection === 'value')
+        this.coins.reverse();
+      // select coins to fill tx with
+      // This is potentially asynchronous
+      // because it uses the size estimator
+      await this.selectFill();
+    } else if (this.hardFee !== -1) {
       this.selectHard();
     } else {
       // This is potentially asynchronous:
@@ -1848,6 +1914,45 @@ class CoinSelector {
     this.change = this.tx.getInputValue() - this.total();
 
     return this;
+  }
+
+  /**
+   * Fill a tx with inputs
+   * @returns {void}
+   */
+  async selectFill() {
+    // output to send coin values to
+    // naively doing just first output
+    const output = this.tx.outputs[0];
+
+    while(this.index < this.coins.length) {
+      const coin = this.coins[this.index++];
+      if (!this.isSpendable(coin))
+        continue;
+
+      // if the value of the coin is larger than target threshold
+      // and output isn't dust, we can stop filling
+      if (
+        coin.value >= this.threshold &&
+        output.value > this.fee + output.getDustThreshold()
+      )
+        break;
+
+      this.tx.addCoin(coin);
+      const size = await this.tx.estimateSize(this.estimate);
+
+      // check if new coin makes tx too large
+      // if it is then we have all of our coins
+      if (size > policy.MAX_TX_WEIGHT)
+        break;
+
+      // otherwise, add new coin to chosen
+      this.chosen.push(coin);
+
+      // send value of all inputs to first output minus the fee
+      this.fee = this.getFee(size);
+      output.value = this.tx.getInputValue() - this.fee;
+    }
   }
 
   /**

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1359,7 +1359,7 @@ class MTX extends TX {
     if (!options.fill)
       options.fill = true;
     // unless otherwise set, we want to sort and selct coins by value
-    // fill will automatically sort from lowest to highest value
+    // fill will automatically sort from lowest to highest
     if (!options.select)
       options.select = 'value';
 
@@ -1375,8 +1375,9 @@ class MTX extends TX {
     // Later can add more sophisticated sweeping to
     // multiple addresses and subtractFee support
     this.outputs[0].value = this.getInputValue() - select.fee;
+    const dustThreshold = this.outputs[0].getDustThreshold();
     assert(
-      !this.outputs[0].getDustThreshold(),
+      this.outputs[0].value > dustThreshold,
       'Output is dust. Not enough coins to fill tx.'
     );
     assert.strictEqual(this.getFee(), select.fee);
@@ -1881,7 +1882,6 @@ class CoinSelector {
 
   async select(coins) {
     this.init(coins);
-
     if (this.fill) {
       // if sorting by value, reverse
       // so smallest value is first
@@ -1933,6 +1933,7 @@ class CoinSelector {
       // if the value of the coin is larger than target threshold
       // and output isn't dust, we can stop filling
       if (
+        this.threshold &&
         coin.value >= this.threshold &&
         output.value > this.fee + output.getDustThreshold()
       )
@@ -1951,7 +1952,12 @@ class CoinSelector {
 
       // send value of all inputs to first output minus the fee
       this.fee = this.getFee(size);
-      output.value = this.tx.getInputValue() - this.fee;
+
+      output.value = this.tx.getInputValue();
+
+      // only start subtracting the fee if we have enough coins
+      if (output.value > this.fee)
+        output.value = output.value - this.fee;
     }
   }
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1061,7 +1061,7 @@ class Wallet extends EventEmitter {
    * Fill a transaction with inputs, estimate
    * transaction size, calculate fee, and add a change output.
    * @see MTX#selectCoins
-   * @see MTX#fill
+   * @see MTX#fund
    * @param {MTX} mtx - _Must_ be a mutable transaction.
    * @param {Object?} options
    * @param {(String|Number)?} options.account - If no account is
@@ -1340,6 +1340,80 @@ class Wallet extends EventEmitter {
     await this.wdb.send(tx);
 
     return tx;
+  }
+
+  /**
+   * Consolidate UTXOs from a wallet by sending largest
+   * tx possible until no more coins left or Coin value
+   * threshold has been reached
+   * @param {Object} options - See {@link Wallet#fill options}.
+   * @param {(Integer)?}  options.accountIndex - accountIndex to
+   * generate addresses from
+   * @param {String|Buffer} passphrase for wallet
+   * @returns {Promise[]} - Returns array of {@link TX}
+   */
+  async sweep(options, passphrase) {
+    const mtxs = [];
+    let coins = await this.getCoins(options.account);
+    // while there are still available coins
+    while(coins.length) {
+      // create blank mtx
+      const mtx = new MTX();
+      // pick random address from options.addresses or generate new one
+      const addressCount = options.addresses.length;
+      let address;
+      if (addressCount) {
+        const index =
+          Math.floor(Math.random() * (addressCount + 1));
+        address = options.addresses[index];
+      } else {
+        address = this.createReceive(options.accountIndex);
+      }
+      // create new output to address with zero value
+      const output = new Output({address, value: 0});
+      mtx.addOutput(output);
+      // pass mtx and options to fill
+      mtx.fill(options);
+
+      // TODO:
+      // sort, set locktime, template mtx
+      // add to mtxs array
+      // run some verifications
+
+      const tx = mtx.toTX();
+      // lock the tx coins so we can use the rest
+      // to continue sweeping
+      this.txdb.lockTX(tx);
+      // set coins list to only unlocked coins
+      coins = this.txdb.filterLocked(coins);
+    }
+
+    const txs = mtxs.map(async (mtx) => {
+      await this.sign(mtx, passphrase);
+
+      if (!mtx.isSigned())
+        throw new Error('TX could not be fully signed.');
+
+      const tx = mtx.toTX();
+
+      // Policy sanity checks.
+      if (tx.getSigopsCost(mtx.view) > policy.MAX_TX_SIGOPS_COST)
+        throw new Error('TX exceeds policy sigops.');
+
+      if (tx.getWeight() > policy.MAX_TX_WEIGHT)
+        throw new Error('TX exceeds policy weight.');
+
+      await this.wdb.addTX(tx);
+
+      this.logger.debug('Sending wallet tx (%s): %s', this.id, tx.txid());
+
+      await this.wdb.send(tx);
+
+      return tx;
+    });
+
+    // TODO: Send/broadcast txs
+    return txs;
   }
 
   /**

--- a/test/mtx-test.js
+++ b/test/mtx-test.js
@@ -2,21 +2,148 @@
 /* eslint prefer-arrow-callback: "off" */
 
 'use strict';
+const assert = require('assert');
 
+const { Outpoint, Coin } = require('../lib/primitives');
+const { WalletKey } = require('../lib/wallet');
+const Script = require('../lib/script/script');
 const { MTX, Selector } = require('../lib/primitives/mtx');
+const { policy } = require('../lib/protocol');
 
-describe('MTX', () => {
-  it('should fill with coins', () => {
+const compressed = true;
+const network = 'main';
 
-  });
+const alice = WalletKey.generate(compressed, network);
 
-  it('shouldn\'t fill if not enough coins', () => {
+function dummyCoins(num = 1000, value = 500) {
+  let count = 0;
+  const coins = [];
 
-  });
-});
+  while(count < num) {
+    const cb = new MTX();
+    cb.addInput({
+      prevout: new Outpoint(),
+      Script: new Script(),
+      sequence: 0xffffffff
+    });
+    // dust output to alice
+    cb.addOutput({
+      address: alice.getAddress('string', network),
+      value
+    });
+    coins.push(Coin.fromTX(cb, 0, 0));
+    count++;
+  }
+  return coins;
+}
 
 describe('CoinSelector', () => {
-  it('should select fill coins', () => {
+  it('should select fill coins', async () => {
+    const mtx = new MTX();
 
+    mtx.addOutput({ value: 0, address: alice.getAddress('string', network)});
+
+    let coins = dummyCoins();
+    const selector = new Selector(mtx, {
+      fill: true,
+      select: 'value',
+      rate: 500
+    });
+
+    let selected = await selector.select(coins);
+    assert(selected.chosen.length, 'No coins were selected');
+
+    // try and provide number of coins that would
+    // push the weight over the limit
+    while (selected.chosen.length === coins.length) {
+      const newCoins = dummyCoins();
+      coins = coins.concat(newCoins);
+      selected = await selector.select(coins);
+    }
+
+    assert(
+      selected.chosen.length !== coins.length,
+      `Selector should stop selecting once coins cause weight
+       to surpass policy limit`
+    );
+    const size = await selector.tx.estimateSize();
+    assert(
+      size > policy.MAX_TX_WEIGHT,
+      `Selector's tx size should have exceeded weight limit
+       as indication that tx is filled`
+    );
+  });
+
+  it('should only select fill coins up to value threshold', async () => {
+    const threshold = 5000;
+    const coinsAtThreshold = 5;
+
+    const mtx = new MTX();
+    mtx.addOutput({ value: 0, address: alice.getAddress('string', network)});
+
+    let coins = dummyCoins();
+    // add some coins at the threshold
+    coins = coins.concat(dummyCoins(coinsAtThreshold, threshold));
+
+    const selector = new Selector(mtx, {
+      fill: true,
+      select: 'value',
+      rate: 500,
+      threshold
+    });
+
+    const selected = await selector.select(coins);
+    assert(
+      coins.length - selected.chosen.length === coinsAtThreshold,
+      'Coins w/ value at threshold should not be selected'
+    );
   });
 });
+
+describe('MTX', () => {
+  it('should fill with coins', async () => {
+    const mtx = new MTX();
+
+    mtx.addOutput({ value: 5000, address: alice.getAddress('string', network)});
+
+    const smallCoin = { count: 1000, value: 500 };
+    const largeCoin = { count: 4000, value: 1000 };
+
+    let coins = dummyCoins(smallCoin.count, smallCoin.value);
+    const largerCoins = dummyCoins(largeCoin.count, largeCoin.value);
+    // use coins with larger value to test prioritization
+    coins = coins.concat(largerCoins);
+    await mtx.fill(coins, {
+      rate: 500,
+      changeAddress: alice.getAddress('string', network)
+    });
+
+    assert(mtx.inputs.length, 'mtx did not fill with coins');
+    assert(
+      coins.length > mtx.inputs.length,
+      'MTX filled with too many coins'
+    );
+
+    const size = await mtx.estimateSize();
+    assert(
+      size <= policy.MAX_TX_WEIGHT,
+      'Filled mtx should not exceed policy weight'
+    );
+
+    assert(
+      mtx.inputs.length > smallCoin.count,
+      'mtx didn\'t fill with all the smaller value coins'
+    );
+    let counter = 0;
+
+    while (counter < smallCoin.count) {
+      const prevout = mtx.view.getOutput(mtx.inputs[counter].prevout);
+      assert(
+        prevout.value === smallCoin.value,
+        'fill should prioritize small coins'
+      );
+      counter++;
+    }
+  });
+});
+

--- a/test/mtx-test.js
+++ b/test/mtx-test.js
@@ -1,0 +1,22 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const { MTX, Selector } = require('../lib/primitives/mtx');
+
+describe('MTX', () => {
+  it('should fill with coins', () => {
+
+  });
+
+  it('shouldn\'t fill if not enough coins', () => {
+
+  });
+});
+
+describe('CoinSelector', () => {
+  it('should select fill coins', () => {
+
+  });
+});


### PR DESCRIPTION
- [x] mtx fill method
- [x] mtx coin selector for fill coins
- [ ] sweep method in the wallet for sweeping all UTXOS

`MTX.fill` works mostly like `fund` and takes the same options except that instead of filling with coins to reach the total output level (plus fee), it keeps adding coins until there are no more coins, the coin with the lowest value is higher than the threshold (optional), or the tx size has reached `policy.MAX_TX_WEIGHT`. 

For the naive implementation, we are only expecting one output for `fill` and will increase it by the value of each new coin added to it (and then subtract the fee based on the new size). `Wallet.sweep` will have the option of passing it an array of addresses that can be used to sweep to (similar to a normal `send`). As a default one will be generated from the wallet. Possible later to support more than one output and split the value and fee evenly.

MTX `fill` and the `CoinSelector` both support a threshold option where you can indicate what the maximum coin value you want to fill with (could help with privacy if you don't want to sweep _all_ coins).