### PR TITLE
Config: Support passing pluginOptions to FullNode (requires bcfg update)

### DIFF
--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -40,6 +40,9 @@ class Node extends EventEmitter {
       alias: { 'n': 'network' }
     });
 
+    if (options.pluginOptions)
+      options.child = options.pluginOptions;
+
     this.config.inject(options);
     this.config.load(options);
 

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -17,10 +17,14 @@ const network = Network.get('regtest');
 const node = new FullNode({
   network: 'regtest',
   apiKey: 'foo',
-  walletAuth: true,
   memory: true,
   workers: true,
-  plugins: [require('../lib/wallet/plugin')]
+  plugins: [require('../lib/wallet/plugin')],
+  pluginOptions: {
+    walletAuth: true,
+    // prevents reading local wallet.conf file that could break tests
+    walletConfig: '/bad/path'
+  }
 });
 
 const {NodeClient, WalletClient} = require('bclient');


### PR DESCRIPTION
This fixes the issue of allowing http-test to hard set wallet-config.
My attempt at fixing #534 #535 #561 

Depends on corresponding PR to `bcfg`:
https://github.com/bcoin-org/bcfg/pull/2