### PR TITLE
browser: update since refactor

### DIFF
--- a/browser/index.html
+++ b/browser/index.html
@@ -75,7 +75,7 @@
         overflow-y: scroll;
       }
     </style>
-    <script src="/app.js" defer></script>
+    <script src="app.js" defer></script>
   </head>
   <body>
     <h1>Bcoin, the browser full node</h1>

--- a/browser/src/app.js
+++ b/browser/src/app.js
@@ -95,8 +95,7 @@ function show(obj) {
     floating.style.display = 'block';
     return;
   }
-  const json = obj && obj.toJSON ? obj.toJSON() : null;
-  floating.innerHTML = escape(JSON.stringify(json, null, 2));
+  floating.innerHTML = escape(JSON.stringify(obj, null, 2));
   floating.style.display = 'block';
 }
 

--- a/docs/Running-in-the-browser.md
+++ b/docs/Running-in-the-browser.md
@@ -1,16 +1,2 @@
-Because bcoin is written in node.js, it is capable of being browserified.
+This page has been moved to [https://bcoin.io/guides/browser.html](https://bcoin.io/guides/browser.html)
 
-## Running a full node in the browser
-
-``` bash
-$ cd ~/bcoin
-$ make # Browserify bcoin
-$ node browser/server.js 8080 # Start up a simple webserver and websocket->tcp bridge
-$ chromium http://localhost:8080
-```
-
-You should see something like this: http://i.imgur.com/0pWySyZ.png
-
-This is a simple proof-of-concept. It's not a pretty interface. I hope to see
-others doing something far more interesting. A browser extension may be better:
-the chrome extension API exposes raw TCP access.


### PR DESCRIPTION
Tiny fixes are needed to run bcoin in a browser.

The location of the `app.js` file gets confused in some browsers when running locally (Chrome kept trying to access `/app.js` as an absolute path `file:///app.js`)

Since the big refactor this year and use of bclient for RPC calls, the object returned from RPC calls is slightly different and was always being displayed as `null`.

An update to `blgr` is also required for bcoin-in-browser to work:
https://github.com/bcoin-org/blgr/pull/1, which re-adds the method `logger.format()` after it was refactored out a few months ago. This seems to be the cleanest way of restoring the in-page logger functionality.

These changes have been tested on local and a remote server, and functionality has been described in a new bcoin.io guide (pending merge): https://github.com/bcoin-org/bcoin-org.github.io/pull/122 and so I added a second commit (optional) that redirects users to the longer, more detailed guide.
