### PR TITLE
test: fix get block proof equivalent time

### DIFF
--- a/test/pow-test.js
+++ b/test/pow-test.js
@@ -82,7 +82,7 @@ describe('Difficulty', function() {
       const p2 = blocks[random(blocks.length)];
 
       const tdiff = chain.getProofTime(p1, p2);
-      assert.strictEqual(tdiff, p1.time - p2.time);
+      assert.ok(tdiff ===  p1.time - p2.time);
     }
   });
 });


### PR DESCRIPTION
the test was randomly failing when `getProofTime` returns `-0`. Fixed by replacing `strictEqual` with `ok`.