### PR TITLE
docs: add missing params

### DIFF
--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -180,6 +180,7 @@ class Account {
    * the first addresses along with the lookahead
    * addresses). Called automatically from the
    * walletdb.
+   * @param {Number} b - wallet id
    * @returns {Promise}
    */
 
@@ -267,6 +268,7 @@ class Account {
   /**
    * Add a public account key to the account (multisig).
    * Saves the key in the wallet database.
+   * @param {Number} b - wallet id
    * @param {HDPublicKey} key
    * @returns {Promise}
    */
@@ -498,6 +500,7 @@ class Account {
   /**
    * Save the account to the database. Necessary
    * when address depth and keys change.
+   * @param {Number} b - wallet id
    * @returns {Promise}
    */
 
@@ -507,6 +510,7 @@ class Account {
 
   /**
    * Save addresses to path map.
+   * @param {Number} b - wallet id
    * @param {WalletKey[]} rings
    * @returns {Promise}
    */
@@ -517,6 +521,7 @@ class Account {
 
   /**
    * Save paths to path map.
+   * @param {Number} b - wallet id
    * @param {Path[]} rings
    * @returns {Promise}
    */
@@ -527,6 +532,7 @@ class Account {
 
   /**
    * Initialize address depths (including lookahead).
+   * @param {Number} b - wallet id
    * @returns {Promise}
    */
 
@@ -562,6 +568,7 @@ class Account {
 
   /**
    * Allocate new lookahead addresses if necessary.
+   * @param {Number} b - wallet id
    * @param {Number} receiveDepth
    * @param {Number} changeDepth
    * @param {Number} nestedDepth
@@ -628,6 +635,7 @@ class Account {
 
   /**
    * Allocate new lookahead addresses.
+   * @param {Number} b - wallet id
    * @param {Number} lookahead
    * @returns {Promise}
    */


### PR DESCRIPTION
It looks like these functions were updated during a refactor but the docstrings were not.
This pull request adds the missing param to each docstring