### PR TITLE
Adds --walletonly option to bcoin launch. Creates wallet server without chain or pool

### DIFF
--- a/bin/bcoin
+++ b/bin/bcoin
@@ -46,6 +46,9 @@ for arg in "$@"; do
     --spv)
       cmd='spvnode'
     ;;
+    --walletonly)
+      cmd='walletonlynode'
+    ;;
   esac
 done
 

--- a/bin/walletonlynode
+++ b/bin/walletonlynode
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+'use strict';
+
+process.title = 'bcoin';
+
+const assert = require('assert');
+const WalletOnlyNode = require('../lib/node/walletonlynode');
+
+const node = new WalletOnlyNode({
+  config: true,
+  argv: true,
+  env: true,
+  logFile: true,
+  logConsole: true,
+  logLevel: 'debug',
+  db: 'leveldb',
+  memory: false,
+  persistent: true,
+  workers: true,
+  listen: false,
+  loader: require
+});
+
+const plugin = require('../lib/wallet/plugin');
+node.use(plugin);
+
+process.on('unhandledRejection', (err, promise) => {
+  throw err;
+});
+
+(async () => {
+  await node.ensure();
+  await node.open();
+})().catch((err) => {
+  console.error(err.stack);
+  process.exit(1);
+});

--- a/lib/node/walletonlynode.js
+++ b/lib/node/walletonlynode.js
@@ -1,0 +1,110 @@
+/*!
+ * walletonlynode.js - WalletOnlyNode node for bcoin
+ * Copyright (c) 2014-2015, Fedor Indutny (MIT License)
+ * Copyright (c) 2014-2017, Christopher Jeffrey (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const assert = require('bsert');
+const Node = require('./node');
+const notavail = new Object();
+
+/**
+ * WalletOnlyNode Node
+ * Create an WalletOnlyNode node which only maintains a wallet.
+ * @alias module:node.WalletOnlyNode
+ * @extends Node
+ */
+
+class WalletOnlyNode extends Node {
+  /**
+   * Create WalletOnlyNode node.
+   * @constructor
+   * @param {Object?} options
+   * @param {Buffer?} options.sslKey
+   * @param {Buffer?} options.sslCert
+   * @param {Number?} options.httpPort
+   * @param {String?} options.httpHost
+   */
+
+  constructor(options) {
+    super('bcoin', 'bcoin.conf', 'debug.log', options);
+
+    this.opened = false;
+
+    this.chain = new Proxy(notavail, {
+      get(target, name) {
+        throw new Error('Chain methods not available in wallet-only mode');
+      }
+    });
+
+    this.pool = new Proxy(notavail, {
+      get(target, name) {
+        throw new Error('Pool methods not available in wallet-only mode');
+      }
+    });
+
+    this.http = new Proxy(notavail, {
+      get(target, name) {
+        throw new Error('Node http methods not available in wallet-only mode');
+      }
+    });
+
+    this.rpc = new Proxy(notavail, {
+      get(target, name) {
+        throw new Error('Node RPC methods not available in wallet-only mode');
+      }
+    });
+
+    this.init();
+  }
+
+  /**
+   * Initialize the node.
+   * @private
+   */
+
+  init() {
+    this.loadPlugins();
+  }
+
+  /**
+   * Open the node and all its child objects,
+   * wait for the database to load.
+   * @returns {Promise}
+   */
+
+  async open() {
+    assert(!this.opened, 'WalletOnlyNode is already open.');
+    this.opened = true;
+
+    await this.handlePreopen();
+    await this.openPlugins();
+    await this.handleOpen();
+
+    this.logger.info('WalletOnlyNode is loaded.');
+  }
+
+  /**
+   * Close the node, wait for the database to close.
+   * @returns {Promise}
+   */
+
+  async close() {
+    assert(this.opened, 'WalletOnlyNode is not open.');
+    this.opened = false;
+
+    await this.handlePreclose();
+    await this.http.close();
+    await this.closePlugins();
+    await this.handleClose();
+  }
+}
+
+/*
+ * Expose
+ */
+
+module.exports = WalletOnlyNode;


### PR DESCRIPTION
Addresses https://github.com/bcoin-org/bcoin/issues/471 and additional requests in slack #support about offline bcoin wallets. I definitely think this is something that will get used.

The main idea is to reduce log spam from `pool` and `chain` modules when there are no peers, no mempool, no blocks, no network, etc.

A dummy object catches all method calls to those objects and returns an error `not available in wallet-only mode`

Thanks to the great refactoring from earlier this year, almost every single API and RPC method for the wallet still works perfectly. A few commands like `send` will return the error described above.

Request review from @nodar-chkuaselidze @tuxcanfly @chjj 

Is the module name OK? Should the `process.title` be any different for this mode?