### PR TITLE
http: identify log messages as node-http and wallet-http

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -39,7 +39,7 @@ class HTTP extends Server {
     super(new HTTPOptions(options));
 
     this.network = this.options.network;
-    this.logger = this.options.logger.context('http');
+    this.logger = this.options.logger.context('node-http');
     this.node = this.options.node;
 
     this.chain = this.node.chain;

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -146,11 +146,6 @@ class RPC extends RPCBase {
     }
   }
 
-  handleError(err) {
-    this.logger.error('RPC internal error.');
-    this.logger.error(err);
-  }
-
   init() {
     this.add('stop', this.stop);
     this.add('help', this.help);

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -100,7 +100,7 @@ class RPC extends RPCBase {
     this.pool = node.pool;
     this.fees = node.fees;
     this.miner = node.miner;
-    this.logger = node.logger.context('rpc');
+    this.logger = node.logger.context('node-rpc');
     this.locker = new Lock();
 
     this.mining = false;

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -42,7 +42,7 @@ class HTTP extends Server {
     super(new HTTPOptions(options));
 
     this.network = this.options.network;
-    this.logger = this.options.logger.context('http');
+    this.logger = this.options.logger.context('wallet-http');
     this.wdb = this.options.node.wdb;
     this.rpc = this.options.node.rpc;
 

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -89,7 +89,7 @@ class RPC extends RPCBase {
 
     this.wdb = node.wdb;
     this.network = node.network;
-    this.logger = node.logger.context('rpc');
+    this.logger = node.logger.context('wallet-rpc');
     this.client = node.client;
     this.locker = new Lock();
 

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -113,6 +113,15 @@ class RPC extends RPCBase {
     }
   }
 
+  handleCall(cmd, query) {
+    this.logger.debug('Handling RPC call: %s.', cmd.method);
+  }
+
+  handleError(err) {
+    this.logger.error('RPC internal error.');
+    this.logger.error(err);
+  }
+
   init() {
     this.add('help', this.help);
     this.add('stop', this.stop);

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -117,11 +117,6 @@ class RPC extends RPCBase {
     this.logger.debug('Handling RPC call: %s.', cmd.method);
   }
 
-  handleError(err) {
-    this.logger.error('RPC internal error.');
-    this.logger.error(err);
-  }
-
   init() {
     this.add('help', this.help);
     this.add('stop', this.stop);


### PR DESCRIPTION
I dunno if this helpful for anyone else, but when playing with socket testing I noticed that both wallet and node http servers report some identical messages like `(http) Successful auth from 127.0.0.1.` but I wasn't sure which server I was hitting.

This PR simply changes the log context identifiers to `node-http` and `wallet-http` instead of just `http`