### PR TITLE
Tab completion of API in Node.js REPL

### DIFF
--- a/lib/bcoin.js
+++ b/lib/bcoin.js
@@ -30,6 +30,7 @@ const bcoin = exports;
 bcoin.define = function define(name, path) {
   let cache = null;
   Object.defineProperty(bcoin, name, {
+    enumerable: true,
     get() {
       if (!cache)
         cache = require(path);


### PR DESCRIPTION
Trivial change to enable tab completion of API in a Node.js REPL.

Open a Node.js REPL, and:
```
const bcoin = require('.');
bcoin.<press-tab>
```
Will show the available API.