### PR TITLE
Update/Change bcoin-cli Warning

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -4,7 +4,7 @@
 
 console.error('%s%s',
   'Warning: The `bcoin cli` interface is deprecated.\n',
-  'Please use `bcoin-cli` ($ npm install bclient).');
+  'Please use `bclient` (https://github.com/bcoin-org/bclient).');
 
 if (process.argv.length > 2 && process.argv[2] === 'wallet') {
   process.argv.splice(2, 1); // Evil hack.


### PR DESCRIPTION
I found this warning when running `./bin/cli` somewhat confusing, as the message instructs users to use `bcoin-cli` (which no longer exists) and instructs them to install bclient from NPM.  

I believe that updating the name of the client to `bclient` and instead directing the user to a project URL is noticeably more informative.