### PR TITLE
Enable `fundrawtransaction` to take a transaction with more than 0 inputs.

### DIFF
--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1299,7 +1299,8 @@ class MTX extends TX {
    * Select coins and fill the inputs.
    * @param {Coin[]} coins
    * @param {Object} options - See {@link CoinSelector#constructor} options.
-   * @param {Boolean} options.preserveInput - if this is not set, mtx must have empty inputs
+   * @param {Boolean} options.preserveInput - without this,
+   *   the inputs must be empty
    * @returns {CoinSelector}
    */
 
@@ -1575,16 +1576,21 @@ class CoinSelector {
    * @constructor
    * @param {TX} tx
    * @param {Object?} options
-   * @param {String?} options.selection - must be one of 'all', 'random', 'age', 'value'
-   * @param {Number?} options.subtractIndex - subtract fee from an output of this index.
-   * @param {Number?|Boolean?} options.subtractFee - same with subtractIndex if it is `Number`.
-   * @param {Number?} options.height - sometime coin's spendability depends on this (e.g. coinbase maturity)
+   * @param {String?} options.selection - must be one of 'all', 'random',
+   *   'age', 'value'
+   * @param {Number?} options.subtractIndex - subtract fee from an output
+   *   of this index.
+   * @param {Number?|Boolean?} options.subtractFee - same with subtractIndex
+   *   if it is `Number`.
+   * @param {Number?} options.height - sometime coin's spendability depends
+   *   on this (e.g. coinbase maturity)
    * @param {Number?} options.depth - same with above
-   * @param {Number?} options.confirmations - same with above (currently not used)
+   * @param {Number?} options.confirmations - same with above.
    * @param {Amount?} options.hardFee - always use this value as fee.
    * @param {Rate?} options.rate - use this value as fee rate.
    * @param {Amount?} options.maxFee - maximum fee.
-   * @param {Boolean?} options.round - round fee to nearest kB (useful in predictable estimation for testing)
+   * @param {Boolean?} options.round - round fee to nearest kB
+   *   (useful in predictable estimation for testing)
    * @param {String?|Address?} options.changeAddress
    * @param {Input?} options.inputs - tx inputs to prefer. (currently not used)
    */
@@ -1708,7 +1714,7 @@ class CoinSelector {
     }
 
     if (options.preserveInput) {
-      assert(typeof options.preserveInput === "boolean");
+      assert(typeof options.preserveInput === 'boolean');
       this.preserveInput = options.preserveInput;
     }
 

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1306,7 +1306,9 @@ class MTX extends TX {
   async fund(coins, options) {
     assert(options, 'Options are required.');
     assert(options.changeAddress, 'Change address is required.');
-    assert(this.inputs.length === 0, 'TX is already funded.');
+    if (!options.preserveInput) {
+      assert(this.inputs.length === 0, 'TX is already funded.');
+    }
 
     // Select necessary coins.
     const select = await this.selectCoins(coins, options);
@@ -1607,6 +1609,7 @@ class CoinSelector {
     this.round = false;
     this.changeAddress = null;
     this.inputs = new BufferMap();
+    this.preserveInput = false;
 
     // Needed for size estimation.
     this.estimate = null;
@@ -1704,6 +1707,11 @@ class CoinSelector {
       this.estimate = options.estimate;
     }
 
+    if (options.preserveInput) {
+      assert(typeof options.preserveInput === "boolean");
+      this.preserveInput = options.preserveInput;
+    }
+
     if (options.inputs) {
       assert(Array.isArray(options.inputs));
       for (let i = 0; i < options.inputs.length; i++) {
@@ -1745,7 +1753,8 @@ class CoinSelector {
     this.chosen = [];
     this.change = 0;
     this.fee = CoinSelector.MIN_FEE;
-    this.tx.inputs.length = 0;
+    if (!this.preserveInput)
+      this.tx.inputs.length = 0;
 
     switch (this.selection) {
       case 'all':

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1214,7 +1214,7 @@ class MTX extends TX {
   /**
    * Select necessary coins based on total output value.
    * @param {Coin[]} coins
-   * @param {Object?} options
+   * @param {Object?} options - @see {CoinSelector#constructor} for options
    * @returns {CoinSelection}
    * @throws on not enough funds available.
    */
@@ -1298,7 +1298,8 @@ class MTX extends TX {
   /**
    * Select coins and fill the inputs.
    * @param {Coin[]} coins
-   * @param {Object} options - See {@link MTX#selectCoins} options.
+   * @param {Object} options - See {@link CoinSelector#constructor} options.
+   * @param {Boolean} options.preserveInput - if this is not set, mtx must have empty inputs
    * @returns {CoinSelector}
    */
 
@@ -1572,6 +1573,18 @@ class CoinSelector {
    * @constructor
    * @param {TX} tx
    * @param {Object?} options
+   * @param {String?} options.selection - must be one of 'all', 'random', 'age', 'value'
+   * @param {Number?} options.subtractIndex - subtract fee from an output of this index.
+   * @param {Number?|Boolean?} options.subtractFee - same with subtractIndex if it is `Number`.
+   * @param {Number?} options.height - sometime coin's spendability depends on this (e.g. coinbase maturity)
+   * @param {Number?} options.depth - same with above
+   * @param {Number?} options.confirmations - same with above (currently not used)
+   * @param {Amount?} options.hardFee - always use this value as fee.
+   * @param {Rate?} options.rate - use this value as fee rate.
+   * @param {Amount?} options.maxFee - maximum fee.
+   * @param {Boolean?} options.round - round fee to nearest kB (useful in predictable estimation for testing)
+   * @param {String?|Address?} options.changeAddress
+   * @param {Input?} options.inputs - tx inputs to prefer. (currently not used)
    */
 
   constructor(tx, options) {

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -224,7 +224,8 @@ class RPC extends RPCBase {
 
     await wallet.fund(tx, {
       rate: rate,
-      changeAddress: change
+      changeAddress: change,
+      preserveInput: true
     });
 
     return {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1130,6 +1130,7 @@ class Wallet extends EventEmitter {
       height: this.wdb.state.height,
       rate: rate,
       maxFee: options.maxFee,
+      preserveInput: options.preserveInput,
       estimate: prev => this.estimateSize(prev)
     });
 

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -624,7 +624,8 @@ describe('Wallet', function() {
   });
 
   for (const testcase of [0, 1]) {
-    const description = testcase === 0 ? 'empty inputs' : 'funder has already partially funded'
+    const description = testcase === 0 ? 'empty inputs' :
+      'funder has already partially funded';
     it(`should fill tx with inputs (${description})`, async () => {
       const alice = await wdb.create();
       const bob = await wdb.create();
@@ -707,13 +708,13 @@ describe('Wallet', function() {
     try {
       await alice.fund(m2, {
         rate: 10000,
-        round: true,
+        round: true
       });
     } catch (e) {
       err = e;
     }
 
-    assert(err)
+    assert(err);
   });
 
   it('should fill tx with inputs with accurate fee', async () => {


### PR DESCRIPTION
Currently, `MTX.fund` can only run for tx which has 0-inputs.
This adds optional parameter ( `options.preserveInput` ) to the method to fund tx with more than 0 inputs, while preserving backward compatibility.

This partially solves #521 . `[fund|decode]rawtransaction` still fails to decode 0 input tx, but `fundrawtransaction` now works if the tx has more than one inputs.
The RPC will return “Could not resolve prefered inputs” Error if the wallet has no information about the raw transaction’s existing input.  This is essentially the same behavior with bitcoin core’s rpc.
I am planning to make #607 depend on this feature for rpc `walletcreatefundedpsbt`
