### PR TITLE
wallet: add --no-node option for offline usage

### DIFF
--- a/lib/wallet/node.js
+++ b/lib/wallet/node.js
@@ -29,15 +29,18 @@ class WalletNode extends Node {
     super('bcoin', 'wallet.conf', 'wallet.log', options);
 
     this.opened = false;
+    this.client = null;
 
-    this.client = new Client({
-      network: this.network,
-      url: this.config.str('node-url'),
-      host: this.config.str('node-host'),
-      port: this.config.uint('node-port', this.network.rpcPort),
-      ssl: this.config.bool('node-ssl'),
-      apiKey: this.config.str('node-api-key')
-    });
+    if (!this.config.bool('no-node', false)) {
+      this.client = new Client({
+        network: this.network,
+        url: this.config.str('node-url'),
+        host: this.config.str('node-host'),
+        port: this.config.uint('node-port', this.network.rpcPort),
+        ssl: this.config.bool('node-ssl'),
+        apiKey: this.config.str('node-api-key')
+      });
+   }
 
     this.wdb = new WalletDB({
       network: this.network,


### PR DESCRIPTION
This PR addresses https://github.com/bcoin-org/bcoin/issues/471 and replaces https://github.com/bcoin-org/bcoin/pull/583 which was way overkill! Thanks to @nodar-chkuaselidze for the revelation there :-)

This PR simply adds the option `--no-node` to `bwallet`. When `true`, bwallet uses `client=null` (`wdb` then creates its own `nullclient`), so there are no attempts to connect to a running bcoin node, and the log stays nice and clean. None of this:

```
[error] (node) Timed out waiting for connection. Reconnecting...
[error] (node) Network error: ws://localhost:48332/socket.io/?transport=websocket: connect ECONNREFUSED 127.0.0.1:48332
```