### PR TITLE
mempool: reflect spent coins in mempool coinview.

### DIFF
--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -503,6 +503,28 @@ class Mempool extends EventEmitter {
   }
 
   /**
+   * Check whether coin is still unspent.
+   * @param {Hash} hash
+   * @param {Number} index
+   * @returns {boolean}
+   */
+
+  hasCoin(hash, index) {
+    const entry = this.map.get(hash);
+
+    if (!entry)
+      return false;
+
+    if (this.isSpent(hash, index))
+      return false;
+
+    if (index >= entry.tx.outputs.length)
+      return false;
+
+    return true;
+  }
+
+  /**
    * Check to see if a coin has been spent. This differs from
    * {@link ChainDB#isSpent} in that it actually maintains a
    * map of spent coins, whereas ChainDB may return `true`
@@ -1689,6 +1711,8 @@ class Mempool extends EventEmitter {
 
   /**
    * Get coin viewpoint (lock).
+   * Note: this does not return
+   * historical view of coins from the indexers.
    * @method
    * @param {TX} tx
    * @returns {Promise} - Returns {@link CoinView}.
@@ -1697,10 +1721,38 @@ class Mempool extends EventEmitter {
   async getSpentView(tx) {
     const unlock = await this.locker.lock();
     try {
-      return await this.getCoinView(tx);
+      return await this._getSpentView(tx);
     } finally {
       unlock();
     }
+  }
+
+  /**
+   * Get coin viewpoint
+   * @param {TX} tx
+   * @returns {Promise} - Returns {@link CoinView}
+   */
+
+  async _getSpentView(tx) {
+    const view = new CoinView();
+
+    for (const {prevout} of tx.inputs) {
+      const {hash, index} = prevout;
+      const tx = this.getTX(hash);
+
+      if (tx) {
+        if (index < tx.outputs.length)
+          view.addIndex(tx, index, -1);
+        continue;
+      }
+
+      const coin = await this.chain.readCoin(prevout);
+
+      if (coin)
+        view.addEntry(prevout, coin);
+    }
+
+    return view;
   }
 
   /**
@@ -1718,7 +1770,7 @@ class Mempool extends EventEmitter {
       const tx = this.getTX(hash);
 
       if (tx) {
-        if (index < tx.outputs.length)
+        if (this.hasCoin(hash, index))
           view.addIndex(tx, index, -1);
         continue;
       }


### PR DESCRIPTION
Currently coinview does not account for spent coins in the mempool,
This does not create problems because we have additional checks in
right places which detect double spends, but technically
coinview should help you detect double spent in the mempool as well.
This way it will be compatible with chain.getCoinView.

getSpentView will still return all outputs that are available
in the mempool. (This could also return spentView from indexers if
available, this method is used by `signrawtransaction`.)