### PR TITLE
path: remove redundant accountID from path string

### DIFF
--- a/lib/wallet/path.js
+++ b/lib/wallet/path.js
@@ -265,7 +265,7 @@ class Path {
     if (this.keyType !== Path.types.HD)
       return null;
 
-    return `m/${this.account}'/${this.branch}/${this.index}`;
+    return `m/${this.branch}/${this.index}`;
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/bcoin-org/bcoin/issues/484

~~However, as discussed with @nodar-chkuaselidze in slack, because this string gets written to the db  this would break consistency with all keys saved before the change and possibly require a db migration.~~

This needs testing because it affects the API output, and may break downstream applications.