### PR TITLE
Wallet: better error for send() if no outputs given

### DIFF
--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1244,7 +1244,7 @@ class Wallet extends EventEmitter {
     const mtx = new MTX();
 
     assert(Array.isArray(outputs), 'Outputs must be an array.');
-    assert(outputs.length > 0, 'No outputs available.');
+    assert(outputs.length > 0, 'At least one output required.');
 
     // Add the outputs
     for (const obj of outputs) {

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -18,6 +18,7 @@ const Input = require('../lib/primitives/input');
 const Outpoint = require('../lib/primitives/outpoint');
 const Script = require('../lib/script/script');
 const HD = require('../lib/hd');
+const Wallet = require('../lib/wallet/wallet');
 
 const KEY1 = 'xprv9s21ZrQH143K3Aj6xQBymM31Zb4BVc7wxqfUhMZrzewdDVCt'
   + 'qUP9iWfcHgJofs25xbaUpCps9GDXj83NiWvQCAkWQhVj5J4CorfnpKX94AZ';
@@ -1641,6 +1642,21 @@ describe('Wallet', function() {
       assert.strictEqual(addresses.size, 100);
     });
   }
+
+  it('should throw error with missing outputs', async () => {
+    const wallet = new Wallet({});
+
+    let err = null;
+
+    try {
+       await wallet.send({outputs: []});
+    } catch (e) {
+      err = e;
+   }
+
+    assert(err);
+    assert.equal(err.message, 'At least one output required.');
+  });
 
   it('should cleanup', async () => {
     consensus.COINBASE_MATURITY = 100;


### PR DESCRIPTION
If you try to `wallet.send()` with an empty `outputs` array, the error you currently get is:
`No outputs available.`

This was confusing me because I thought the wallet was unable to find any coins to spend, like it had a zero balance or coinbase outputs were not mature yet.

This PR changes that error to `At least one output required.` which indicates to the user/developer more specifically which output is missing.