### PR TITLE
Wallet RPC: bug fixes for several commands' argument parsing and errors

### DIFF
--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -745,7 +745,7 @@ class RPC extends RPCBase {
   }
 
   async importWallet(args, help) {
-    if (help || args.length > 2)
+    if (help || args.length < 1 || args.length > 2)
       throw new RPCError(errs.MISC_ERROR, 'importwallet "filename" ( rescan )');
 
     const wallet = this.wallet;
@@ -1571,9 +1571,9 @@ class RPC extends RPCBase {
   }
 
   async importPrunedFunds(args, help) {
-    if (help || args.length < 2 || args.length > 3) {
+    if (help || args.length !== 2) {
       throw new RPCError(errs.MISC_ERROR,
-        'importprunedfunds "rawtransaction" "txoutproof" ( "label" )');
+        'importprunedfunds "rawtransaction" "txoutproof"');
     }
 
     const valid = new Validator(args);

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -834,7 +834,7 @@ class RPC extends RPCBase {
   }
 
   async importPubkey(args, help) {
-    if (help || args.length < 1 || args.length > 4) {
+    if (help || args.length < 1 || args.length > 3) {
       throw new RPCError(errs.MISC_ERROR,
         'importpubkey "pubkey" ( "label" rescan )');
     }

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -1605,7 +1605,7 @@ class RPC extends RPCBase {
     };
 
     if (!await this.wdb.addTX(tx, entry))
-      throw new RPCError(errs.WALLET_ERROR, 'No tracked address for TX.');
+      throw new RPCError(errs.WALLET_ERROR, 'Address for TX not tracked in wallet, or TX already in wallet');
 
     return null;
   }

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -252,19 +252,11 @@ class RPC extends RPCBase {
   }
 
   async addMultisigAddress(args, help) {
-    if (help || args.length < 2 || args.length > 3) {
-      throw new RPCError(errs.MISC_ERROR,
-        'addmultisigaddress nrequired ["key",...] ( "account" )');
-    }
-
     // Impossible to implement in bcoin (no address book).
     throw new Error('Not implemented.');
   }
 
   async addWitnessAddress(args, help) {
-    if (help || args.length < 1 || args.length > 1)
-      throw new RPCError(errs.MISC_ERROR, 'addwitnessaddress "address"');
-
     // Unlikely to be implemented.
     throw new Error('Not implemented.');
   }
@@ -894,8 +886,7 @@ class RPC extends RPCBase {
   }
 
   async listAddressGroupings(args, help) {
-    if (help)
-      throw new RPCError(errs.MISC_ERROR, 'listaddressgroupings');
+    // Not implemented. 
     throw new Error('Not implemented.');
   }
 
@@ -1446,11 +1437,6 @@ class RPC extends RPCBase {
   }
 
   async setAccount(args, help) {
-    if (help || args.length < 1 || args.length > 2) {
-      throw new RPCError(errs.MISC_ERROR,
-        'setaccount "bitcoinaddress" "account"');
-    }
-
     // Impossible to implement in bcoin:
     throw new Error('Not implemented.');
   }

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -1377,7 +1377,7 @@ class RPC extends RPCBase {
       name = 'default';
 
     if (!sendTo)
-      throw new RPCError(errs.TYPE_ERROR, 'Invalid parameter.');
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid send-to address.');
 
     const to = new Validator(sendTo);
     const uniq = new Set();
@@ -1389,10 +1389,10 @@ class RPC extends RPCBase {
       const hash = addr.getHash('hex');
 
       if (value == null)
-        throw new RPCError(errs.INVALID_PARAMETER, 'Invalid parameter.');
+        throw new RPCError(errs.INVALID_PARAMETER, 'Invalid amount.');
 
       if (uniq.has(hash))
-        throw new RPCError(errs.INVALID_PARAMETER, 'Invalid parameter.');
+        throw new RPCError(errs.INVALID_PARAMETER, 'Each send-to address must be unique.');
 
       uniq.add(hash);
 

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -1605,7 +1605,8 @@ class RPC extends RPCBase {
     };
 
     if (!await this.wdb.addTX(tx, entry))
-      throw new RPCError(errs.WALLET_ERROR, 'Address for TX not tracked in wallet, or TX already in wallet');
+      throw new RPCError(errs.WALLET_ERROR,
+        'Address for TX not in wallet, or TX already in wallet');
 
     return null;
   }

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -1363,7 +1363,7 @@ class RPC extends RPCBase {
     if (help || args.length < 2 || args.length > 5) {
       throw new RPCError(errs.MISC_ERROR,
         'sendmany "fromaccount" {"address":amount,...}'
-        + ' ( minconf "comment" ["address",...] )');
+        + ' ( minconf "comment" subtractfee )');
     }
 
     const wallet = this.wallet;

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -486,7 +486,7 @@ class RPC extends RPCBase {
     const valid = new Validator(args);
     let name = valid.str(0);
 
-    if (name === '')
+    if (name === '' || args.length === 0)
       name = 'default';
 
     const addr = await wallet.createReceive(name);
@@ -495,7 +495,7 @@ class RPC extends RPCBase {
   }
 
   async getRawChangeAddress(args, help) {
-    if (help || args.length > 1)
+    if (help || args.length !== 0)
       throw new RPCError(errs.MISC_ERROR, 'getrawchangeaddress');
 
     const wallet = this.wallet;
@@ -745,7 +745,7 @@ class RPC extends RPCBase {
   }
 
   async importWallet(args, help) {
-    if (help || args.length !== 1)
+    if (help || args.length > 2)
       throw new RPCError(errs.MISC_ERROR, 'importwallet "filename" ( rescan )');
 
     const wallet = this.wallet;

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -1028,17 +1028,17 @@ class RPC extends RPCBase {
   }
 
   async listSinceBlock(args, help) {
+    if (help || args.length > 3) {
+      throw new RPCError(errs.MISC_ERROR,
+        'listsinceblock ( "blockhash" target-confirmations includeWatchonly)');
+    }
+
     const wallet = this.wallet;
     const chainHeight = this.wdb.state.height;
     const valid = new Validator(args);
     const block = valid.rhash(0);
     const minconf = valid.u32(1, 0);
     const watchOnly = valid.bool(2, false);
-
-    if (help) {
-      throw new RPCError(errs.MISC_ERROR,
-        'listsinceblock ( "blockhash" target-confirmations includeWatchonly)');
-    }
 
     if (wallet.watchOnly !== watchOnly)
       return [];

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -886,7 +886,7 @@ class RPC extends RPCBase {
   }
 
   async listAddressGroupings(args, help) {
-    // Not implemented. 
+    // Not implemented.
     throw new Error('Not implemented.');
   }
 
@@ -1383,7 +1383,8 @@ class RPC extends RPCBase {
         throw new RPCError(errs.INVALID_PARAMETER, 'Invalid amount.');
 
       if (uniq.has(hash))
-        throw new RPCError(errs.INVALID_PARAMETER, 'Each send-to address must be unique.');
+        throw new RPCError(errs.INVALID_PARAMETER,
+          'Each send-to address must be unique.');
 
       uniq.add(hash);
 

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -1187,7 +1187,7 @@ class RPC extends RPCBase {
     if (name === '')
       name = 'default';
 
-    const txs = await wallet.getHistory();
+    const txs = await wallet.getHistory(name);
 
     common.sortTX(txs);
 


### PR DESCRIPTION
`getnewaddress` CAN take 0 arguments (uses default account) but wouldn't respond correctly to CLI with 0 args:

```
$ bwallet-cli rpc getnewaddress
Account not found.
```

`getrawchangeaddress` always takes 0 arguments but was allowing up to 1 (ignored) argument.


`importWallet` needs to be able to take up to 2 arguments.

`importprunedfunds` ignores label, [Core removed label arg in 0.13.1](https://github.com/bitcoin/bitcoin/blob/a49b4a75a1b671492e65eed17d6894d85ea5ebfd/doc/release-notes/release-notes-0.13.1.md#low-level-rpc-changes). Also error could be misleading, there's two ways to fail to import...