### PR TITLE
[do not merge] Testing PRs for brq and bcurl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,8 @@
       }
     },
     "bcurl": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/bcurl/-/bcurl-0.1.4.tgz",
-      "integrity": "sha512-wy+/9uBQWrcNcMy4qCl241qATNnB0evBO5oTJboINXXG3c152wDyEnedAvypkOp4Mh0fYrlsO6yYr5RmRXnVIQ==",
+      "version": "github:pinheadmz/bcurl#ddec7cc31e2a0eef2341d447d91f32be8aa32909",
+      "from": "github:pinheadmz/bcurl#patch-1",
       "requires": {
         "brq": "~0.1.4",
         "bsert": "~0.0.5",
@@ -145,9 +144,8 @@
       }
     },
     "brq": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.4.tgz",
-      "integrity": "sha512-VPQtZgDjc3awXuzpuGrjuJtqsImDKrj7z4tVWC2bMafutD4Efx50otZMyxvQzJlQz3kXK3uAKonrHLKWy0Yo+A==",
+      "version": "github:pinheadmz/brq#0fa13642c3f3c80fa0187f57ede995e0049253df",
+      "from": "github:pinheadmz/brq#patch-1",
       "requires": {
         "bsert": "~0.0.5"
       }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
+    "bcurl": "pinheadmz/bcurl#patch-1",
+    "brq": "pinheadmz/brq#patch-1",
     "bcfg": "~0.1.4",
     "bclient": "~0.1.5",
     "bcrypto": "~3.0.1",


### PR DESCRIPTION
https://github.com/bcoin-org/bcurl/pull/10
and
https://github.com/bcoin-org/brq/pull/8

Tests pass locally with these patches in place, just wanted to double check on CI

```
pp:bcoin matthewzipkin$ npm list bcurl
bcoin@1.0.2 /Users/matthewzipkin/Desktop/work/bcoin
├─┬ bclient@0.1.5
│ └── bcurl@0.1.4  deduped (github:pinheadmz/bcurl#ddec7cc31e2a0eef2341d447d91f32be8aa32909)
└── bcurl@0.1.4  (github:pinheadmz/bcurl#ddec7cc31e2a0eef2341d447d91f32be8aa32909)

pp:bcoin matthewzipkin$ npm list brq
bcoin@1.0.2 /Users/matthewzipkin/Desktop/work/bcoin
├─┬ bcurl@0.1.4 (github:pinheadmz/bcurl#ddec7cc31e2a0eef2341d447d91f32be8aa32909)
│ └── brq@0.1.4  deduped (github:pinheadmz/brq#0fa13642c3f3c80fa0187f57ede995e0049253df)
├── brq@0.1.4  (github:pinheadmz/brq#0fa13642c3f3c80fa0187f57ede995e0049253df)
└─┬ bupnp@0.2.4
  └── brq@0.1.4  deduped (github:pinheadmz/brq#0fa13642c3f3c80fa0187f57ede995e0049253df)
```