### PR TITLE
Fix syncFilter() in WalletDB

### DIFF
--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -3079,12 +3079,21 @@ class Pool extends EventEmitter {
    * @param {String?} enc
    */
 
-  setFilter(filter) {
+  setSpvFilter(filter) {
     if (!this.options.spv)
       return;
 
     this.spvFilter = filter;
     this.queueFilterLoad();
+  }
+
+  /**
+   * Set the tx filter.
+   * @param {BloomFilter} filter
+   */
+
+  setTxFilter(filter) {
+    this.txFilter = filter;
   }
 
   /**

--- a/lib/wallet/nodeclient.js
+++ b/lib/wallet/nodeclient.js
@@ -152,7 +152,7 @@ class NodeClient extends AsyncEmitter {
 
   async setFilter(filter) {
     this.filter = filter;
-    this.node.pool.setFilter(filter);
+    this.node.pool.setTxFilter(filter);
   }
 
   /**
@@ -171,6 +171,14 @@ class NodeClient extends AsyncEmitter {
    */
 
   async resetFilter() {
+    this.node.pool.queueFilterLoad();
+  }
+
+  /**
+   * Send filter to peers.
+   */
+
+  sendFilter() {
     this.node.pool.queueFilterLoad();
   }
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -517,7 +517,6 @@ class WalletDB extends EventEmitter {
   /**
    * Send filter to the remote node.
    * @private
-   * @returns {Promise}
    */
 
   syncFilter() {
@@ -525,7 +524,7 @@ class WalletDB extends EventEmitter {
       this.filter.size / 8 / (1 << 20));
 
     this.filterSent = true;
-    return this.client.setFilter(this.filter);
+    this.client.setFilter(this.filter);
   }
 
   /**

--- a/test/fix-sync-filter-regression.js
+++ b/test/fix-sync-filter-regression.js
@@ -1,0 +1,40 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const bcoin = require('..');
+const SPVNode = bcoin.SPVNode;
+const WalletDB = bcoin.wallet.WalletDB;
+const NodeClient = bcoin.wallet.NodeClient;
+const assert = require('./util/assert');
+const _ = require('lodash');
+
+const network = bcoin.Network.get().toString();
+
+const spvnode = new SPVNode({
+  network: network
+});
+
+const walletdb = new WalletDB({
+  network: network,
+  client: new NodeClient(spvnode)
+});
+
+describe('NodeClient.setFilter() regression test', function() {
+  before(async () => {
+    await spvnode.open();
+  });
+
+  after(async () => {
+    await spvnode.close();
+    await walletdb.close();
+  });
+
+  it('should have the same spvFilter before '
+  + 'and after walletdb.open() in spvnode', async () => {
+    const initialSpvFilter = _.clone(spvnode.pool.spvFilter);
+    await walletdb.open();
+    assert.deepEqual(initialSpvFilter, spvnode.pool.spvFilter);
+  });
+});


### PR DESCRIPTION
syncFilter() should send the filter to peers, not change it.
A function for sending the filter is also defined in NodeClient. Fixes #567.