### PR TITLE
Wallet option to skip templates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@
 - `PUT /wallet/:id` Creating a watch-only wallet now requires an `accountKey`
   argument. This is to prevent bcoin from generating keys and addresses the
   user can not spend from.
-- `POST /wallet/:id/create` Now has a `sign` argument for optional signing
-  of transactions.
+- `POST /wallet/:id/create`
+  - Now has a `sign` argument for optional signing of transactions.
+  - Now has a `template` option, that will skip templating inputs when
+  `sign = false`, but you can enable it if necessary. It does not have an
+  effect when `sign = true`.
+  - Exposes `blocks`, which can will be used if there is no `rate` option.
+  - Exposes `sort` (Default `true`), that can be used to disable BIP69 sorting.
 
 #### RPC
 

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -468,13 +468,16 @@ class HTTP extends Server {
 
       const options = {
         rate: valid.u64('rate'),
+        blocks: valid.u32('blocks'),
         maxFee: valid.u64('maxFee'),
         selection: valid.str('selection'),
         smart: valid.bool('smart'),
         account: valid.str('account'),
+        sort: valid.bool('sort'),
         subtractFee: valid.bool('subtractFee'),
         subtractIndex: valid.i32('subtractIndex'),
         depth: valid.u32(['confirmations', 'depth']),
+        template: valid.bool('template', sign),
         outputs: []
       };
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1236,6 +1236,9 @@ class Wallet extends EventEmitter {
    * to avoid sorting), set locktime, and template it.
    * @param {Object} options - See {@link Wallet#fund options}.
    * @param {Object[]} options.outputs - See {@link MTX#addOutput}.
+   * @param {Boolean} options.sort - Sort inputs and outputs (BIP69).
+   * @param {Boolean} options.template - Build scripts for inputs.
+   * @param {Number} options.locktime - TX locktime
    * @returns {Promise} - Returns {@link MTX}.
    */
 
@@ -1280,6 +1283,9 @@ class Wallet extends EventEmitter {
     assert(mtx.isSane(), 'TX failed sanity check.');
     assert(mtx.verifyInputs(this.wdb.state.height + 1),
       'TX failed context check.');
+
+    if (options.template === false)
+      return mtx;
 
     const total = await this.template(mtx);
 


### PR DESCRIPTION
Introduce `options.template` option to `createTX` wallet http call which will allow controlling if we want transaction templated.
By default `template` will be true and won't break current usage (checks if it was set and is not `false`).

If you don't want to sign transaction right away, it can be useful to store just plain transaction.
For some plugins this will be useful as well, e.g. PSBT which stores empty inputs.

Summary:
- [x] `template` option for `createTX`.
- [x] tests for `template` option.

Other:
- Expose additional options to `createTX` http call. (`blocks`, `sort`)
  - to have identical options for `send` and `createTX`.
- Add more option docs to createTX method.
