### PR TITLE
Proposal: rename config file bcoin.conf -> node.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Bcoin Release Notes & Changelog
 
+## v1.0.x
+
+### Configuraiton Changes
+
+- Important: `bcoin.conf` has been renamed to `node.conf`
+
 ## v1.0.0
 
 ### Migration

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,4 +1,4 @@
-By default, the mainnet bcoin config file will reside in ~/.bcoin/bcoin.conf.
+By default, the mainnet bcoin config file will reside in ~/.bcoin/node.conf.
 
 All bcoin configuration options work in the config file, CLI arguments, and
 process environment (with a `BCOIN_` prefix).

--- a/etc/sample.conf
+++ b/etc/sample.conf
@@ -1,4 +1,4 @@
-# Sample bcoin config file (~/.bcoin/bcoin.conf)
+# Sample bcoin config file (~/.bcoin/node.conf)
 
 #
 # Options

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -33,7 +33,7 @@ class FullNode extends Node {
    */
 
   constructor(options) {
-    super('bcoin', 'bcoin.conf', 'debug.log', options);
+    super('bcoin', 'node.conf', 'debug.log', options);
 
     this.opened = false;
 

--- a/lib/node/spvnode.js
+++ b/lib/node/spvnode.js
@@ -35,7 +35,7 @@ class SPVNode extends Node {
    */
 
   constructor(options) {
-    super('bcoin', 'bcoin.conf', 'debug.log', options);
+    super('bcoin', 'node.conf', 'debug.log', options);
 
     this.opened = false;
 


### PR DESCRIPTION
**Rationale:**
- This is more consistent naming now that we have separate conf files for wallet. (`bcoin.conf` and `wallet.conf` appears inconsistent, and `~/.bcoin/bcoin.conf` is also redundant)
- Allows more easy portability of the code to forks such as `bcash`, resulting fewer changes, and less documentation.
- This would allow `bclient` to be instantly compatible with forks such as `bcash` without extra parameters or modifications. (https://github.com/bcoin-org/bclient/blob/master/bin/bcoin-cli#L36)

**Cons:**
- Would result in a breaking change that all bcoin users would have to migrate to. In theory we could make this change backwards compatible, but appears that would require changing `bcfg` to support fallback conf files.
- Requires synchronous changes/releases for `bcoin`, `bcash` and `bclient`

**Additional considerations:**
Environment variables are also inconsistent, eg. bcoin expects `BCOIN_`, bcash expects `BCASH_`, bclient expected `BCOIN_` (even when talking to bcash).  Ideally this could also be unified.

Nodar proposed changing to `BNODE_` and `BWALLET_`. This would also be a breaking change for existing users, but would have a big impact on our ability to unify documentation/tutorials, resulting in less confusion for future users.

Note: ENV change is not currently included in this PR.

Thoughts?