### PR TITLE
wallet: get correct address for `getnewaddress` rpc

### DIFF
--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -492,7 +492,7 @@ class RPC extends RPCBase {
 
     const addr = await wallet.createReceive(name);
 
-    return addr.getAddress('string');
+    return addr.getAddress('string', this.network);
   }
 
   async getRawChangeAddress(args, help) {
@@ -502,7 +502,7 @@ class RPC extends RPCBase {
     const wallet = this.wallet;
     const addr = await wallet.createChange();
 
-    return addr.getAddress('string');
+    return addr.getAddress('string', this.network);
   }
 
   async getReceivedByAccount(args, help) {


### PR DESCRIPTION
A test for this can be added to `rpc-test.js` in https://github.com/bcoin-org/bcoin/pull/550 once merged. I also have an unrelated work-in-progress test that uses this, and is how I found it.