### PR TITLE
Create Bloom filter of walletDB once

### DIFF
--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -79,7 +79,7 @@ class WalletDB extends EventEmitter {
     this.txLock = new Lock();
 
     // Address and outpoint filter.
-    this.filter = new BloomFilter();
+    this.filter = null;
 
     this.init();
   }


### PR DESCRIPTION
this.filter was initialized to an empty Bloom filter, only to be replaced with a more specific one in line 107. This change makes things a little faster and less confusing.