### PR TITLE
Wallet: support import of x/y/zpubkey

### DIFF
--- a/lib/hd/private.js
+++ b/lib/hd/private.js
@@ -42,7 +42,7 @@ class HDPrivateKey {
    * Create an hd private key.
    * @constructor
    * @param {Object|String} options
-   * @param {string} options.keyType
+   * @param {string} options.purpose
    * @param {Number?} options.depth
    * @param {Number?} options.parentFingerPrint
    * @param {Number?} options.childIndex
@@ -51,7 +51,7 @@ class HDPrivateKey {
    */
 
   constructor(options) {
-    this.keyType = 'x';
+    this.purpose = 'x';
     this.depth = 0;
     this.parentFingerPrint = 0;
     this.childIndex = 0;
@@ -81,14 +81,14 @@ class HDPrivateKey {
     assert(Buffer.isBuffer(options.chainCode));
     assert(Buffer.isBuffer(options.privateKey));
 
-    if (options.keyType){
+    if (options.purpose) {
       assert(
-        ['x','y','z'].indexOf(options.keyType) !== -1,
-        'Bad key type'
+        ['x','y','z'].indexOf(options.purpose) !== -1,
+        'Bad purpose'
       );
-      this.keyType = options.keyType;
+      this.purpose = options.purpose;
     } else {
-      this.keyType = 'x';
+      this.purpose = 'x';
     }
 
     this.depth = options.depth;
@@ -121,7 +121,7 @@ class HDPrivateKey {
 
     if (!key) {
       key = new HDPublicKey();
-      key.keyType = this.keyType;
+      key.purpose = this.purpose;
       key.depth = this.depth;
       key.parentFingerPrint = this.parentFingerPrint;
       key.childIndex = this.childIndex;
@@ -231,7 +231,7 @@ class HDPrivateKey {
     }
 
     const child = new this.constructor();
-    child.keyType = this.keyType;
+    child.purpose = this.purpose;
     child.depth = this.depth + 1;
     child.parentFingerPrint = this.fingerPrint;
     child.childIndex = index;
@@ -450,7 +450,7 @@ class HDPrivateKey {
     if (!secp256k1.privateKeyVerify(left))
       throw new Error('Master private key is invalid.');
 
-    this.keyType = 'x';
+    this.purpose = 'x';
     this.depth = 0;
     this.parentFingerPrint = 0;
     this.childIndex = 0;
@@ -578,30 +578,28 @@ class HDPrivateKey {
 
   fromReader(br, network) {
     const version = br.readU32BE();
-
     const confirmNetwork = Network.fromPrivate(version, network);
-    
-    let type = null;
-    for (const label in confirmNetwork.keyPrefix){
-      if (confirmNetwork.keyPrefix[label] === version){
-        type = label;
+
+    let purpose = null;
+    for (const label in confirmNetwork.keyPrefix) {
+      if (confirmNetwork.keyPrefix[label] === version) {
+        purpose = label;
         break;
       }
     }
 
-    switch (type) {
+    switch (purpose) {
       case 'xprivkey':
-        this.keyType = 'x';
+        this.purpose = 'x';
         break;
       case 'yprivkey':
-        this.keyType = 'y';
+        this.purpose = 'y';
         break;
       case 'zprivkey':
-        this.keyType = 'z';
+        this.purpose = 'z';
         break;
       default:
-        throw new Error('Bad version/type bytes');
-        break;
+        throw new Error('Bad purpose bytes');
     }
 
     this.depth = br.readU8();
@@ -656,16 +654,16 @@ class HDPrivateKey {
   toWriter(bw, network) {
     network = Network.get(network);
 
-    switch (this.keyType) {
+    switch (this.purpose) {
+      case 'x':
+        bw.writeU32BE(network.keyPrefix.xprivkey);
+        break;
       case 'y':
         bw.writeU32BE(network.keyPrefix.yprivkey);
         break;
       case 'z':
         bw.writeU32BE(network.keyPrefix.zprivkey);
         break;
-      case 'x':
-      default:
-        bw.writeU32BE(network.keyPrefix.xprivkey);
     }
     bw.writeU8(this.depth);
     bw.writeU32BE(this.parentFingerPrint);

--- a/lib/hd/private.js
+++ b/lib/hd/private.js
@@ -42,6 +42,7 @@ class HDPrivateKey {
    * Create an hd private key.
    * @constructor
    * @param {Object|String} options
+   * @param {string} options.keyType
    * @param {Number?} options.depth
    * @param {Number?} options.parentFingerPrint
    * @param {Number?} options.childIndex
@@ -50,6 +51,7 @@ class HDPrivateKey {
    */
 
   constructor(options) {
+    this.keyType = 'x';
     this.depth = 0;
     this.parentFingerPrint = 0;
     this.childIndex = 0;
@@ -78,6 +80,16 @@ class HDPrivateKey {
     assert((options.childIndex >>> 0) === options.childIndex);
     assert(Buffer.isBuffer(options.chainCode));
     assert(Buffer.isBuffer(options.privateKey));
+
+    if (options.keyType){
+      assert(
+        ['x','y','z'].indexOf(options.keyType) !== -1,
+        'Bad key type'
+      );
+      this.keyType = options.keyType;
+    } else {
+      this.keyType = 'x';
+    }
 
     this.depth = options.depth;
     this.parentFingerPrint = options.parentFingerPrint;
@@ -109,6 +121,7 @@ class HDPrivateKey {
 
     if (!key) {
       key = new HDPublicKey();
+      key.keyType = this.keyType;
       key.depth = this.depth;
       key.parentFingerPrint = this.parentFingerPrint;
       key.childIndex = this.childIndex;
@@ -218,6 +231,7 @@ class HDPrivateKey {
     }
 
     const child = new this.constructor();
+    child.keyType = this.keyType;
     child.depth = this.depth + 1;
     child.parentFingerPrint = this.fingerPrint;
     child.childIndex = index;
@@ -436,6 +450,7 @@ class HDPrivateKey {
     if (!secp256k1.privateKeyVerify(left))
       throw new Error('Master private key is invalid.');
 
+    this.keyType = 'x';
     this.depth = 0;
     this.parentFingerPrint = 0;
     this.childIndex = 0;
@@ -564,7 +579,30 @@ class HDPrivateKey {
   fromReader(br, network) {
     const version = br.readU32BE();
 
-    Network.fromPrivate(version, network);
+    const confirmNetwork = Network.fromPrivate(version, network);
+    
+    let type = null;
+    for (const label in confirmNetwork.keyPrefix){
+      if (confirmNetwork.keyPrefix[label] === version){
+        type = label;
+        break;
+      }
+    }
+
+    switch (type) {
+      case 'xprivkey':
+        this.keyType = 'x';
+        break;
+      case 'yprivkey':
+        this.keyType = 'y';
+        break;
+      case 'zprivkey':
+        this.keyType = 'z';
+        break;
+      default:
+        throw new Error('Bad version/type bytes');
+        break;
+    }
 
     this.depth = br.readU8();
     this.parentFingerPrint = br.readU32BE();
@@ -618,7 +656,17 @@ class HDPrivateKey {
   toWriter(bw, network) {
     network = Network.get(network);
 
-    bw.writeU32BE(network.keyPrefix.xprivkey);
+    switch (this.keyType) {
+      case 'y':
+        bw.writeU32BE(network.keyPrefix.yprivkey);
+        break;
+      case 'z':
+        bw.writeU32BE(network.keyPrefix.zprivkey);
+        break;
+      case 'x':
+      default:
+        bw.writeU32BE(network.keyPrefix.xprivkey);
+    }
     bw.writeU8(this.depth);
     bw.writeU32BE(this.parentFingerPrint);
     bw.writeU32BE(this.childIndex);

--- a/lib/hd/public.js
+++ b/lib/hd/public.js
@@ -34,7 +34,7 @@ class HDPublicKey {
    * @constructor
    * @param {Object|Base58String} options
    * @param {Base58String?} options.xkey - Serialized base58 key.
-   * @param {string} options.keyType
+   * @param {string} options.purpose
    * @param {Number?} options.depth
    * @param {Number?} options.parentFingerPrint
    * @param {Number?} options.childIndex
@@ -43,7 +43,7 @@ class HDPublicKey {
    */
 
   constructor(options) {
-    this.keyType = 'x';
+    this.purpose = 'x';
     this.depth = 0;
     this.parentFingerPrint = 0;
     this.childIndex = 0;
@@ -70,14 +70,14 @@ class HDPublicKey {
     assert(Buffer.isBuffer(options.chainCode));
     assert(Buffer.isBuffer(options.publicKey));
 
-    if (options.keyType){
+    if (options.purpose) {
       assert(
-        ['x','y','z'].indexOf(options.keyType) !== -1,
-        'Bad key type'
+        ['x','y','z'].indexOf(options.purpose) !== -1,
+        'Bad purpose'
       );
-      this.keyType = options.keyType;
+      this.purpose = options.purpose;
     } else {
-      this.keyType = 'x';
+      this.purpose = 'x';
     }
 
     this.depth = options.depth;
@@ -448,27 +448,26 @@ class HDPublicKey {
 
     const confirmNetwork = Network.fromPublic(version, network);
 
-    let type = null;
-    for (const label in confirmNetwork.keyPrefix){
-      if (confirmNetwork.keyPrefix[label] === version){
-        type = label;
+    let purpose = null;
+    for (const label in confirmNetwork.keyPrefix) {
+      if (confirmNetwork.keyPrefix[label] === version) {
+        purpose = label;
         break;
       }
     }
 
-    switch (type) {
+    switch (purpose) {
       case 'xpubkey':
-        this.keyType = 'x';
+        this.purpose = 'x';
         break;
       case 'ypubkey':
-        this.keyType = 'y';
+        this.purpose = 'y';
         break;
       case 'zpubkey':
-        this.keyType = 'z';
+        this.purpose = 'z';
         break;
       default:
-        throw new Error('Bad version/type bytes');
-        break;
+        throw new Error('Bad purpose bytes');
     }
 
     this.depth = br.readU8();
@@ -507,22 +506,22 @@ class HDPublicKey {
    * Write the key to a buffer writer.
    * @param {BufferWriter} bw
    * @param {(Network|NetworkType)?} network
-   * @param {string} type 
+   * @param {string} type
    */
 
   toWriter(bw, network) {
     network = Network.get(network);
 
-    switch (this.keyType) {
+    switch (this.purpose) {
+      case 'x':
+        bw.writeU32BE(network.keyPrefix.xpubkey);
+        break;
       case 'y':
         bw.writeU32BE(network.keyPrefix.ypubkey);
         break;
       case 'z':
         bw.writeU32BE(network.keyPrefix.zpubkey);
         break;
-      case 'x':
-      default:
-        bw.writeU32BE(network.keyPrefix.xpubkey);
     }
     bw.writeU8(this.depth);
     bw.writeU32BE(this.parentFingerPrint);

--- a/lib/hd/public.js
+++ b/lib/hd/public.js
@@ -34,6 +34,7 @@ class HDPublicKey {
    * @constructor
    * @param {Object|Base58String} options
    * @param {Base58String?} options.xkey - Serialized base58 key.
+   * @param {string} options.keyType
    * @param {Number?} options.depth
    * @param {Number?} options.parentFingerPrint
    * @param {Number?} options.childIndex
@@ -42,6 +43,7 @@ class HDPublicKey {
    */
 
   constructor(options) {
+    this.keyType = 'x';
     this.depth = 0;
     this.parentFingerPrint = 0;
     this.childIndex = 0;
@@ -67,6 +69,16 @@ class HDPublicKey {
     assert((options.childIndex >>> 0) === options.childIndex);
     assert(Buffer.isBuffer(options.chainCode));
     assert(Buffer.isBuffer(options.publicKey));
+
+    if (options.keyType){
+      assert(
+        ['x','y','z'].indexOf(options.keyType) !== -1,
+        'Bad key type'
+      );
+      this.keyType = options.keyType;
+    } else {
+      this.keyType = 'x';
+    }
 
     this.depth = options.depth;
     this.parentFingerPrint = options.parentFingerPrint;
@@ -434,7 +446,30 @@ class HDPublicKey {
   fromReader(br, network) {
     const version = br.readU32BE();
 
-    Network.fromPublic(version, network);
+    const confirmNetwork = Network.fromPublic(version, network);
+
+    let type = null;
+    for (const label in confirmNetwork.keyPrefix){
+      if (confirmNetwork.keyPrefix[label] === version){
+        type = label;
+        break;
+      }
+    }
+
+    switch (type) {
+      case 'xpubkey':
+        this.keyType = 'x';
+        break;
+      case 'ypubkey':
+        this.keyType = 'y';
+        break;
+      case 'zpubkey':
+        this.keyType = 'z';
+        break;
+      default:
+        throw new Error('Bad version/type bytes');
+        break;
+    }
 
     this.depth = br.readU8();
     this.parentFingerPrint = br.readU32BE();
@@ -472,12 +507,23 @@ class HDPublicKey {
    * Write the key to a buffer writer.
    * @param {BufferWriter} bw
    * @param {(Network|NetworkType)?} network
+   * @param {string} type 
    */
 
   toWriter(bw, network) {
     network = Network.get(network);
 
-    bw.writeU32BE(network.keyPrefix.xpubkey);
+    switch (this.keyType) {
+      case 'y':
+        bw.writeU32BE(network.keyPrefix.ypubkey);
+        break;
+      case 'z':
+        bw.writeU32BE(network.keyPrefix.zpubkey);
+        break;
+      case 'x':
+      default:
+        bw.writeU32BE(network.keyPrefix.xpubkey);
+    }
     bw.writeU8(this.depth);
     bw.writeU32BE(this.parentFingerPrint);
     bw.writeU32BE(this.childIndex);

--- a/lib/primitives/keyring.js
+++ b/lib/primitives/keyring.js
@@ -160,6 +160,7 @@ class KeyRing {
     assert(Buffer.isBuffer(key), 'Public key must be a buffer.');
     assert(secp256k1.publicKeyVerify(key), 'Not a valid public key.');
     this.publicKey = key;
+
     return this;
   }
 
@@ -591,7 +592,7 @@ class KeyRing {
    */
 
   getAddress(enc, network) {
-    if (this.nested)
+    if (this.nested || this.addressFromKeyType === 'y')
       return this.getNestedAddress(enc, network);
 
     if (this.script)

--- a/lib/primitives/keyring.js
+++ b/lib/primitives/keyring.js
@@ -592,7 +592,7 @@ class KeyRing {
    */
 
   getAddress(enc, network) {
-    if (this.nested || this.addressFromKeyType === 'y')
+    if (this.nested || this.purpose === 'y')
       return this.getNestedAddress(enc, network);
 
     if (this.script)

--- a/lib/protocol/network.js
+++ b/lib/protocol/network.js
@@ -402,19 +402,35 @@ function cmpWIF(network, prefix) {
 }
 
 function cmpPub(network, prefix) {
-  return network.keyPrefix.xpubkey === prefix;
+  return (
+    network.keyPrefix.xpubkey === prefix ||
+    network.keyPrefix.ypubkey === prefix ||
+    network.keyPrefix.zpubkey === prefix
+  );
 }
 
 function cmpPriv(network, prefix) {
-  return network.keyPrefix.xprivkey === prefix;
+  return (
+    network.keyPrefix.xprivkey === prefix ||
+    network.keyPrefix.yprivkey === prefix ||
+    network.keyPrefix.zprivkey === prefix
+  );
 }
 
 function cmpPub58(network, prefix) {
-  return network.keyPrefix.xpubkey58 === prefix;
+  return (
+    network.keyPrefix.xpubkey58 === prefix ||
+    network.keyPrefix.ypubkey58 === prefix ||
+    network.keyPrefix.zpubkey58 === prefix
+  );
 }
 
 function cmpPriv58(network, prefix) {
-  return network.keyPrefix.xprivkey58 === prefix;
+  return (
+    network.keyPrefix.xprivkey58 === prefix ||
+    network.keyPrefix.yprivkey58 === prefix ||
+    network.keyPrefix.zprivkey58 === prefix
+  );
 }
 
 function cmpAddress(network, prefix) {

--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -416,10 +416,22 @@ main.deploys = [
 
 main.keyPrefix = {
   privkey: 0x80,
+
   xpubkey: 0x0488b21e,
   xprivkey: 0x0488ade4,
   xpubkey58: 'xpub',
   xprivkey58: 'xprv',
+  // P2WPKH in P2SH
+  ypubkey: 0x049d7cb2,
+  yprivkey: 0x049d7878,
+  ypubkey58: 'ypub',
+  yprivkey58: 'yprv',
+  // P2WSH
+  zpubkey: 0x04b24746,
+  zprivkey: 0x04b2430c,
+  zpubkey58: 'ypub',
+  zprivkey58: 'yprv',
+
   coinType: 0
 };
 
@@ -675,10 +687,22 @@ testnet.deploys = [
 
 testnet.keyPrefix = {
   privkey: 0xef,
+
   xpubkey: 0x043587cf,
   xprivkey: 0x04358394,
   xpubkey58: 'tpub',
   xprivkey58: 'tprv',
+  // P2WPKH in P2SH -- note variable name (x, y, z) vs actual (t, u, v)
+  ypubkey: 0x044a5262,
+  yprivkey: 0x044a4e28,
+  ypubkey58: 'upub',
+  yprivkey58: 'uprv',
+  // P2WPKH -- note variable name (x, y, z) vs actual (t, u, v)
+  zpubkey: 0x045f1cf6,
+  zprivkey: 0x045f18bc,
+  zpubkey58: 'vpub',
+  zprivkey58: 'vprv',
+
   coinType: 1
 };
 
@@ -839,10 +863,24 @@ regtest.deploys = [
 
 regtest.keyPrefix = {
   privkey: 0x5a,
+
   xpubkey: 0xeab4fa05,
   xprivkey: 0xeab404c7,
   xpubkey58: 'rpub',
   xprivkey58: 'rprv',
+
+  // copying testnet for now although bcoin normally does not
+  // P2WPKH in P2SH -- note variable name (x, y, z) vs actual (t, u, v)
+  ypubkey: 0x044a5262,
+  yprivkey: 0x044a4e28,
+  ypubkey58: 'upub',
+  yprivkey58: 'uprv',
+  // P2WPKH -- note variable name (x, y, z) vs actual (t, u, v)
+  zpubkey: 0x045f1cf6,
+  zprivkey: 0x045f18bc,
+  zpubkey58: 'vpub',
+  zprivkey58: 'vprv',
+
   coinType: 1
 };
 

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -44,6 +44,7 @@ class Account {
     this.initialized = false;
     this.witness = wdb.options.witness === true;
     this.watchOnly = false;
+    this.keyType = 'x',
     this.type = Account.types.PUBKEYHASH;
     this.m = 1;
     this.n = 1;
@@ -100,6 +101,18 @@ class Account {
       assert(typeof options.watchOnly === 'boolean');
       this.watchOnly = options.watchOnly;
     }
+
+    if (options.keyType != null) {
+      assert(typeof options.keyType === 'string');
+      assert(
+        ['x','y','z'].indexOf(options.keyType) !== -1,
+        'Bad key type'
+      );
+      this.keyType = options.keyType;
+    }
+
+    if (this.keyType === 'y' || this.keyType === 'z')
+      this.witness = true;
 
     if (options.type != null) {
       if (typeof options.type === 'string') {
@@ -467,13 +480,26 @@ class Account {
 
     let key;
     if (master && master.key && !this.watchOnly) {
-      const type = this.network.keyPrefix.coinType;
-      key = master.key.deriveAccount(44, type, this.accountIndex);
+      const coinType = this.network.keyPrefix.coinType;
+      
+      switch (this.keyType) {
+        case 'x':
+          key = master.key.deriveAccount(44, coinType, this.accountIndex);
+          break;
+        case 'y':
+          key = master.key.deriveAccount(49, coinType, this.accountIndex);
+          break;
+        case 'z':
+          key = master.key.deriveAccount(84, coinType, this.accountIndex);
+          break;
+      }
+
       key = key.derive(branch).derive(index);
     } else {
       key = this.accountKey.derive(branch).derive(index);
     }
 
+    key.keyType = this.keyType;
     const ring = WalletKey.fromHD(this, key, branch, index);
 
     switch (this.type) {
@@ -536,6 +562,9 @@ class Account {
 
     for (let i = 0; i <= this.lookahead; i++) {
       const key = this.deriveReceive(i);
+
+console.log(key);  // ------ right here, the address is correct (nested)
+
       await this.saveKey(b, key);
     }
 

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -44,7 +44,7 @@ class Account {
     this.initialized = false;
     this.witness = wdb.options.witness === true;
     this.watchOnly = false;
-    this.keyType = 'x',
+    this.purpose = 'x',
     this.type = Account.types.PUBKEYHASH;
     this.m = 1;
     this.n = 1;
@@ -102,16 +102,16 @@ class Account {
       this.watchOnly = options.watchOnly;
     }
 
-    if (options.keyType != null) {
-      assert(typeof options.keyType === 'string');
+    if (options.purpose != null) {
+      assert(typeof options.purpose === 'string');
       assert(
-        ['x','y','z'].indexOf(options.keyType) !== -1,
-        'Bad key type'
+        ['x','y','z'].indexOf(options.purpose) !== -1,
+        'Bad purpose'
       );
-      this.keyType = options.keyType;
+      this.purpose = options.purpose;
     }
 
-    if (this.keyType === 'y' || this.keyType === 'z')
+    if (this.purpose === 'y' || this.purpose === 'z')
       this.witness = true;
 
     if (options.type != null) {
@@ -481,8 +481,8 @@ class Account {
     let key;
     if (master && master.key && !this.watchOnly) {
       const coinType = this.network.keyPrefix.coinType;
-      
-      switch (this.keyType) {
+
+      switch (this.purpose) {
         case 'x':
           key = master.key.deriveAccount(44, coinType, this.accountIndex);
           break;
@@ -499,7 +499,7 @@ class Account {
       key = this.accountKey.derive(branch).derive(index);
     }
 
-    key.keyType = this.keyType;
+    key.purpose = this.purpose;
     const ring = WalletKey.fromHD(this, key, branch, index);
 
     switch (this.type) {
@@ -562,9 +562,6 @@ class Account {
 
     for (let i = 0; i <= this.lookahead; i++) {
       const key = this.deriveReceive(i);
-
-console.log(key);  // ------ right here, the address is correct (nested)
-
       await this.saveKey(b, key);
     }
 
@@ -892,6 +889,9 @@ console.log(key);  // ------ right here, the address is correct (nested)
     if (this.witness)
       flags |= 2;
 
+    const purposeBits = Account.purposes[this.purpose];
+    flags |= (purposeBits << 6);
+
     bw.writeU8(flags);
     bw.writeU8(this.type);
     bw.writeU8(this.m);
@@ -920,6 +920,9 @@ console.log(key);  // ------ right here, the address is correct (nested)
     const br = bio.read(data);
     const flags = br.readU8();
 
+    const purposeBits = flags >> 6;
+    this.purpose = Account.purposesByVal[purposeBits];
+
     this.initialized = (flags & 1) !== 0;
     this.witness = (flags & 2) !== 0;
     this.type = br.readU8();
@@ -930,7 +933,6 @@ console.log(key);  // ------ right here, the address is correct (nested)
     this.nestedDepth = br.readU32();
     this.lookahead = br.readU8();
     this.accountKey = readKey(br);
-
     assert(this.type < Account.typesByVal.length);
 
     const count = br.readU8();
@@ -985,6 +987,26 @@ Account.typesByVal = [
   'PUBKEYHASH',
   'MULTISIG'
 ];
+
+/**
+ * Account purposes.
+ * @enum {Number}
+ * @default
+ */
+
+Account.purposes = {
+  x: 0,
+  y: 1,
+  z: 2
+};
+
+/**
+ * Account purposes by value.
+ * @enum {Number}
+ * @default
+ */
+
+Account.purposesByVal = ['x', 'y', 'z'];
 
 /**
  * Default address lookahead.

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -56,7 +56,7 @@ class Wallet extends EventEmitter {
     this.writeLock = new Lock();
     this.fundLock = new Lock();
 
-    this.keyType = 'x';
+    this.purpose = 'x';
     this.wid = 0;
     this.id = null;
     this.watchOnly = false;
@@ -91,7 +91,7 @@ class Wallet extends EventEmitter {
       assert(HD.isPrivate(key),
         'Must create wallet with hd private key.');
 
-      this.keyType = key.keyType;
+      this.purpose = key.purpose;
     } else {
       mnemonic = new Mnemonic(options.mnemonic);
       key = HD.fromMnemonic(mnemonic, options.password);
@@ -587,11 +587,11 @@ class Wallet extends EventEmitter {
       if (!HD.isPublic(key))
         throw new Error('Must add HD public keys to watch only wallet.');
 
-      this.keyType = key.keyType;
+      this.purpose = key.purpose;
     } else {
       assert(this.master.key);
       const coinType = this.network.keyPrefix.coinType;
-      switch (this.keyType) {
+      switch (this.purpose) {
         case 'x':
           key = this.master.key.deriveAccount(44, coinType, this.accountDepth);
           break;
@@ -614,7 +614,7 @@ class Wallet extends EventEmitter {
       accountKey: key,
       accountIndex: this.accountDepth,
       type: options.type,
-      keyType: this.keyType,
+      purpose: this.purpose,
       m: options.m,
       n: options.n,
       keys: options.keys

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -56,6 +56,7 @@ class Wallet extends EventEmitter {
     this.writeLock = new Lock();
     this.fundLock = new Lock();
 
+    this.keyType = 'x';
     this.wid = 0;
     this.id = null;
     this.watchOnly = false;
@@ -89,6 +90,8 @@ class Wallet extends EventEmitter {
 
       assert(HD.isPrivate(key),
         'Must create wallet with hd private key.');
+
+      this.keyType = key.keyType;
     } else {
       mnemonic = new Mnemonic(options.mnemonic);
       key = HD.fromMnemonic(mnemonic, options.password);
@@ -583,10 +586,22 @@ class Wallet extends EventEmitter {
 
       if (!HD.isPublic(key))
         throw new Error('Must add HD public keys to watch only wallet.');
+
+      this.keyType = key.keyType;
     } else {
       assert(this.master.key);
-      const type = this.network.keyPrefix.coinType;
-      key = this.master.key.deriveAccount(44, type, this.accountDepth);
+      const coinType = this.network.keyPrefix.coinType;
+      switch (this.keyType) {
+        case 'x':
+          key = this.master.key.deriveAccount(44, coinType, this.accountDepth);
+          break;
+        case 'y':
+          key = this.master.key.deriveAccount(49, coinType, this.accountDepth);
+          break;
+        case 'z':
+          key = this.master.key.deriveAccount(84, coinType, this.accountDepth);
+          break;
+        }
       key = key.toPublic();
     }
 
@@ -599,6 +614,7 @@ class Wallet extends EventEmitter {
       accountKey: key,
       accountIndex: this.accountDepth,
       type: options.type,
+      keyType: this.keyType,
       m: options.m,
       n: options.n,
       keys: options.keys

--- a/lib/wallet/walletkey.js
+++ b/lib/wallet/walletkey.js
@@ -68,6 +68,7 @@ class WalletKey extends KeyRing {
    */
 
   fromHD(account, key, branch, index) {
+    this.addressFromKeyType = key.keyType;
     this.keyType = Path.types.HD;
     this.name = account.name;
     this.account = account.accountIndex;

--- a/lib/wallet/walletkey.js
+++ b/lib/wallet/walletkey.js
@@ -68,7 +68,7 @@ class WalletKey extends KeyRing {
    */
 
   fromHD(account, key, branch, index) {
-    this.addressFromKeyType = key.keyType;
+    this.purpose = key.purpose;
     this.keyType = Path.types.HD;
     this.name = account.name;
     this.account = account.accountIndex;

--- a/test/data/hd.json
+++ b/test/data/hd.json
@@ -53,6 +53,24 @@
       "prv": "xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j"
     }
   },
+  "xyz": {
+    "phrase": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+    "x": {
+      "path": "m'/44'/0'/0'",
+      "xprv": "xprv9xpXFhFpqdQK3TmytPBqXtGSwS3DLjojFhTGht8gwAAii8py5X6pxeBnQ6ehJiyJ6nDjWGJfZ95WxByFXVkDxHXrqu53WCRGypk2ttuqncb",
+      "xpub": "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj"
+    },
+    "y": {
+      "path": "m/49'/0'/0'",
+      "yprv": "yprvAHwhK6RbpuS3dgCYHM5jc2ZvEKd7Bi61u9FVhYMpgMSuZS613T1xxQeKTffhrHY79hZ5PsskBjcc6C2V7DrnsMsNaGDaWev3GLRQRgV7hxF",
+      "ypub": "ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP"
+    },    
+    "z": {
+      "path": "m/84'/0'/0'",
+      "zprv": "zprvAdG4iTXWBoARxkkzNpNh8r6Qag3irQB8PzEMkAFeTRXxHpbF9z4QgEvBRmfvqWvGp42t42nvgGpNgYSJA9iefm1yYNZKEm7z6qUWCroSQnE",
+      "zpub": "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs"
+    }
+  },
   "phrase": "volume doll flush federal inflict tomato result property total curtain shield aisle",
   "seed": "5559092716434b83f158bffb51337a944529ae30d7e62d46d3be0c66fa4b36e8d60ccfd2c976b831885dc9df9ac3716ee4bf90003f25621070a49cbea58f528b",
   "master_priv": "xprv9s21ZrQH143K35zTejeVRhkXgegDFUVpoh8Mxs2BQmXEB4w9SZ1CuoJPuQ2KGQrS1ZF3Pk7V7KWHn7FqR2JbAE9Bh8PURnrFnrmArj4kxos",

--- a/test/hd-test.js
+++ b/test/hd-test.js
@@ -11,6 +11,7 @@ const HD = require('../lib/hd');
 const vectors = require('./data/hd.json');
 const vector1 = vectors.vector1;
 const vector2 = vectors.vector2;
+const xyz = vectors.xyz;
 
 let master = null;
 let child = null;
@@ -129,4 +130,31 @@ describe('HD', function() {
       });
     }
   }
+
+  // https://github.com/satoshilabs/slips/blob/master/slip-0132.md
+  // #bitcoin-test-vectors
+  it('should derive prv and pub keys for x/y/z types', () => {
+    const mne = HD.Mnemonic.fromPhrase(vectors.xyz.phrase);
+
+    const xkey = HD.PrivateKey.fromMnemonic(mne);
+    xkey.keyType = 'x';
+    const xprv = xkey.derivePath(vectors.xyz.x.path);
+    const xpub = xprv.toPublic();
+    base58Equal(xprv.toBase58('main'), vectors.xyz.x.xprv);
+    base58Equal(xpub.toBase58('main'), vectors.xyz.x.xpub);
+
+    const ykey = HD.PrivateKey.fromMnemonic(mne);
+    ykey.keyType = 'y';
+    const yprv = ykey.derivePath(vectors.xyz.y.path);
+    const ypub = yprv.toPublic();
+    base58Equal(yprv.toBase58('main'), vectors.xyz.y.yprv);
+    base58Equal(ypub.toBase58('main'), vectors.xyz.y.ypub);
+
+    const zkey = HD.PrivateKey.fromMnemonic(mne);
+    zkey.keyType = 'z';
+    const zprv = zkey.derivePath(vectors.xyz.z.path);
+    const zpub = zprv.toPublic();
+    base58Equal(zprv.toBase58('main'), vectors.xyz.z.zprv);
+    base58Equal(zpub.toBase58('main'), vectors.xyz.z.zpub);
+  });
 });

--- a/test/hd-test.js
+++ b/test/hd-test.js
@@ -11,7 +11,6 @@ const HD = require('../lib/hd');
 const vectors = require('./data/hd.json');
 const vector1 = vectors.vector1;
 const vector2 = vectors.vector2;
-const xyz = vectors.xyz;
 
 let master = null;
 let child = null;
@@ -137,21 +136,21 @@ describe('HD', function() {
     const mne = HD.Mnemonic.fromPhrase(vectors.xyz.phrase);
 
     const xkey = HD.PrivateKey.fromMnemonic(mne);
-    xkey.keyType = 'x';
+    xkey.purpose = 'x';
     const xprv = xkey.derivePath(vectors.xyz.x.path);
     const xpub = xprv.toPublic();
     base58Equal(xprv.toBase58('main'), vectors.xyz.x.xprv);
     base58Equal(xpub.toBase58('main'), vectors.xyz.x.xpub);
 
     const ykey = HD.PrivateKey.fromMnemonic(mne);
-    ykey.keyType = 'y';
+    ykey.purpose = 'y';
     const yprv = ykey.derivePath(vectors.xyz.y.path);
     const ypub = yprv.toPublic();
     base58Equal(yprv.toBase58('main'), vectors.xyz.y.yprv);
     base58Equal(ypub.toBase58('main'), vectors.xyz.y.ypub);
 
     const zkey = HD.PrivateKey.fromMnemonic(mne);
-    zkey.keyType = 'z';
+    zkey.purpose = 'z';
     const zprv = zkey.derivePath(vectors.xyz.z.path);
     const zpub = zprv.toPublic();
     base58Equal(zprv.toBase58('main'), vectors.xyz.z.zprv);

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -1318,6 +1318,50 @@ describe('Wallet', function() {
     assert(wkey);
   });
 
+  // https://github.com/satoshilabs/slips/blob/master/slip-0132.md \
+  // #bitcoin-test-vectors
+  it('should import xpubkey', async () => {
+    const wallet = await wdb.create({
+      id: 'xpubtest',
+      watchOnly: true,
+      accountKey:
+      'xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4' +
+      'R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj'
+    });
+
+    const account = await wallet.getAccount(0);
+    const recAddr = account.toJSON().receiveAddress;
+    assert.strictEqual(recAddr, '1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA');
+  });
+
+  it('should import ypubkey', async () => {
+    const wallet = await wdb.create({
+      id: 'ypubtest',
+      watchOnly: true,
+      accountKey:
+      'ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9az' +
+      'LDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP'
+    });
+
+    const account = await wallet.getAccount(0);
+    const recAddr = account.toJSON().receiveAddress;
+    assert.strictEqual(recAddr, '37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf');
+  });
+
+  it('should import zpubkey', async () => {
+    const wallet = await wdb.create({
+      id: 'zpubtest',
+      watchOnly: true,
+      accountKey:
+      'zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhX' +
+      'NfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs'
+    });
+
+    const account = await wallet.getAccount(0);
+    const recAddr = account.toJSON().receiveAddress;
+    assert.strictEqual(recAddr, 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu');
+  });
+
   it('should import address', async () => {
     const key = KeyRing.generate();
 


### PR DESCRIPTION
Addresses https://github.com/bcoin-org/bcoin/issues/606

## Motivation ##
I wanted to create a watch-only bcoin wallet that follows my Trezor wallet. For SegWit users, Trezor created `ypub` and `zpub` version types ([see SLIP32](https://github.com/satoshilabs/slips/blob/master/slip-0132.md)):


Coin                                      | Public Key            | Private Key           | Address Encoding | BIP 32 Path |
------------------------------------------|-----------------------|-----------------------|------------------|-------------|
Bitcoin           | `0x0488b21e` - `xpub` | `0x0488ade4` - `xprv` | P2PKH or P2SH    | m/44'/0'    |
Bitcoin                                   | `0x049d7cb2` - `ypub` | `0x049d7878` - `yprv` | P2WPKH in P2SH   | m/49'/0'    |
Bitcoin                                   | `0x04b24746` - `zpub` | `0x04b2430c` - `zprv` | P2WPKH           | m/84'/0'    |


Currently bcoin only supports `xpub` and in fact all wallets derive accounts and addresses from the path `m/44'` so these new paths would be unreachable.

## Method ##
### Networks ###
I started with the `keyPrefix` object in networks.js to add all the new codes. Note that bcoin uses `xprv` internally for testnet even though those keys are prefixed with `tprv` like so:

```
  "key": {
    "xprivkey": "tprv8ZgxMBicQKsPeXAktk2K3Q92rbVj1C9x6J69knw5e6tiVjRMN9KTTkVAhrvCFLVaYaC8vFhWuLL5nMkE4JTqbZMngnshvDx6LG6dC2y9HSG"
  },
```

I maintain that convention and use x/y/z throughout, even though the actual user-facing prefixes may be different.

### HD private/public key ###
Key objects have a new property `purpose` that is either `x` (default), `y`, or `z`. `purpose` can be passed as an option, but mainly it is derived from an imported extended private or public key, based on the prefix bytes.

### Wallet Account ###
Wallets and Accounts also have a `purpose` that is either passed as an option or derived from the `accountKey` option (for watch-only). This is mostly where the x/y/z/ logic gets switched. Each `purpose` has a specific [BIP44 purpose](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#Purpose) in the derivation path AND specifically dictated address types. For `y` and `z`, `witness` is always `true`. For `y`, addresses are always witness-nested-in-P2SH. Normally these addresses could only be derived on `branch = 2` from a regular wallet. This PR ALWAYS returns nested addresses for receive and change if the account type is `y`. Similarly, `z` wallets always return bech32-encoded native SegWit addresses.

### Serialized Account for database ###
Ok here's where it gets a bit touchy. Accounts are serialized before saving to the database. Currently, all the relevant bits from the `accountKey` are included EXCEPT the header bytes: 
```
toRaw() ... 
    bw.writeU8(flags);
    bw.writeU8(this.type);
    bw.writeU8(this.m);
    bw.writeU8(this.n);
    bw.writeU32(this.receiveDepth);
    bw.writeU32(this.changeDepth);
    bw.writeU32(this.nestedDepth);
    bw.writeU8(this.lookahead);
    writeKey(this.accountKey, bw);
    bw.writeU8(this.keys.length);

writeKey() ...
  bw.writeU8(key.depth);
  bw.writeU32BE(key.parentFingerPrint);
  bw.writeU32BE(key.childIndex);
  bw.writeBytes(key.chainCode);
  bw.writeBytes(key.publicKey);
```
So what I did was, steal the TWO leftmost bits of the `flags` byte and re-purposed them for `purpose`. This means we can only have 4 values for `purpose` and we still have 6 bits for actual flags (of which only two are currently used: `initialized` and `witness`).

```
flags |= (purposeBits << 6);
```

Alternatively, this can be adjusted if we want more future-proof-ness and use less bits for flags and more for `purpose`, etc.

This has the benefit of _some_ backwards-compatibility:
- upgrade old->new bcoin with old wallet: no issues, new features available
- downgrade new->old bcoin with old wallet: no issues, new features not available
- downgrade new->old bcoin with new wallet using `y` or `z`: no failures but `y` and `z` wallets will not derive new addresses correctly (they will derive everything as if it is `purpose = 'x'`)