### PR TITLE
spvnode: parse --no-wallet flag

### DIFF
--- a/bin/spvnode
+++ b/bin/spvnode
@@ -24,7 +24,7 @@ const node = new SPVNode({
 });
 
 // Temporary hack
-if (!node.has('walletdb')) {
+if (!node.config.bool('no-wallet') && !node.has('walletdb')) {
   const plugin = require('../lib/wallet/plugin');
   node.use(plugin);
 }


### PR DESCRIPTION
To match behavior in `node` (fullnode) if a user wants to use `bmultisig` instead of the built-in wallet.