### PR TITLE
Fix pool.hasTX() method (updated)

### DIFF
--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -3347,7 +3347,7 @@ class Pool extends EventEmitter {
     if (!this.mempool) {
       // Check the TX filter if
       // we don't have a mempool.
-      if (!this.txFilter.added(hash, 'hex'))
+      if (this.txFilter.test(hash, 'hex'))
         return true;
     } else {
       // Check the mempool.

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -2426,6 +2426,7 @@ class Pool extends EventEmitter {
     }
 
     if (!this.mempool) {
+      this.txFilter.added(tx.hash());
       this.emit('tx', tx);
       return;
     }

--- a/test/pool-test.js
+++ b/test/pool-test.js
@@ -1,0 +1,30 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('./util/assert');
+const FullNode = require('../lib/node/fullnode');
+const SPVNode = require('../lib/node/spvnode');
+
+const full = new FullNode({
+  network: 'regtest'
+});
+
+const spv = new SPVNode({
+  network: 'regtest'
+});
+
+const dummyHash = '0123456789abcdef'.repeat(4);
+
+describe('Pool', function() {
+  it('should check if a tx exists without adding it to the filter', () => {
+    assert(!spv.pool.hasTX(dummyHash));
+    assert(!spv.pool.hasTX(dummyHash));
+  });
+
+  it('should check if a tx exists without adding it to the mempool', () => {
+    assert(!full.pool.hasTX(dummyHash));
+    assert(!full.pool.hasTX(dummyHash));
+  });
+});


### PR DESCRIPTION
I wanted to sync my master to the upstream and rename the branch to `has-tx-fix` and in the process I broke PR #358 (some force pushing was involved). I took the chance to rebase the commits of this PR on `master`, since the `wallet-rewrite` branch (on which this PR #358 was based) has gone defunct.