### PR TITLE
http: fix address/coins by address to use Address instead of string

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -17,6 +17,7 @@ const sha256 = require('bcrypto/lib/sha256');
 const random = require('bcrypto/lib/random');
 const ccmp = require('bcrypto/lib/ccmp');
 const util = require('../utils/util');
+const Address = require('../primitives/address');
 const TX = require('../primitives/tx');
 const Outpoint = require('../primitives/outpoint');
 const Network = require('../protocol/network');
@@ -156,7 +157,8 @@ class HTTP extends Server {
       enforce(address, 'Address is required.');
       enforce(!this.chain.options.spv, 'Cannot get coins in SPV mode.');
 
-      const coins = await this.node.getCoinsByAddress(address);
+      const addr = Address.fromString(address, this.network);
+      const coins = await this.node.getCoinsByAddress(addr);
       const result = [];
 
       for (const coin of coins)
@@ -230,7 +232,8 @@ class HTTP extends Server {
       enforce(address, 'Address is required.');
       enforce(!this.chain.options.spv, 'Cannot get TX in SPV mode.');
 
-      const metas = await this.node.getMetaByAddress(address);
+      const addr = Address.fromString(address, this.network);
+      const metas = await this.node.getMetaByAddress(addr);
       const result = [];
 
       for (const meta of metas) {


### PR DESCRIPTION
After b92839c82acd08f8d206e6c19d238192a1bb6cec# `Address.getHash` stopped accepting a string address,
which breaks some API calls (e.g. `/coin/address/:address`).

~Even though hash can be passed around as Buffer, address needs conversion to retrieve the hash. Therefore this PR restores string to address hash conversion in `getHash`.~

Instead of passing strings, I've updated the fix to pass `Address` from the `HTTP` layers. This is the correct fix because `chain.getCoinsByAddress` expects the input to be an Array of `Address`, rather than Array of `string` as was being passed earlier.