### PR TITLE
wallet: improve logging + rescan (minor)

### DIFF
--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -941,7 +941,7 @@ class TXDB {
     if (wtx.height === -1)
       return null;
 
-    return await this.disconnect(wtx, wtx.getBlock());
+    return this.disconnect(wtx, wtx.getBlock());
   }
 
   /**

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -914,6 +914,7 @@ class TXDB {
     if (!block)
       return 0;
 
+    this.logger.debug('Rescan: reverting block %d', height);
     const hashes = block.toArray();
 
     for (let i = hashes.length - 1; i >= 0; i--) {
@@ -940,7 +941,7 @@ class TXDB {
     if (wtx.height === -1)
       return null;
 
-    return this.disconnect(wtx, wtx.getBlock());
+    return await this.disconnect(wtx, wtx.getBlock());
   }
 
   /**

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -177,6 +177,7 @@ class WalletDB extends EventEmitter {
    */
 
   async open() {
+    this.logger.info('Opening WalletDB...');
     await this.db.open();
     await this.db.verify(layout.V.build(), 'wallet', 7);
 


### PR DESCRIPTION
Adds some minor improvements I found useful when debugging.

1) Logging "Opening WalletDB" similar to "Opening ChainDB". For large wallets this is helpful, as it can take longer to open the wallet than even the chain. Without this it appears the process is stuck.

2) Logging rescan progress. For large rescans it can take a long time to revert the blocks, this shows progress is still on going. Logs are silent about the rescan otherwise.

3) Added `await` to disconnect. I think this might have caused some issues with some of my larger rescan attempts, but difficult to be certain.