### PR TITLE
test: increase timeout for ci

### DIFF
--- a/test/chain-test.js
+++ b/test/chain-test.js
@@ -111,7 +111,7 @@ chain.on('disconnect', (entry, block) => {
 });
 
 describe('Chain', function() {
-  this.timeout(45000);
+  this.timeout(60000);
 
   it('should open chain and miner', async () => {
     await chain.open();

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -103,6 +103,7 @@ describe('Node', function() {
   });
 
   it('should mine competing chains', async () => {
+    this.timeout(20000);
     for (let i = 0; i < 10; i++) {
       const block1 = await mineBlock(tip1, cb1);
       cb1 = block1.txs[0];


### PR DESCRIPTION
This PR fixes an issue with CircleCI tests failing because of insufficient timeouts.