### PR TITLE
pass sort option through http

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -427,6 +427,7 @@ class HTTP extends Server {
         selection: valid.str('selection'),
         smart: valid.bool('smart'),
         account: valid.str('account'),
+        sort: valid.bool('sort'),
         subtractFee: valid.bool('subtractFee'),
         subtractIndex: valid.i32('subtractIndex'),
         depth: valid.u32(['confirmations', 'depth']),


### PR DESCRIPTION
For OP_RETURN applications (like Publish Data plugin for bPanel) need to be able to pass `sort:false` to http wallet to maintain the order. 