### PR TITLE
bugfix: pass along toJSON args

### DIFF
--- a/lib/primitives/input.js
+++ b/lib/primitives/input.js
@@ -298,7 +298,7 @@ class Input {
    */
 
   toJSON(network, coin) {
-    return this.getJSON();
+    return this.getJSON(network, coin);
   }
 
   /**


### PR DESCRIPTION
Without passing along the arguments here, `this.getJSON` will default will return incorrect information.

```js
  getJSON(network, coin) {
    network = Network.get(network);

    let addr;
    if (!coin) {
      addr = this.getAddress();
      if (addr)
        addr = addr.toString(network);
    }

    return {
      prevout: this.prevout.toJSON(),
      script: this.script.toJSON(),
      witness: this.witness.toJSON(),
      sequence: this.sequence,
      address: addr,
      coin: coin ? coin.getJSON(network, true) : undefined
    };
  }
```

The network will default to `main`, which will result in an incorrect address 
