### PR TITLE
chain: allow coin-cache and mempool-size values greater than 4095

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2784,7 +2784,7 @@ class ChainOptions {
     }
 
     if (options.coinCache != null) {
-      assert((options.coinCache >>> 0) === options.coinCache);
+      assert(typeof options.coinCache === 'number');
       this.coinCache = options.coinCache;
     }
 

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -2107,7 +2107,7 @@ class MempoolOptions {
     }
 
     if (options.maxSize != null) {
-      assert((options.maxSize >>> 0) === options.maxSize);
+      assert(typeof options.maxSize === 'number');
       this.maxSize = options.maxSize;
     }
 


### PR DESCRIPTION
Closes #625 

[Because `bcfg.mb()` multiplies the given value `* 1024 * 1024`](https://github.com/bcoin-org/bcfg/blob/master/lib/config.js#L680-L697) it's easy to end up with a value larger than 32 bits. This throws an assertion error in `blockchain/chain.js/ChainOptions.fromOptions()` which tests the user input with a bit shift operation:
`assert((options.coinCache >>> 0) === options.coinCache)`


Observe:
```
> (4095 * 1024 * 1024) >>> 0
4293918720
> (4096 * 1024 * 1024) >>> 0
0
```

This PR just asserts that the `coinCache` value is ` number`.