### PR TITLE
wdb: fix getWalletPaths() always return nothing

### DIFF
--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -1354,7 +1354,7 @@ class WalletDB extends EventEmitter {
   async getWalletPaths(wid) {
     const items = await this.db.range({
       gte: layout.P.min(wid),
-      lte: layout.P.min(wid)
+      lte: layout.P.max(wid)
     });
 
     const paths = [];

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -123,6 +123,20 @@ describe('HTTP', function() {
     assert.strictEqual(balance.unconfirmed, 201840);
   });
 
+  it('should get rpc listreceivedbyaddress', async() => {
+    await wclient.execute('selectwallet',['test']);
+    const list = await wclient.execute('listreceivedbyaddress',
+     [0, false, false]);
+    assert.deepStrictEqual(list, [{
+        'involvesWatchonly': false,
+        'address': addr.toString('regtest'),
+        'account': 'default',
+        'amount': .00201840,
+        'confirmations': 0,
+        'label': ''
+      }]);
+  });
+
   it('should send a tx', async () => {
     const options = {
       rate: 10000,


### PR DESCRIPTION
Found this bug while testing wallet RPC `listreceivedbyaccount` and `listreceivedbyaddress` which always return empty `[]`