### PR TITLE
wallet-http: create account: remove unused 'watch-only'

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -324,7 +324,6 @@ class HTTP extends Server {
       const options = {
         name: valid.str('account'),
         witness: valid.bool('witness'),
-        watchOnly: valid.bool('watchOnly'),
         type: valid.str('type'),
         m: valid.u32('m'),
         n: valid.u32('n'),


### PR DESCRIPTION
When a new account is created, [it inherits its `watch-only` property from the wallet that contains it.](https://github.com/bcoin-org/bcoin/blob/master/lib/wallet/wallet.js#L598) ~By removing this check, user will get "unrecognized option" error if they try to create an account with `watch-only`.~ Currently the parameter is just ignored and could cause user confusion.