### PR TITLE
test: http-test - don't read wallet.conf

### DIFF
--- a/lib/wallet/plugin.js
+++ b/lib/wallet/plugin.js
@@ -34,7 +34,9 @@ class Plugin extends EventEmitter {
     super();
 
     this.config = node.config.filter('wallet');
-    this.config.open('wallet.conf');
+
+    if (node.config.bool('config'))
+      this.config.open('wallet.conf');
 
     this.network = node.network;
     this.logger = node.logger;


### PR DESCRIPTION
Refs #534 

The existing wallet plugin always reads `wallet.conf`, leading to test failures when a conf file with different `api-key` exists.

This PR extends the behavior of enabling a config file by passing `config: true` to the wallet plugin in addition to the node.