### PR TITLE
Separate mempool indexer

### DIFF
--- a/lib/mempool/indexer.js
+++ b/lib/mempool/indexer.js
@@ -476,11 +476,6 @@ class IndexedCoin {
   toCoin() {
     return Coin.fromTX(this.tx, this.index, -1);
   }
-
-  inspect() {
-    return `<IndexedCoin tx=${this.tx.hash().toString('hex')}`
-    + ` index=${this.index}>`;
-  }
 }
 
 module.exports = MempoolIndexer;

--- a/lib/mempool/indexer.js
+++ b/lib/mempool/indexer.js
@@ -18,10 +18,10 @@ const Coin = require('../primitives/coin');
  * Handles TXIndex and CoinIndex for looking up by address.
  *
  * Coin index in mempool keeps track of the coins available for an address
- * in the mempool, those that have not been indexed by indexer yet.
+ * in the mempool, those that have not been indexed by chain indexer yet.
  *
  * There are several reasons transaction can be added or removed from the
- * mempool, as well as coins assosiated with addresses with it.
+ * mempool, as well as coins associated with addresses with it.
  *  - Transaction was received from the network or orphan got resolved:
  *    - events: add entry and tx
  *    - We want to remove coins that are in tx inputs.
@@ -32,19 +32,19 @@ const Coin = require('../primitives/coin');
  *  - Transaction was included in block
  *    - events: `remove entry` and `confirmed` OR `double spend`
  *      (Can potentially resolve orphans)
- *    - We don't want to recover inputs as they are spent in chain.
- *    - We don't need outputs as well, because they are now part of the
- *      chain indexer.
- *    - On double spend we might need to partially recover
- *      double spent transaction's inputs as coins if they are in mempool
- *      (partial double spent test case)
+ *    - if tx was confirmed we wont have tx.hash() in the mempool,
+ *      so we can leave things to removeEntry.
+ *    - On double spend transaction that was spent in mempool
+ *      will get unindexed(remove entry), which will recover
+ *      all coins that are in the mempool. (inputs that were
+ *      double spent wont be in the mempool (getTX will fail).
  *  - Transaction was removed because of memory constraints
  *    - events: `remove entry`
  *    - In this case we want to recover inputs as coins
  *  - on reorganization we need to also clean up coins
  *    - events: `unconfirmed` and `add entry` + `tx`
  *    - add tx creates new coins
- *    - on unocnfirmed we need to recover outputs as coins
+ *    - on unconfirmed we need to recover outputs as coins
  *      (Unless they are not spent in mempool)
  *
  * We don't need to take care of conflict as
@@ -78,23 +78,9 @@ class MempoolIndexer {
    */
 
   init() {
-    this.mempool.on('confirmed', (tx, block) => this.confirmed(tx, block));
     this.mempool.on('unconfirmed', (tx, block) => this.unconfirmed(tx, block));
     this.mempool.on('add entry', (entry, view) => this.addEntry(entry, view));
     this.mempool.on('remove entry', entry => this.removeEntry(entry));
-    this.mempool.on('double spend', entry => this.doubleSpend(entry));
-  }
-  /**
-   * We have new tx in the mempool.
-   * We can index to TXIndex here.
-   * - We received it from the network.
-   * - Block was disconnected.
-   * - Orphan got resolved
-   * @param {TX} tx
-   * @param {CoinView} view
-   */
-
-  addTX(tx, view) {
   }
 
   /**
@@ -155,19 +141,6 @@ class MempoolIndexer {
   }
 
   /**
-   * Transaction was included in the block.
-   * We want to get rid of the input coins as well as output coins.
-   * (if there are any)
-   * This event comes after remove entry, which recovers inputs
-   * as coins, we want to get rid of those coins as well.
-   * @param {TX} tx
-   * @param {Block} block
-   */
-
-  confirmed(tx, block) {
-  }
-
-  /**
    * Block disconnected and we recover coins if they are available.
    * This event comes after `tx` and `add entry`, we might want to
    * check if outputs indexed by those are already spent in the mempool.
@@ -176,15 +149,12 @@ class MempoolIndexer {
    */
 
   unconfirmed(tx, block) {
-  }
+    const hash = tx.hash();
 
-  /**
-   * Transaction was double spent in the mempool.
-   * We want to recover coisn that are not spent in the mempool.
-   * @param {MempoolEntry} entry
-   */
-
-  doubleSpend(entry) {
+    for (let i = 0; i < tx.outputs.length; i++) {
+      if (this.mempool.isSpent(hash, i))
+        this.coinIndex.remove(hash, i);
+    }
   }
 
   /**
@@ -198,28 +168,50 @@ class MempoolIndexer {
   }
 
   /**
-   * Find all transactions partaining to a certain address.
+   * Find all transactions pertaining to a certain address.
    * Note: this does not accept multiple addresses.
-   * @param {Address} addr
+   * @param {Address} addrs
    * @returns {TX[]}
    */
 
-  getTXByAddress(addr) {
-    const hash = Address.getHash(addr);
+  getTXByAddress(addrs) {
+    if (!Array.isArray(addrs))
+      addrs = [addrs];
 
-    return this.txIndex.get(hash);
+    const out = [];
+
+    for (const addr of addrs) {
+      const hash = Address.getHash(addr, this.network);
+      const txs = this.txIndex.get(hash);
+
+      for (const tx of txs)
+        out.push(tx);
+    }
+
+    return out;
   }
 
   /**
    * Find all transactions pertaining to a certain address.
-   * @param {Address} addr
+   * @param {Address} addrs
    * @param {TXMeta[]]}
    */
 
-  getMetaByAddress(addr) {
-    const hash = Address.getHash(addr);
+  getMetaByAddress(addrs) {
+    if (!Array.isArray(addrs))
+      addrs = [addrs];
 
-    return this.txIndex.getMeta(hash);
+    const out = [];
+
+    for (const addr of addrs) {
+      const hash = Address.getHash(addr);
+      const txs = this.txIndex.getMeta(hash);
+
+      for (const tx of txs)
+        out.push(tx);
+    }
+
+    return out;
   }
 
   /**
@@ -228,10 +220,21 @@ class MempoolIndexer {
    * @return {Coin[]}
    */
 
-  getCoinsByAddress(addr) {
-    const hash = Address.getHash(addr);
+  getCoinsByAddress(addrs) {
+    if (!Array.isArray(addrs))
+      addrs = [addrs];
 
-    return this.coinIndex.get(hash);
+    const out = [];
+
+    for (const addr of addrs) {
+      const hash = Address.getHash(addr);
+      const coins = this.coinIndex.get(hash);
+
+      for (const coin of coins)
+        out.push(coin);
+    }
+
+    return out;
   }
 }
 

--- a/lib/mempool/indexer.js
+++ b/lib/mempool/indexer.js
@@ -9,7 +9,6 @@
 const assert = require('bsert');
 const {BufferMap} = require('buffer-map');
 const Address = require('../primitives/address');
-const Network = require('../protocol/network');
 const Outpoint = require('../primitives/outpoint');
 const TXMeta = require('../primitives/txmeta');
 const Coin = require('../primitives/coin');

--- a/lib/mempool/indexer.js
+++ b/lib/mempool/indexer.js
@@ -1,0 +1,484 @@
+/*!
+ * mempool/index.js - mempool for bcoin
+ * Copyright (c) 2018, the bcoin developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const assert = require('bsert');
+const {BufferMap} = require('buffer-map');
+const Address = require('../primitives/address');
+const Network = require('../protocol/network');
+const Outpoint = require('../primitives/outpoint');
+const TXMeta = require('../primitives/txmeta');
+const Coin = require('../primitives/coin');
+
+/**
+ * Mempool indexer
+ * Handles TXIndex and CoinIndex for looking up by address.
+ *
+ * Coin index in mempool keeps track of the coins available for an address
+ * in the mempool, those that have not been indexed by indexer yet.
+ *
+ * There are several reasons transaction can be added or removed from the
+ * mempool, as well as coins assosiated with addresses with it.
+ *  - Transaction was received from the network or orphan got resolved:
+ *    - events: add entry and tx
+ *    - We want to remove coins that are in tx inputs.
+ *      If there are any - Meaning they are spending transaction in mempool
+ *    - We want to add outputs as coins in the mempool.
+ *    - If outputs are resolving orphans those orphans will be added via same
+ *      events (tx and add entry)
+ *  - Transaction was included in block
+ *    - events: `remove entry` and `confirmed` OR `double spend`
+ *      (Can potentially resolve orphans)
+ *    - We don't want to recover inputs as they are spent in chain.
+ *    - We don't need outputs as well, because they are now part of the
+ *      chain indexer.
+ *    - On double spend we might need to partially recover
+ *      double spent transaction's inputs as coins if they are in mempool
+ *      (partial double spent test case)
+ *  - Transaction was removed because of memory constraints
+ *    - events: `remove entry`
+ *    - In this case we want to recover inputs as coins
+ *  - on reorganization we need to also clean up coins
+ *    - events: `unconfirmed` and `add entry` + `tx`
+ *    - add tx creates new coins
+ *    - on unocnfirmed we need to recover outputs as coins
+ *      (Unless they are not spent in mempool)
+ *
+ * We don't need to take care of conflict as
+ * that event prevents tx from entering the mempool.
+ *
+ * and orphan related events as they are not part of
+ * the coin or tx indexers as orphans.
+ *
+ *
+ * @alias module:mempool.MempoolIndexer
+ */
+
+class MempoolIndexer {
+  /**
+   * Create a mempool indexer.
+   * @param {Mempool} mempool
+   */
+
+  constructor(options) {
+    this.options = new MempoolIndexerOptions(options);
+    this.mempool = this.options.mempool;
+
+    this.coinIndex = new CoinIndex();
+    this.txIndex = new TXIndex();
+
+    this.init();
+  }
+
+  /**
+   * Start listening for the mempool events
+   */
+
+  init() {
+    this.mempool.on('confirmed', (tx, block) => this.confirmed(tx, block));
+    this.mempool.on('unconfirmed', (tx, block) => this.unconfirmed(tx, block));
+    this.mempool.on('add entry', (entry, view) => this.addEntry(entry, view));
+    this.mempool.on('remove entry', entry => this.removeEntry(entry));
+    this.mempool.on('double spend', entry => this.doubleSpend(entry));
+  }
+  /**
+   * We have new tx in the mempool.
+   * We can index to TXIndex here.
+   * - We received it from the network.
+   * - Block was disconnected.
+   * - Orphan got resolved
+   * @param {TX} tx
+   * @param {CoinView} view
+   */
+
+  addTX(tx, view) {
+  }
+
+  /**
+   * We have new entry in the mempool.
+   * `add entry` is emitted after `tx`.
+   * We can index coins.
+   * - We received it from the network.
+   * - Block was disconnected.
+   * - Orphan got resolved
+   * @param {MempoolEntry} entry
+   * @param {CoinView} view
+   */
+
+  addEntry(entry, view) {
+    const tx = entry.tx;
+
+    this.txIndex.insert(entry, view);
+
+    for (const {prevout} of tx.inputs) {
+      const {hash, index} = prevout;
+
+      this.coinIndex.remove(hash, index);
+    }
+
+    for (let i = 0; i < tx.outputs.length; i++)
+      this.coinIndex.insert(tx, i);
+  }
+
+  /**
+   * Transaction was removed from mempool.
+   * This might happen for several reasons:
+   *  - Mempool size limit got rid of it.
+   *  - Transaction was included in block.
+   *  - Double spend in a block
+   *  - After reorg tx is no longer final
+   * We concentrate on recovering inputs as coins.
+   * @param {MempoolEntry} entry
+   */
+
+  removeEntry(entry) {
+    const tx = entry.tx;
+    const hash = tx.hash();
+
+    this.txIndex.remove(hash);
+
+    for (const {prevout} of tx.inputs) {
+      const {hash, index} = prevout;
+      const prev = this.mempool.getTX(hash);
+
+      if (!prev)
+        continue;
+
+      this.coinIndex.insert(prev, index);
+    }
+
+    for (let i = 0; i < tx.outputs.length; i++)
+      this.coinIndex.remove(hash, i);
+  }
+
+  /**
+   * Transaction was included in the block.
+   * We want to get rid of the input coins as well as output coins.
+   * (if there are any)
+   * This event comes after remove entry, which recovers inputs
+   * as coins, we want to get rid of those coins as well.
+   * @param {TX} tx
+   * @param {Block} block
+   */
+
+  confirmed(tx, block) {
+  }
+
+  /**
+   * Block disconnected and we recover coins if they are available.
+   * This event comes after `tx` and `add entry`, we might want to
+   * check if outputs indexed by those are already spent in the mempool.
+   * @param {TX} tx
+   * @param {Block} block
+   */
+
+  unconfirmed(tx, block) {
+  }
+
+  /**
+   * Transaction was double spent in the mempool.
+   * We want to recover coisn that are not spent in the mempool.
+   * @param {MempoolEntry} entry
+   */
+
+  doubleSpend(entry) {
+  }
+
+  /**
+   * Reset indexes
+   * @private
+   */
+
+  reset() {
+    this.txIndex.reset();
+    this.coinIndex.reset();
+  }
+
+  /**
+   * Find all transactions partaining to a certain address.
+   * Note: this does not accept multiple addresses.
+   * @param {Address} addr
+   * @returns {TX[]}
+   */
+
+  getTXByAddress(addr) {
+    const hash = Address.getHash(addr);
+
+    return this.txIndex.get(hash);
+  }
+
+  /**
+   * Find all transactions pertaining to a certain address.
+   * @param {Address} addr
+   * @param {TXMeta[]]}
+   */
+
+  getMetaByAddress(addr) {
+    const hash = Address.getHash(addr);
+
+    return this.txIndex.getMeta(hash);
+  }
+
+  /**
+   * Find all coins pertaining to a certain address.
+   * @param {Address} addr
+   * @return {Coin[]}
+   */
+
+  getCoinsByAddress(addr) {
+    const hash = Address.getHash(addr);
+
+    return this.coinIndex.get(hash);
+  }
+}
+
+/**
+ * Mempool Indexer Options
+ * @alias module:mempool.MempoolIndexerOptions
+ */
+
+class MempoolIndexerOptions {
+  /**
+   * Create indexer options.
+   * @param {Object}
+   */
+
+  constructor(options) {
+    this.mempool = null;
+
+    this.fromOptions(options);
+  }
+
+  /**
+   * Inject properties from object.
+   * @private
+   * @param {Object} options
+   * returns {MempoolIndexerOptions}
+   */
+
+  fromOptions(options) {
+    assert(options, 'Mempool indexer requires options.');
+    assert(options.mempool && typeof options.mempool === 'object',
+      'Mempool indexer requires a mempool.'
+    );
+
+    this.mempool = options.mempool;
+
+    return this;
+  }
+}
+
+/**
+ * TX Address Index
+ * @ignore
+ */
+
+class TXIndex {
+  /**
+   * Create TX address index.
+   * @constructor
+   */
+
+  constructor() {
+    // Map of addr->entries.
+    this.index = new BufferMap();
+
+    // Map of txid->addrs.
+    this.map = new BufferMap();
+  }
+
+  reset() {
+    this.index.clear();
+    this.map.clear();
+  }
+
+  get(addr) {
+    const items = this.index.get(addr);
+
+    if (!items)
+      return [];
+
+    const out = [];
+
+    for (const entry of items.values())
+      out.push(entry.tx);
+
+    return out;
+  }
+
+  getMeta(addr) {
+    const items = this.index.get(addr);
+
+    if (!items)
+      return [];
+
+    const out = [];
+
+    for (const entry of items.values()) {
+      const meta = TXMeta.fromTX(entry.tx);
+      meta.mtime = entry.time;
+      out.push(meta);
+    }
+
+    return out;
+  }
+
+  insert(entry, view) {
+    const tx = entry.tx;
+    const hash = tx.hash();
+    const addrs = tx.getHashes(view);
+
+    if (addrs.length === 0)
+      return;
+
+    for (const addr of addrs) {
+      let items = this.index.get(addr);
+
+      if (!items) {
+        items = new BufferMap();
+        this.index.set(addr, items);
+      }
+
+      assert(!items.has(hash));
+      items.set(hash, entry);
+    }
+
+    this.map.set(hash, addrs);
+  }
+
+  remove(hash) {
+    const addrs = this.map.get(hash);
+
+    if (!addrs)
+      return;
+
+    for (const addr of addrs) {
+      const items = this.index.get(addr);
+
+      assert(items);
+      assert(items.has(hash));
+
+      items.delete(hash);
+
+      if (items.size === 0)
+        this.index.delete(addr);
+    }
+
+    this.map.delete(hash);
+  }
+}
+
+/**
+ * Coin Address Index
+ * @ignore
+ */
+
+class CoinIndex {
+  /**
+   * Create coin address index.
+   * @constructor
+   */
+
+  constructor() {
+    // Map of addr->coins.
+    this.index = new BufferMap();
+
+    // Map of outpoint->addr.
+    this.map = new BufferMap();
+  }
+
+  reset() {
+    this.index.clear();
+    this.map.clear();
+  }
+
+  get(addr) {
+    const items = this.index.get(addr);
+
+    if (!items)
+      return [];
+
+    const out = [];
+
+    for (const coin of items.values())
+      out.push(coin.toCoin());
+
+    return out;
+  }
+
+  insert(tx, index) {
+    const output = tx.outputs[index];
+    const hash = tx.hash();
+    const addr = output.getHash();
+
+    if (!addr)
+      return;
+
+    let items = this.index.get(addr);
+
+    if (!items) {
+      items = new BufferMap();
+      this.index.set(addr, items);
+    }
+
+    const key = Outpoint.toKey(hash, index);
+
+    assert(!items.has(key));
+    items.set(key, new IndexedCoin(tx, index));
+
+    this.map.set(key, addr);
+  }
+
+  remove(hash, index) {
+    const key = Outpoint.toKey(hash, index);
+    const addr = this.map.get(key);
+
+    if (!addr)
+      return;
+
+    const items = this.index.get(addr);
+
+    assert(items);
+    assert(items.has(key));
+    items.delete(key);
+
+    if (items.size === 0)
+      this.index.delete(addr);
+
+    this.map.delete(key);
+  }
+}
+
+/**
+ * Indexed Coin
+ * @ignore
+ */
+
+class IndexedCoin {
+  /**
+   * Create an indexed coin.
+   * @constructor
+   * @param {TX} tx
+   * @param {Number} index
+   */
+
+  constructor(tx, index) {
+    this.tx = tx;
+    this.index = index;
+  }
+
+  toCoin() {
+    return Coin.fromTX(this.tx, this.index, -1);
+  }
+
+  inspect() {
+    return `<IndexedCoin tx=${this.tx.hash().toString('hex')}`
+    + ` index=${this.index}>`;
+  }
+}
+
+module.exports = MempoolIndexer;

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -87,16 +87,16 @@ class Mempool extends EventEmitter {
     if (this.options.persistent) {
       const entries = await this.cache.getEntries();
 
-      for (const entry of entries)
-        this.trackEntry(entry);
-
       for (const entry of entries) {
-        this.updateAncestors(entry, addFee);
+        const tx = entry.tx;
+        const view = await this.getCoinView(entry.tx);
 
-        if (this.options.indexAddress) {
-          const view = await this.getCoinView(entry.tx);
-          this.indexEntry(entry, view);
-        }
+        const missing = this.maybeOrphan(tx, view);
+
+        if (missing)
+          continue;
+
+        await this.addEntry(entry, view);
       }
 
       this.logger.info(

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -503,6 +503,28 @@ class Mempool extends EventEmitter {
   }
 
   /**
+   * Check whether coin is still unspent.
+   * @param {Hash} hash
+   * @param {Number} index
+   * @returns {boolean}
+   */
+
+  hasCoin(hash, index) {
+    const entry = this.map.get(hash);
+
+    if (!entry)
+      return false;
+
+    if (this.isSpent(hash, index))
+      return false;
+
+    if (index >= entry.tx.outputs.length)
+      return false;
+
+    return true;
+  }
+
+  /**
    * Check to see if a coin has been spent. This differs from
    * {@link ChainDB#isSpent} in that it actually maintains a
    * map of spent coins, whereas ChainDB may return `true`

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -19,7 +19,6 @@ const policy = require('../protocol/policy');
 const util = require('../utils/util');
 const random = require('bcrypto/lib/random');
 const {VerifyError} = require('../protocol/errors');
-const Address = require('../primitives/address');
 const Script = require('../script/script');
 const Outpoint = require('../primitives/outpoint');
 const TX = require('../primitives/tx');
@@ -72,9 +71,6 @@ class Mempool extends EventEmitter {
     this.map = new BufferMap();
     this.spents = new BufferMap();
     this.rejects = new RollingFilter(120000, 0.000001);
-
-    this.coinIndex = new CoinIndex();
-    this.txIndex = new TXIndex();
   }
 
   /**
@@ -364,8 +360,6 @@ class Mempool extends EventEmitter {
     this.orphans.clear();
     this.map.clear();
     this.spents.clear();
-    this.coinIndex.reset();
-    this.txIndex.reset();
 
     this.freeCount = 0;
     this.lastTime = 0;
@@ -575,20 +569,12 @@ class Mempool extends EventEmitter {
    */
 
   getCoinsByAddress(addrs) {
-    if (!Array.isArray(addrs))
-      addrs = [addrs];
+    process.emitWarning(
+      'deprecated, use node.mempoolIndex.getCoinsByAddress',
+      'DeprecationWarning'
+    );
 
-    const out = [];
-
-    for (const addr of addrs) {
-      const hash = Address.getHash(addr);
-      const coins = this.coinIndex.get(hash);
-
-      for (const coin of coins)
-        out.push(coin);
-    }
-
-    return out;
+    return [];
   }
 
   /**
@@ -598,20 +584,12 @@ class Mempool extends EventEmitter {
    */
 
   getTXByAddress(addrs) {
-    if (!Array.isArray(addrs))
-      addrs = [addrs];
+    process.emitWarning(
+      'deprecated, use node.mempoolIndex.getTXByAddress',
+      'DeprecationWarning'
+    );
 
-    const out = [];
-
-    for (const addr of addrs) {
-      const hash = Address.getHash(addr);
-      const txs = this.txIndex.get(hash);
-
-      for (const tx of txs)
-        out.push(tx);
-    }
-
-    return out;
+    return [];
   }
 
   /**
@@ -621,20 +599,12 @@ class Mempool extends EventEmitter {
    */
 
   getMetaByAddress(addrs) {
-    if (!Array.isArray(addrs))
-      addrs = [addrs];
+    process.emitWarning(
+      'deprecated, use node.mempoolIndex.getMetaByAddress',
+      'DeprecationWarning'
+    );
 
-    const out = [];
-
-    for (const addr of addrs) {
-      const hash = Address.getHash(addr);
-      const txs = this.txIndex.getMeta(hash);
-
-      for (const tx of txs)
-        out.push(tx);
-    }
-
-    return out;
+    return [];
   }
 
   /**
@@ -889,7 +859,7 @@ class Mempool extends EventEmitter {
     // Contextual verification.
     await this.verify(entry, view);
 
-    // Add and index the entry.
+    // Add the entry.
     await this.addEntry(entry, view);
 
     // Trim size if we're too big.
@@ -1813,9 +1783,6 @@ class Mempool extends EventEmitter {
       this.spents.set(key, entry);
     }
 
-    if (this.options.indexAddress && view)
-      this.indexEntry(entry, view);
-
     this.size += entry.memUsage();
   }
 
@@ -1839,57 +1806,7 @@ class Mempool extends EventEmitter {
       this.spents.delete(key);
     }
 
-    if (this.options.indexAddress)
-      this.unindexEntry(entry);
-
     this.size -= entry.memUsage();
-  }
-
-  /**
-   * Index an entry by address.
-   * @private
-   * @param {MempoolEntry} entry
-   * @param {CoinView} view
-   */
-
-  indexEntry(entry, view) {
-    const tx = entry.tx;
-
-    this.txIndex.insert(entry, view);
-
-    for (const {prevout} of tx.inputs) {
-      const {hash, index} = prevout;
-      this.coinIndex.remove(hash, index);
-    }
-
-    for (let i = 0; i < tx.outputs.length; i++)
-      this.coinIndex.insert(tx, i);
-  }
-
-  /**
-   * Unindex an entry by address.
-   * @private
-   * @param {MempoolEntry} entry
-   */
-
-  unindexEntry(entry) {
-    const tx = entry.tx;
-    const hash = tx.hash();
-
-    this.txIndex.remove(hash);
-
-    for (const {prevout} of tx.inputs) {
-      const {hash, index} = prevout;
-      const prev = this.getTX(hash);
-
-      if (!prev)
-        continue;
-
-      this.coinIndex.insert(prev, index);
-    }
-
-    for (let i = 0; i < tx.outputs.length; i++)
-      this.coinIndex.remove(hash, i);
   }
 
   /**
@@ -2138,11 +2055,6 @@ class MempoolOptions {
       this.persistent = options.persistent;
     }
 
-    if (options.indexAddress != null) {
-      assert(typeof options.indexAddress === 'boolean');
-      this.indexAddress = options.indexAddress;
-    }
-
     return this;
   }
 
@@ -2154,210 +2066,6 @@ class MempoolOptions {
 
   static fromOptions(options) {
     return new MempoolOptions().fromOptions(options);
-  }
-}
-
-/**
- * TX Address Index
- * @ignore
- */
-
-class TXIndex {
-  /**
-   * Create TX address index.
-   * @constructor
-   */
-
-  constructor() {
-    // Map of addr->entries.
-    this.index = new BufferMap();
-
-    // Map of txid->addrs.
-    this.map = new BufferMap();
-  }
-
-  reset() {
-    this.index.clear();
-    this.map.clear();
-  }
-
-  get(addr) {
-    const items = this.index.get(addr);
-
-    if (!items)
-      return [];
-
-    const out = [];
-
-    for (const entry of items.values())
-      out.push(entry.tx);
-
-    return out;
-  }
-
-  getMeta(addr) {
-    const items = this.index.get(addr);
-
-    if (!items)
-      return [];
-
-    const out = [];
-
-    for (const entry of items.values()) {
-      const meta = TXMeta.fromTX(entry.tx);
-      meta.mtime = entry.time;
-      out.push(meta);
-    }
-
-    return out;
-  }
-
-  insert(entry, view) {
-    const tx = entry.tx;
-    const hash = tx.hash();
-    const addrs = tx.getHashes(view);
-
-    if (addrs.length === 0)
-      return;
-
-    for (const addr of addrs) {
-      let items = this.index.get(addr);
-
-      if (!items) {
-        items = new BufferMap();
-        this.index.set(addr, items);
-      }
-
-      assert(!items.has(hash));
-      items.set(hash, entry);
-    }
-
-    this.map.set(hash, addrs);
-  }
-
-  remove(hash) {
-    const addrs = this.map.get(hash);
-
-    if (!addrs)
-      return;
-
-    for (const addr of addrs) {
-      const items = this.index.get(addr);
-
-      assert(items);
-      assert(items.has(hash));
-
-      items.delete(hash);
-
-      if (items.size === 0)
-        this.index.delete(addr);
-    }
-
-    this.map.delete(hash);
-  }
-}
-
-/**
- * Coin Address Index
- * @ignore
- */
-
-class CoinIndex {
-  /**
-   * Create coin address index.
-   * @constructor
-   */
-
-  constructor() {
-    // Map of addr->coins.
-    this.index = new BufferMap();
-
-    // Map of outpoint->addr.
-    this.map = new BufferMap();
-  }
-
-  reset() {
-    this.index.clear();
-    this.map.clear();
-  }
-
-  get(addr) {
-    const items = this.index.get(addr);
-
-    if (!items)
-      return [];
-
-    const out = [];
-
-    for (const coin of items.values())
-      out.push(coin.toCoin());
-
-    return out;
-  }
-
-  insert(tx, index) {
-    const output = tx.outputs[index];
-    const hash = tx.hash();
-    const addr = output.getHash();
-
-    if (!addr)
-      return;
-
-    let items = this.index.get(addr);
-
-    if (!items) {
-      items = new BufferMap();
-      this.index.set(addr, items);
-    }
-
-    const key = Outpoint.toKey(hash, index);
-
-    assert(!items.has(key));
-    items.set(key, new IndexedCoin(tx, index));
-
-    this.map.set(key, addr);
-  }
-
-  remove(hash, index) {
-    const key = Outpoint.toKey(hash, index);
-    const addr = this.map.get(key);
-
-    if (!addr)
-      return;
-
-    const items = this.index.get(addr);
-
-    assert(items);
-    assert(items.has(key));
-    items.delete(key);
-
-    if (items.size === 0)
-      this.index.delete(addr);
-
-    this.map.delete(key);
-  }
-}
-
-/**
- * Indexed Coin
- * @ignore
- */
-
-class IndexedCoin {
-  /**
-   * Create an indexed coin.
-   * @constructor
-   * @param {TX} tx
-   * @param {Number} index
-   */
-
-  constructor(tx, index) {
-    this.tx = tx;
-    this.index = index;
-  }
-
-  toCoin() {
-    return Coin.fromTX(this.tx, this.index, -1);
   }
 }
 

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -1112,7 +1112,7 @@ class Mempool extends EventEmitter {
     this.updateAncestors(entry, addFee);
 
     this.emit('tx', tx, view);
-    this.emit('add entry', entry);
+    this.emit('add entry', entry, view);
 
     if (this.fees)
       this.fees.processTX(entry, this.chain.synced);

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -11,6 +11,7 @@ const assert = require('bsert');
 const Chain = require('../blockchain/chain');
 const Fees = require('../mempool/fees');
 const Mempool = require('../mempool/mempool');
+const MempoolIndexer = require('../mempool/indexer');
 const Pool = require('../net/pool');
 const Miner = require('../mining/miner');
 const Node = require('./node');
@@ -143,6 +144,15 @@ class FullNode extends Node {
       noAuth: this.config.bool('no-auth'),
       cors: this.config.bool('cors')
     });
+
+    // Indexers
+    this.mempoolIndex = null;
+
+    if (this.config.bool('index-address')) {
+      this.mempoolIndex = new MempoolIndexer({
+        mempool: this.mempool
+      });
+    }
 
     this.init();
   }
@@ -431,8 +441,12 @@ class FullNode extends Node {
    */
 
   async getMetaByAddress(addrs) {
-    const mempool = this.mempool.getMetaByAddress(addrs);
+    if (!this.mempoolIndex)
+      return [];
+
+    const mempool = this.mempoolIndex.getMetaByAddress(addrs);
     const chain = await this.chain.getMetaByAddress(addrs);
+
     return chain.concat(mempool);
   }
 

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -208,6 +208,9 @@ class FullNode extends Node {
     this.chain.on('reset', async (tip) => {
       try {
         await this.mempool._reset();
+
+        if (this.mempoolIndex)
+          this.mempoolIndex.reset();
       } catch (e) {
         this.error(e);
       }
@@ -414,8 +417,12 @@ class FullNode extends Node {
    */
 
   async getCoinsByAddress(addrs) {
-    const mempool = this.mempool.getCoinsByAddress(addrs);
+    if (!this.mempoolIndex)
+      return [];
+
+    const mempool = this.mempoolIndex.getCoinsByAddress(addrs);
     const chain = await this.chain.getCoinsByAddress(addrs);
+
     const out = [];
 
     for (const coin of chain) {

--- a/test/mempool-test.js
+++ b/test/mempool-test.js
@@ -276,7 +276,7 @@ describe('Mempool', function() {
     const prev = Script.fromProgram(0, key.getKeyHash());
     const prevHash = random.randomBytes(32);
 
-    tx.addCoin(dummyInput(prev, prevHash));
+    tx.addCoin(dummyInput(mempool, prev, prevHash));
 
     const prevs = Script.fromPubkeyhash(key.getKeyHash());
 
@@ -306,7 +306,7 @@ describe('Mempool', function() {
     const prev = Script.fromPubkey(key.publicKey);
     const prevHash = random.randomBytes(32);
 
-    tx.addCoin(dummyInput(prev, prevHash));
+    tx.addCoin(dummyInput(mempool, prev, prevHash));
 
     const sig = tx.signature(0, prev, 70000, key.privateKey, ALL, 0);
     tx.inputs[0].script = Script.fromItems([sig]);
@@ -335,7 +335,7 @@ describe('Mempool', function() {
     const prev = Script.fromProgram(0, key.getKeyHash());
     const prevHash = random.randomBytes(32);
 
-    tx.addCoin(dummyInput(prev, prevHash));
+    tx.addCoin(dummyInput(mempool, prev, prevHash));
 
     let err;
     try {

--- a/test/mempool-test.js
+++ b/test/mempool-test.js
@@ -67,6 +67,7 @@ function dummyInput(mempool, script, hash, value = 70000) {
 
   return Coin.fromTX(fund, 0, -1);
 }
+
 async function getMockBlock(chain, txs = [], cb = true) {
   if (cb) {
     const raddr = KeyRing.generate().getAddress();
@@ -415,7 +416,7 @@ describe('Mempool', function() {
       await workers.close();
     });
 
-    // keys that we will use
+    // number of coins available in chaincoins. (100k satoshi per coin)
     const N = 100;
     const chaincoins = new MemWallet();
     const wallet = new MemWallet();
@@ -546,7 +547,13 @@ describe('Mempool', function() {
         assert.strictEqual(missing.length, 1);
       }
 
-      // TODO: make sure indexes have not changed.
+      {
+        const txs = indexer.getTXByAddress(addr);
+        const coins = indexer.getCoinsByAddress(addr);
+
+        assert.strictEqual(txs.length, 0);
+        assert.strictEqual(coins.length, 0);
+      }
 
       {
         // orphans are not coins
@@ -567,7 +574,16 @@ describe('Mempool', function() {
         assert(childCoin);
       }
 
-      // TODO: make sure indexes are updated correctly
+      {
+        const txs = indexer.getTXByAddress(addr);
+        const coins = indexer.getCoinsByAddress(addr);
+
+        assert.strictEqual(txs.length, 2);
+        assert.strictEqual(coins.length, 1);
+
+        assert.bufferEqual(coins[0].hash, childTX.hash());
+        assert.strictEqual(coins[0].index, 0);
+      }
 
       // update coins in wallets
       for (const tx of [parentTX, childTX]) {
@@ -578,7 +594,6 @@ describe('Mempool', function() {
 
     it('should remove double spend tx from mempool', async () => {
       const coin = chaincoins.getCoins()[0];
-
       const addr = wallet.createReceive().getAddress();
       const randomAddress = KeyRing.generate().getAddress();
 
@@ -606,7 +621,17 @@ describe('Mempool', function() {
         assert.strictEqual(missing, null);
       }
 
-      // TODO: verify we have coin/tx in indexer
+      {
+        const txs = indexer.getTXByAddress(addr);
+        const coins = indexer.getCoinsByAddress(addr);
+
+        assert.strictEqual(txs.length, 1);
+        assert.strictEqual(coins.length, 1);
+
+        assert.bufferEqual(coins[0].hash, tx1.hash());
+        assert.strictEqual(coins[0].index, 0);
+      }
+
       assert(mempool.hasCoin(tx1.hash(), 0));
 
       const block = await getMockBlock(chain, [tx2]);
@@ -614,7 +639,14 @@ describe('Mempool', function() {
 
       await mempool._addBlock(entry, block.txs);
 
-      // TODO: verify we don't have coin/tx in indexer anymore.
+      {
+        const txs = indexer.getTXByAddress(addr);
+        const coins = indexer.getCoinsByAddress(addr);
+
+        assert.strictEqual(txs.length, 0);
+        assert.strictEqual(coins.length, 0);
+      }
+
       assert(!mempool.hasCoin(tx1.hash(), 0));
 
       chaincoins.addTX(tx2);
@@ -637,14 +669,30 @@ describe('Mempool', function() {
 
       assert(mempool.hasCoin(tx.hash(), 0));
 
-      // TODO: verify we have coin in indexer.
+      {
+        const txs = indexer.getTXByAddress(addr);
+        const coins = indexer.getCoinsByAddress(addr);
+
+        assert.strictEqual(txs.length, 1);
+        assert.strictEqual(coins.length, 1);
+
+        assert.bufferEqual(coins[0].hash, tx.hash());
+        assert.strictEqual(coins[0].index, 0);
+      }
 
       const block = await getMockBlock(chain, [tx]);
       const entry = await chain.add(block, VERIFY_NONE);
 
       await mempool._addBlock(entry, block.txs);
 
-      // TODO: verify we don't have coin in indexer anymore.
+      {
+        const txs = indexer.getTXByAddress(addr);
+        const coins = indexer.getCoinsByAddress(addr);
+
+        assert.strictEqual(txs.length, 0);
+        assert.strictEqual(coins.length, 0);
+      }
+
       assert(!mempool.hasCoin(tx.hash(), 0));
 
       chaincoins.addTX(tx);
@@ -677,7 +725,14 @@ describe('Mempool', function() {
         assert.strictEqual(missing.length, 1);
       }
 
-      // TODO: verify we don't have coins have not changed.
+      {
+        // verify we don't have coins have not changed.
+        const txs = indexer.getTXByAddress(addr);
+        const coins = indexer.getCoinsByAddress(addr);
+
+        assert.strictEqual(txs.length, 0);
+        assert.strictEqual(coins.length, 0);
+      }
 
       const block = await getMockBlock(chain, [parentTX]);
       const entry = await chain.add(block, VERIFY_NONE);
@@ -686,7 +741,18 @@ describe('Mempool', function() {
 
       assert(mempool.hasCoin(childTX.hash(), 0));
 
-      // TODO: verify resolved orphan is new coin
+      {
+        // verify resolved orphan is new coin
+        const txs = indexer.getTXByAddress(addr);
+        const coins = indexer.getCoinsByAddress(addr);
+
+        assert.strictEqual(txs.length, 1);
+        assert.strictEqual(coins.length, 1);
+
+        assert.bufferEqual(txs[0].hash(), childTX.hash());
+        assert.bufferEqual(coins[0].hash, childTX.hash());
+        assert.strictEqual(coins[0].index, 0);
+      }
 
       chaincoins.addTX(parentTX);
       wallet.addTX(parentTX);
@@ -764,7 +830,13 @@ describe('Mempool', function() {
         assert(mempool.hasCoin(tx3.hash(), 0));
       }
 
-      // TODO: verify indexer has the right state
+      {
+        const txs = indexer.getTXByAddress(addr);
+        const coins = indexer.getCoinsByAddress(addr);
+
+        assert.strictEqual(txs.length, 3);
+        assert.strictEqual(coins.length, 0);
+      }
 
       const block = await getMockBlock(chain, [tx4]);
       const entry = await chain.add(block, VERIFY_NONE);
@@ -775,7 +847,25 @@ describe('Mempool', function() {
       assert(!mempool.hasCoin(tx3.hash(), 0));
       assert(!mempool.hasCoin(tx4.hash(), 0));
 
-      // TODO: verify we only have tx2 coins in indexer
+      {
+        const txs = indexer.getTXByAddress(addr);
+        const coins = indexer.getCoinsByAddress(addr);
+
+        assert.strictEqual(txs.length, 1);
+        assert.strictEqual(coins.length, 1);
+
+        assert.bufferEqual(coins[0].hash, tx2.hash());
+        assert.strictEqual(coins[0].index, 0);
+      }
+
+      {
+        // raddr does not have anything left in the mempool
+        const txs = indexer.getTXByAddress(raddr);
+        const coins = indexer.getCoinsByAddress(raddr);
+
+        assert.strictEqual(txs.length, 0);
+        assert.strictEqual(coins.length, 0);
+      }
 
       chaincoins.addBlock(entry, block.txs);
       wallet.addBlock(entry, block.txs);
@@ -813,8 +903,17 @@ describe('Mempool', function() {
       }
 
       assert(mempool.hasCoin(ptx.hash(), 0));
-      // TODO: make sure we have coin in indexer,
-      // even though we test this in previous tests.
+
+      {
+        const txs = indexer.getTXByAddress(addr);
+        const coins = indexer.getCoinsByAddress(addr);
+
+        assert.strictEqual(txs.length, 1);
+        assert.strictEqual(coins.length, 1);
+
+        assert.bufferEqual(coins[0].hash, ptx.hash());
+        assert.strictEqual(coins[0].index, 0);
+      }
 
       {
         const missing = await mempool.addTX(ctx);
@@ -824,6 +923,14 @@ describe('Mempool', function() {
       assert(!mempool.hasCoin(ptx.hash(), 0));
       assert(mempool.hasCoin(ctx.hash(), 0));
 
+      {
+        const txs = indexer.getTXByAddress(addr);
+        const coins = indexer.getCoinsByAddress(addr);
+
+        assert.strictEqual(txs.length, 2);
+        assert.strictEqual(coins.length, 0);
+      }
+
       const block = await getMockBlock(chain, [ptx]);
       const entry = await chain.add(block, VERIFY_NONE);
 
@@ -832,14 +939,27 @@ describe('Mempool', function() {
       assert(!mempool.hasCoin(ptx.hash(), 0));
       assert(mempool.hasCoin(ctx.hash(), 0));
 
-      // TODO: make sure we don't have coin/tx in indexer anymore
+      {
+        const txs = indexer.getTXByAddress(addr);
+        const coins = indexer.getCoinsByAddress(addr);
+
+        assert.strictEqual(txs.length, 1);
+        assert.strictEqual(coins.length, 0);
+      }
 
       await chain.disconnect(entry);
       await mempool._removeBlock(entry, block.txs);
 
       assert(!mempool.hasCoin(ptx.hash(), 0));
       assert(mempool.hasCoin(ctx.hash(), 0));
-      // TODO: verify we have coins in indexer
+
+      {
+        const txs = indexer.getTXByAddress(addr);
+        const coins = indexer.getCoinsByAddress(addr);
+
+        assert.strictEqual(txs.length, 2);
+        assert.strictEqual(coins.length, 0);
+      }
     });
   });
 });


### PR DESCRIPTION
Check full details: https://github.com/bcoin-org/bcash/pull/117

Related Issues in bcoin: https://github.com/bcoin-org/bcoin/issues/594 and https://github.com/bcoin-org/bcoin/issues/499.

Summary:
This separate coin/tx indexer from the mempool and moves to its separate file.
 - Separate mempool indexer from the mempool.
- Fix mempool indexer issues on reorg
- Fix mempool indexer issues when recovering from persistent storage.
- Add `view` to the `add entry` event.

Other PRs:
 - bcash: https://github.com/bcoin-org/bcash/pull/117
 - hsd: https://github.com/handshake-org/hsd/pull/81