### PR TITLE
wallet rescan: Add error for SPV mode and excessive depth in pruned mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Bcoin Release Notes & Changelog
 
+## vX.Y.Z
+
+### Regtest pruning policy changed
+
+In the old configuration, a pruned node on Regtest would start pruning at height
+1000 and then keep the last 1000 blocks on disk (pruning anything older). This
+has been changed to facilitate testing. The new parameters are
+`pruneAfterHeight: 500, keepBlocks: 288`.
+
 ## v1.0.0
 
 ### Migration

--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -125,7 +125,9 @@ class HTTP extends Server {
         chain: {
           height: this.chain.height,
           tip: this.chain.tip.rhash(),
-          progress: this.chain.getProgress()
+          progress: this.chain.getProgress(),
+          spv: this.chain.options.spv,
+          prune: this.chain.options.prune
         },
         pool: {
           host: addr.host,

--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -126,8 +126,8 @@ class HTTP extends Server {
           height: this.chain.height,
           tip: this.chain.tip.rhash(),
           progress: this.chain.getProgress(),
-          spv: this.chain.spv,
-          prune: this.chain.prune
+          spv: this.chain.options.spv,
+          prune: this.chain.options.prune
         },
         pool: {
           host: addr.host,

--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -126,8 +126,8 @@ class HTTP extends Server {
           height: this.chain.height,
           tip: this.chain.tip.rhash(),
           progress: this.chain.getProgress(),
-          spv: this.chain.options.spv,
-          prune: this.chain.options.prune
+          spv: this.chain.spv,
+          prune: this.chain.prune
         },
         pool: {
           host: addr.host,

--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -775,8 +775,8 @@ regtest.block = {
   bip65hash: null,
   bip66height: 1251,
   bip66hash: null,
-  pruneAfterHeight: 1000,
-  keepBlocks: 10000,
+  pruneAfterHeight: 500,
+  keepBlocks: 288,
   maxTipAge: 0xffffffff,
   slowHeight: 0
 };

--- a/lib/wallet/client.js
+++ b/lib/wallet/client.js
@@ -77,6 +77,10 @@ class WalletClient extends NodeClient {
 
     return super.rescan(start);
   }
+
+  async getInfo() {
+    return (await super.getInfo());
+  }
 }
 
 /*

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -45,6 +45,7 @@ class HTTP extends Server {
     this.logger = this.options.logger.context('http');
     this.wdb = this.options.node.wdb;
     this.rpc = this.options.node.rpc;
+    this.chain = this.options.node.chain;
 
     this.init();
   }
@@ -191,14 +192,14 @@ class HTTP extends Server {
       }
 
       // SPV doesn't have blocks on disk, so rescan is ineffective
-      enforce(!this.wdb.options.spv, 'Cannot rescan in SPV mode.' +
+      enforce(!this.options.node.chain.spv, 'Cannot rescan in SPV mode.' +
         ' Try rewinding blockchain with node `reset` command.');
 
       const valid = Validator.fromRequest(req);
       const height = valid.u32('height');
 
       // Pruned node can only rescan the blocks it has on disk
-      if (this.options.node.rpc.client.node.chain.options.prune) {
+      if (this.options.node.chain.prune) {
         const tipHeight = await this.options.node.client.getTip();
         const pruneDepth = this.network.block.keepBlocks;
         const minHeight = tipHeight.height - pruneDepth;

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -190,11 +190,22 @@ class HTTP extends Server {
         return;
       }
 
+      // SPV doesn't have blocks on disk, so rescan is ineffective
       enforce(!this.wdb.options.spv, 'Cannot rescan in SPV mode.' +
         ' Try rewinding blockchain with node `reset` command.');
 
       const valid = Validator.fromRequest(req);
       const height = valid.u32('height');
+
+      // Pruned node can only rescan the blocks it has on disk
+      if (this.options.node.rpc.client.node.chain.options.prune) {
+        const tipHeight = await this.options.node.client.getTip();
+        const pruneDepth = this.network.block.keepBlocks;
+        const minHeight = tipHeight.height - pruneDepth;
+
+        enforce(height > minHeight,
+          'Cannot rescan past prune depth of ' + minHeight);
+      }
 
       res.json(200, { success: true });
 

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -192,20 +192,20 @@ class HTTP extends Server {
       }
 
       // SPV doesn't have blocks on disk, so rescan is ineffective
-      enforce(!this.options.node.chain.spv, 'Cannot rescan in SPV mode.' +
+      enforce(!this.options.node.chainInfo.spv, 'Cannot rescan in SPV mode.' +
         ' Try rewinding blockchain with node `reset` command.');
 
       const valid = Validator.fromRequest(req);
       const height = valid.u32('height');
 
       // Pruned node can only rescan the blocks it has on disk
-      if (this.options.node.chain.prune) {
+      if (this.options.node.chainInfo.prune) {
         const tipHeight = await this.options.node.client.getTip();
         const pruneDepth = this.network.block.keepBlocks;
         const minHeight = tipHeight.height - pruneDepth;
 
         enforce(height > minHeight,
-          'Cannot rescan past prune depth of ' + minHeight);
+          'Rescan height must be greater than prune height of ' + minHeight);
       }
 
       res.json(200, { success: true });

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -190,6 +190,9 @@ class HTTP extends Server {
         return;
       }
 
+      enforce(!this.wdb.options.spv, 'Cannot rescan in SPV mode.' +
+        ' Try rewinding blockchain with node `reset` command.');
+
       const valid = Validator.fromRequest(req);
       const height = valid.u32('height');
 

--- a/lib/wallet/node.js
+++ b/lib/wallet/node.js
@@ -109,7 +109,6 @@ class WalletNode extends Node {
     await this.handleOpen();
 
     const clientInfo = await this.client.getInfo();
-
     this.chain = {
       spv: clientInfo.chain.spv,
       prune: clientInfo.chain.prune

--- a/lib/wallet/node.js
+++ b/lib/wallet/node.js
@@ -109,7 +109,7 @@ class WalletNode extends Node {
     await this.handleOpen();
 
     const clientInfo = await this.client.getInfo();
-    this.chain = {
+    this.chainInfo = {
       spv: clientInfo.chain.spv,
       prune: clientInfo.chain.prune
     };

--- a/lib/wallet/node.js
+++ b/lib/wallet/node.js
@@ -108,6 +108,13 @@ class WalletNode extends Node {
     await this.http.open();
     await this.handleOpen();
 
+    const clientInfo = await this.client.getInfo();
+
+    this.chain = {
+      spv: clientInfo.chain.spv,
+      prune: clientInfo.chain.prune
+    };
+
     this.logger.info('Wallet node is loaded.');
   }
 

--- a/lib/wallet/nodeclient.js
+++ b/lib/wallet/nodeclient.js
@@ -218,12 +218,12 @@ class NodeClient extends AsyncEmitter {
    */
 
   async getInfo() {
-    return {
+    return Promise.resolve({
       chain: {
         spv:this.node.chain.options.spv,
         prune:this.node.chain.options.prune
       }
-    };
+    });
   }
 }
 

--- a/lib/wallet/nodeclient.js
+++ b/lib/wallet/nodeclient.js
@@ -211,6 +211,20 @@ class NodeClient extends AsyncEmitter {
       return this.emitAsync('block rescan', entry, txs);
     });
   }
+
+  /**
+   * Get relevant node info for wallet
+   * @returns {Promise}
+   */
+
+  async getInfo() {
+    return {
+      chain: {
+        spv:this.node.chain.options.spv,
+        prune:this.node.chain.options.prune
+      }
+    };
+  }
 }
 
 /*

--- a/lib/wallet/nullclient.js
+++ b/lib/wallet/nullclient.js
@@ -162,6 +162,20 @@ class NullClient extends EventEmitter {
   async rescan(start) {
     ;
   }
+
+  /**
+   * Get relevant node info for wallet
+   * @returns {Promise}
+   */
+
+  async getInfo() {
+    return Promise.resolve({
+      chain: {
+        spv: false,
+        prune: false
+      }
+    });
+  }
 }
 
 /*

--- a/lib/wallet/plugin.js
+++ b/lib/wallet/plugin.js
@@ -90,7 +90,7 @@ class Plugin extends EventEmitter {
     await this.http.open();
 
     const clientInfo = await this.client.getInfo();
-    this.chain = {
+    this.chainInfo = {
       spv: clientInfo.chain.spv,
       prune: clientInfo.chain.prune
     };

--- a/lib/wallet/plugin.js
+++ b/lib/wallet/plugin.js
@@ -88,6 +88,12 @@ class Plugin extends EventEmitter {
     await this.wdb.open();
     this.rpc.wallet = this.wdb.primary;
     await this.http.open();
+
+    const clientInfo = await this.client.getInfo();
+    this.chain = {
+      spv: clientInfo.chain.spv,
+      prune: clientInfo.chain.prune
+    };
   }
 
   async close() {

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -195,6 +195,12 @@ class WalletDB extends EventEmitter {
       this.state.height,
       this.state.startHeight);
 
+    const clientInfo = await this.client.getInfo();
+    this.chain = {
+      spv: clientInfo.chain.spv,
+      prune: clientInfo.chain.prune
+    };
+
     const wallet = await this.ensure({
       id: 'primary'
     });
@@ -439,6 +445,16 @@ class WalletDB extends EventEmitter {
       height = this.state.startHeight;
 
     assert((height >>> 0) === height, 'WDB: Must pass in a height.');
+
+    // Pruned node can only rescan the blocks it has on disk
+    if (this.chain.prune) {
+      const tipHeight = await this.client.getTip();
+      const pruneDepth = this.network.block.keepBlocks;
+      const minHeight = tipHeight.height - pruneDepth;
+
+      assert(height > minHeight,
+        'Cannot rescan past prune depth of ' + minHeight);
+    }
 
     this.logger.info(
       'WalletDB is scanning %d blocks.',

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -196,7 +196,7 @@ class WalletDB extends EventEmitter {
       this.state.startHeight);
 
     const clientInfo = await this.client.getInfo();
-    this.chain = {
+    this.chainInfo = {
       spv: clientInfo.chain.spv,
       prune: clientInfo.chain.prune
     };
@@ -447,13 +447,13 @@ class WalletDB extends EventEmitter {
     assert((height >>> 0) === height, 'WDB: Must pass in a height.');
 
     // Pruned node can only rescan the blocks it has on disk
-    if (this.chain.prune) {
+    if (this.chainInfo.prune) {
       const tipHeight = await this.client.getTip();
       const pruneDepth = this.network.block.keepBlocks;
       const minHeight = tipHeight.height - pruneDepth;
 
       assert(height > minHeight,
-        'Cannot rescan past prune depth of ' + minHeight);
+        'Rescan height must be greater than prune height of ' + minHeight);
     }
 
     this.logger.info(

--- a/test/prune-test.js
+++ b/test/prune-test.js
@@ -52,8 +52,16 @@ describe('Pruned node', function() {
 
   it('should generate 1000 blocks', async () => {
     const addr = await wallet.createAddress('default');
-    assert(await nclient.execute('generatetoaddress', [500, addr.address]));
-    assert(await nclient.execute('generatetoaddress', [500, addr.address]));
+    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
+    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
+    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
+    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
+    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
+    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
+    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
+    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
+    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
+    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
     const info = await nclient.getInfo();
     assert.strictEqual(1000, info.chain.height);
   });

--- a/test/prune-test.js
+++ b/test/prune-test.js
@@ -43,6 +43,11 @@ describe('Pruned node', function() {
     await wclient.open();
   });
 
+  it('should indicate prune in getInfo', async () => {
+    const info = await nclient.getInfo();
+    assert.strictEqual(true, info.chain.prune);
+  });
+
   it('should create wallet', async () => {
     const info = await wclient.createWallet('test');
     assert.strictEqual(info.id, 'test');

--- a/test/prune-test.js
+++ b/test/prune-test.js
@@ -82,7 +82,7 @@ describe('Pruned node', function() {
     } catch(e) {
       assert.strictEqual(
         e.message,
-        'Cannot rescan past prune depth of ' + pruneHeight
+        'Rescan height must be greater than prune height of ' + pruneHeight
       );
     }
 
@@ -92,7 +92,7 @@ describe('Pruned node', function() {
     } catch(e) {
       assert.strictEqual(
         e.message,
-        'Cannot rescan past prune depth of ' + pruneHeight
+        'Rescan height must be greater than prune height of ' + pruneHeight
       );
     }
   });

--- a/test/prune-test.js
+++ b/test/prune-test.js
@@ -56,17 +56,11 @@ describe('Pruned node', function() {
   });
 
   it('should generate 1000 blocks', async () => {
-    const addr = await wallet.createAddress('default');
-    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
-    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
-    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
-    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
-    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
-    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
-    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
-    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
-    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
-    assert(await nclient.execute('generatetoaddress', [100, addr.address]));
+    for (let i = 0; i < 1000; i++) {
+      const block = await node.miner.cpu.mineBlock();
+      assert(block);
+      assert(await node.chain.add(block));
+    }
     const info = await nclient.getInfo();
     assert.strictEqual(1000, info.chain.height);
   });

--- a/test/prune-test.js
+++ b/test/prune-test.js
@@ -1,0 +1,93 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('./util/assert');
+const consensus = require('../lib/protocol/consensus');
+const FullNode = require('../lib/node/fullnode');
+const Network = require('../lib/protocol/network');
+const network = Network.get('regtest');
+
+const node = new FullNode({
+  network: 'regtest',
+  apiKey: 'foo',
+  walletAuth: true,
+  memory: true,
+  workers: true,
+  plugins: [require('../lib/wallet/plugin')],
+  prune: true
+});
+
+const {NodeClient, WalletClient} = require('bclient');
+
+const nclient = new NodeClient({
+  port: network.rpcPort,
+  apiKey: 'foo'
+});
+
+const wclient = new WalletClient({
+  port: network.walletPort,
+  apiKey: 'foo'
+});
+
+let wallet = null;
+
+describe('Pruned node', function() {
+  this.timeout(15000);
+
+  it('should open node', async () => {
+    consensus.COINBASE_MATURITY = 0;
+    await node.open();
+    await nclient.open();
+    await wclient.open();
+  });
+
+  it('should create wallet', async () => {
+    const info = await wclient.createWallet('test');
+    assert.strictEqual(info.id, 'test');
+    wallet = wclient.wallet('test', info.token);
+    await wallet.open();
+  });
+
+  it('should generate 1000 blocks', async () => {
+    const addr = await wallet.createAddress('default');
+    assert(await nclient.execute('generatetoaddress', [500, addr.address]));
+    assert(await nclient.execute('generatetoaddress', [500, addr.address]));
+    const info = await nclient.getInfo();
+    assert.strictEqual(1000, info.chain.height);
+  });
+
+  it('should fail to rescan past prune height', async () => {
+    const pruneHeight = 1000 - 288;
+
+    try {
+      await nclient.getBlock(pruneHeight);
+    } catch(e) {
+      assert.strictEqual(e.message, 'Block not found.');
+    }
+
+    try {
+      await wclient.rescan(pruneHeight);
+    } catch(e) {
+      assert.strictEqual(
+        e.message,
+        'Cannot rescan past prune depth of ' + pruneHeight
+      );
+    }
+  });
+
+  it('should succeed to rescan within prune height', async () => {
+    const pruneHeight = 1000 - 288;
+    assert(await nclient.getBlock(pruneHeight + 1));
+    assert(await wclient.rescan(pruneHeight + 1));
+  });
+
+  it('should cleanup', async () => {
+    consensus.COINBASE_MATURITY = 100;
+    await wallet.close();
+    await wclient.close();
+    await nclient.close();
+    await node.close();
+  });
+});

--- a/test/prune-test.js
+++ b/test/prune-test.js
@@ -4,55 +4,24 @@
 'use strict';
 
 const assert = require('./util/assert');
-const consensus = require('../lib/protocol/consensus');
 const FullNode = require('../lib/node/fullnode');
-const Network = require('../lib/protocol/network');
-const network = Network.get('regtest');
 
 const node = new FullNode({
   network: 'regtest',
-  apiKey: 'foo',
-  walletAuth: true,
   memory: true,
-  workers: true,
   plugins: [require('../lib/wallet/plugin')],
   prune: true
 });
-
-const {NodeClient, WalletClient} = require('bclient');
-
-const nclient = new NodeClient({
-  port: network.rpcPort,
-  apiKey: 'foo'
-});
-
-const wclient = new WalletClient({
-  port: network.walletPort,
-  apiKey: 'foo'
-});
-
-let wallet = null;
 
 describe('Pruned node', function() {
   this.timeout(60000);
 
   it('should open node', async () => {
-    consensus.COINBASE_MATURITY = 0;
     await node.open();
-    await nclient.open();
-    await wclient.open();
   });
 
   it('should indicate prune in getInfo', async () => {
-    const info = await nclient.getInfo();
-    assert.strictEqual(true, info.chain.prune);
-  });
-
-  it('should create wallet', async () => {
-    const info = await wclient.createWallet('test');
-    assert.strictEqual(info.id, 'test');
-    wallet = wclient.wallet('test', info.token);
-    await wallet.open();
+    assert.strictEqual(true, node.chain.options.prune);
   });
 
   it('should generate 1000 blocks', async () => {
@@ -61,8 +30,7 @@ describe('Pruned node', function() {
       assert(block);
       assert(await node.chain.add(block));
     }
-    const info = await nclient.getInfo();
-    assert.strictEqual(1000, info.chain.height);
+    assert.strictEqual(1000, node.chain.height);
   });
 
   it('should fail to rescan past prune height', async () => {
@@ -70,19 +38,9 @@ describe('Pruned node', function() {
 
     // This block is not on disk
     try {
-      await nclient.getBlock(pruneHeight);
+      await node.getBlock(pruneHeight);
     } catch(e) {
       assert.strictEqual(e.message, 'Block not found.');
-    }
-
-    // HTTP API call
-    try {
-      await wclient.rescan(pruneHeight);
-    } catch(e) {
-      assert.strictEqual(
-        e.message,
-        'Rescan height must be greater than prune height of ' + pruneHeight
-      );
     }
 
     // direct WalletDB call
@@ -98,15 +56,12 @@ describe('Pruned node', function() {
 
   it('should succeed to rescan within prune height', async () => {
     const pruneHeight = 1000 - 288;
-    assert(await nclient.getBlock(pruneHeight + 1));
-    assert(await wclient.rescan(pruneHeight + 1));
+    // This block *IS* on disk
+    assert(await node.getBlock(pruneHeight + 1));
+    await node.plugins.walletdb.wdb.rescan(pruneHeight + 1);
   });
 
   it('should cleanup', async () => {
-    consensus.COINBASE_MATURITY = 100;
-    await wallet.close();
-    await wclient.close();
-    await nclient.close();
     await node.close();
   });
 });

--- a/test/prune-test.js
+++ b/test/prune-test.js
@@ -69,14 +69,26 @@ describe('Pruned node', function() {
   it('should fail to rescan past prune height', async () => {
     const pruneHeight = 1000 - 288;
 
+    // This block is not on disk
     try {
       await nclient.getBlock(pruneHeight);
     } catch(e) {
       assert.strictEqual(e.message, 'Block not found.');
     }
 
+    // HTTP API call
     try {
       await wclient.rescan(pruneHeight);
+    } catch(e) {
+      assert.strictEqual(
+        e.message,
+        'Cannot rescan past prune depth of ' + pruneHeight
+      );
+    }
+
+    // direct WalletDB call
+    try {
+      await node.plugins.walletdb.wdb.rescan(pruneHeight);
     } catch(e) {
       assert.strictEqual(
         e.message,

--- a/test/prune-test.js
+++ b/test/prune-test.js
@@ -5,6 +5,7 @@
 
 const assert = require('./util/assert');
 const FullNode = require('../lib/node/fullnode');
+const Block = require('../lib/primitives/block');
 
 const node = new FullNode({
   network: 'regtest',
@@ -37,13 +38,9 @@ describe('Pruned node', function() {
     const pruneHeight = 1000 - 288;
 
     // This block is not on disk
-    try {
-      await node.getBlock(pruneHeight);
-    } catch(e) {
-      assert.strictEqual(e.message, 'Block not found.');
-    }
+    assert.strictEqual(null, await node.getBlock(pruneHeight));
 
-    // direct WalletDB call
+    // Try to rescan it anyway
     try {
       await node.plugins.walletdb.wdb.rescan(pruneHeight);
     } catch(e) {
@@ -57,7 +54,7 @@ describe('Pruned node', function() {
   it('should succeed to rescan within prune height', async () => {
     const pruneHeight = 1000 - 288;
     // This block *IS* on disk
-    assert(await node.getBlock(pruneHeight + 1));
+    assert((await node.getBlock(pruneHeight + 1)) instanceof Block);
     await node.plugins.walletdb.wdb.rescan(pruneHeight + 1);
   });
 

--- a/test/prune-test.js
+++ b/test/prune-test.js
@@ -34,7 +34,7 @@ const wclient = new WalletClient({
 let wallet = null;
 
 describe('Pruned node', function() {
-  this.timeout(15000);
+  this.timeout(60000);
 
   it('should open node', async () => {
     consensus.COINBASE_MATURITY = 0;


### PR DESCRIPTION
In SPV mode, `rescan` doesn't actually do anything. If a user creates a watch-only wallet by importing an `xpub` while in SPV mode, that wallet will not necessarily be in sync with the chain. Unlike fullnode, a `rescan` will not sync the wallet. This PR adds an error that redirects the user to `reset` which, in SPV mode at least, should not take too long and will discover any wallet transactions that occurred before the import point.

This issue also applies to pruned nodes, if historical transactions for the imported address were confirmed before the prune height. However a pruned node can not `reset`. We could expand the error to cover pruned nodes as well.

We might also want to add a note in the docs that importing keys into a pruned node may not correctly recover those keys' blockchain history.

Or... is it possible to enable `reset` on a pruned node?