### PR TITLE
pkg: update bcrypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "bcfg": "~0.1.0",
     "bclient": "~0.1.0",
-    "bcrypto": "~0.3.1",
+    "bcrypto": "0.3.2",
     "bdb": "~0.2.0",
     "bdns": "~0.1.0",
     "bevent": "~0.1.0",


### PR DESCRIPTION
Refs #500 

There are API incompatibilites with latest bcrypto i.e. `bcrypto@0.3.7`. Updated `package.json` to strictly use `0.3.2` for now.