### PR TITLE
export buffer for browser clients

### DIFF
--- a/lib/bcoin-browser.js
+++ b/lib/bcoin-browser.js
@@ -112,7 +112,7 @@ bcoin.Witness = require('./script/witness');
 // Utils
 bcoin.utils = require('./utils');
 bcoin.util = require('./utils/util');
-bcoin.Buffer = require('buffer/').Buffer
+bcoin.Buffer = require('buffer/').Buffer;
 
 // Wallet
 bcoin.wallet = require('./wallet');

--- a/lib/bcoin-browser.js
+++ b/lib/bcoin-browser.js
@@ -112,6 +112,7 @@ bcoin.Witness = require('./script/witness');
 // Utils
 bcoin.utils = require('./utils');
 bcoin.util = require('./utils/util');
+bcoin.Buffer = require('buffer/').Buffer
 
 // Wallet
 bcoin.wallet = require('./wallet');


### PR DESCRIPTION
As a developer creating a client that runs off of the bcoin js client side (browser) lib, there is a need for me to have access to the Buffer class, as several methods in the bcoin library take Buffers as parameters. 
In my case, I am actually utilizing the client side lib to run in a native iOS app and trying to find another way to bundle in the Buffer library would be difficult. 
Instead, since the Buffer library is already imported into your project, I have added a single line to expose the Buffer library to outside parties, like myself. 
Please consider this PR for ease of use and integration of the client side library.
Thanks