### PR TITLE
wallet / txdb: add unlockCoins() to unlock all locked coins

### DIFF
--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1175,6 +1175,15 @@ class TXDB {
   }
 
   /**
+   * Unlock all coins.
+   */
+
+  unlockCoins() {
+    for (const coin of this.getLocked())
+      this.unlockCoin(coin);
+  }
+
+  /**
    * Test locked status of a single coin.
    * @param {Coin|Outpoint} coin
    */

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1950,6 +1950,14 @@ class Wallet extends EventEmitter {
   }
 
   /**
+   * Unlock all locked coins.
+   */
+
+  unlockCoins() {
+    return this.txdb.unlockCoins();
+  }
+
+  /**
    * Test locked status of a single coin.
    * @param {Coin|Outpoint} coin
    */


### PR DESCRIPTION
The wallet RPC has a function `lockunspent` that should be able to unlock all locked coins.

From Bitcoin Core help (our own docs coming soon...):
> If no transaction outputs are specified when unlocking then all current locked transaction outputs are unlocked.

This has not yet been implemented in bcoin:

```
$ bwallet-cli rpc lockunspent true
wallet.unlockCoins is not a function
```

This PR implements `wallet.unlockCoins()`