### PR TITLE
Fixes pool.getBroadcasted() error item.hash is not a function

### DIFF
--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -955,7 +955,7 @@ class Pool extends EventEmitter {
     this.logger.debug(
       'Peer requested %s %h as a %s packet (%s).',
       item.isTX() ? 'tx' : 'block',
-      item.hash(),
+      item.hash,
       item.hasWitness() ? 'witness' : 'normal',
       peer.hostname());
 


### PR DESCRIPTION
This issue was uncovered by @OrfeasLitos in progress of writing [this guide](https://github.com/bcoin-org/bcoin-org.github.io/pull/107), in which an error is thrown when a peer requests a transaction from the inventory:

`[D:2018-08-27T19:15:36Z] (net) Error: item.hash is not a function (127.0.0.1:55362)`

The bug was introduced 20 days ago in https://github.com/bcoin-org/bcoin/commit/a0ac953079a5ce09eb23828239ed5ab70b975f0f and prevents all transaction broadcasting to peers!

Thanks to @tuxcanfly for finding the bug and checking for other occurrences (none found yet!)

Test is a little funny but it's the only way I could figure to hit that exact line.