### PR TITLE
test: coverage report for local exploration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           - v1-dependencies-
       - run:
           name: Tests with coverage
-          command: npm run test-ci
+          command: npm run coverage
       - run:
           name: Install codecov
           command: npm i codecov

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "test-browser": "NODE_BACKEND=js mocha --reporter spec test/*.js",
     "test-file": "mocha --reporter spec",
     "test-file-browser": "NODE_BACKEND=js mocha --reporter spec",
-    "test-ci": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec test/*.js",
+    "coverage": "istanbul cover node_modules/.bin/_mocha -- --reporter spec test/*.js",
     "webpack": "webpack --mode production --config webpack.browser.js",
     "webpack-browser": "webpack --mode production --config webpack.browser.js",
     "webpack-compat": "webpack --mode production --config webpack.compat.js",


### PR DESCRIPTION
Include html report to explore code coverage areas locally
in a web browser, and change script name as it's not exclusive
to continous integration.

Usage:
```sh
firefox coverage/lcov-report/index.html
```