### PR TITLE
Fix typos and JSDoc return type

### DIFF
--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -4203,7 +4203,6 @@ class BroadcastItem extends EventEmitter {
 
   /**
    * Add a job to be executed on ack, timeout, or reject.
-   * @returns {Promise}
    */
 
   addJob(resolve, reject) {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -815,7 +815,7 @@ class Wallet extends EventEmitter {
    * Create a new address (increments depth) without a lock.
    * @private
    * @param {(Number|String)?} acct
-   * @param {Number} branche
+   * @param {Number} branch
    * @returns {Promise} - Returns {@link WalletKey}.
    */
 
@@ -2022,7 +2022,7 @@ class Wallet extends EventEmitter {
       if (this.txdb.isLocked(coin))
         continue;
 
-      // Always used confirmed coins.
+      // Always use confirmed coins.
       if (coin.height !== -1) {
         coins.push(coin);
         continue;


### PR DESCRIPTION
Fix two typos in comments in `lib/wallet/wallet.js` and a wrong JSDoc return type in `lib/net/pool.js`.