### PR TITLE
[WIP] wallet: batch process resending txs to prevent memory overflow

### DIFF
--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -177,6 +177,8 @@ class WalletDB extends EventEmitter {
    */
 
   async open() {
+    this.logger.info('Opening WalletDB...');
+
     await this.db.open();
     await this.db.verify(layout.V.build(), 'wallet', 7);
 
@@ -1491,28 +1493,49 @@ class WalletDB extends EventEmitter {
       return;
 
     this.logger.info(
-      'Rebroadcasting %d transactions for %d.',
+      'Rebroadcasting %d transactions for %d wallets.',
       hashes.length,
       wid);
 
-    const txs = [];
+    const sleep = ms => new Promise(res => setTimeout(res, ms));
 
-    for (const hash of hashes) {
-      const data = await b.get(tlayout.t.build(hash));
+    // This probably should be set to a sane dos level
+    // perhaps from an existing constant in net/common?
+    const batchLimit = 1000;
+    let totalSent = 0;
 
-      if (!data)
-        continue;
+    do {
+      const batch = hashes.splice(0, batchLimit);
+      const txs = [];
 
-      const wtx = TXRecord.fromRaw(data);
+      for (const hash of batch) {
+        const data = await b.get(tlayout.t.build(hash));
 
-      if (wtx.tx.isCoinbase())
-        continue;
+        if (!data)
+          continue;
 
-      txs.push(wtx.tx);
-    }
+        const wtx = TXRecord.fromRaw(data);
 
-    for (const tx of common.sortDeps(txs))
-      await this.send(tx);
+        if (wtx.tx.isCoinbase())
+          continue;
+
+        txs.push(wtx.tx);
+      }
+
+      for (const tx of common.sortDeps(txs))
+        await this.send(tx);
+
+      totalSent += batch.length;
+      this.logger.debug('Broadcast %d / %d txs',
+        totalSent,
+        hashes.length);
+
+      // Wait 5s to before sending next batch
+      // Needs to both prevent spamming nodes
+      // & give time for nodejs GC to free memory
+      // (Probably a better way to force free memory?)
+      await sleep(5000);
+    } while(hashes.length > 0);
   }
 
   /**


### PR DESCRIPTION
**Do Not Merge**

This commit is really a test/hack that solved the issue I was having, not meant to be merged. It does serve as a starting point for discussion to determine a proper solution.

In my scenario I had a large walletdb corrupted by (seemingly) borked rescan. When launching bcoin it would attempt to rebroadcast 150k+ txs. This resulted in a js heap overflow causing the node to be stuck in a reboot loop. This change solved the memory overflow problem, even though in reality this was caused by a "broken" state. Essentially my wallets' corrupted state revealed this memory overflow issue by accident. When testing this fix I actually commented out `await this.send(tx);` to prevent my node from blasting 150k txs to all my peers. We should consider preventing the node from doing this at all.

3 points of discussion:
1) What is a sane limit for # of txs to broadcast at a time, to prevent being banned by other peers? Is this even a concern?
2) Should we even allow rebroadcasting large numbers of txs, or just skip automatic rebroadcasting if this number exceeds a certain threshold? I can imagine in extreme edge cases such as this someone could manually trigger this using `resend` rpc call rather than it happening automatically on startup. We would still want batching in this scenario.
3) What's the best way to prevent memory overflow here? While this fix did work in my scenario, I closely monitored memory usage with this fix, and most likely if # of txs was double (300k+) it probably would have still resulted in heap overflow. There's certainly a saner way to optimize this rather than relying on nodejs garbage collection in between the sleep interval.