### PR TITLE
Update Regtest Specific Params

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2389,6 +2389,9 @@ class Chain extends AsyncEmitter {
   async getState(prev, deployment) {
     const bit = deployment.bit;
 
+    if (deployment.startTime === -1)
+      return thresholdStates.ACTIVE;
+
     let window = this.network.minerWindow;
     let threshold = this.network.activationThreshold;
 

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2389,9 +2389,6 @@ class Chain extends AsyncEmitter {
   async getState(prev, deployment) {
     const bit = deployment.bit;
 
-    if (deployment.startTime === -1)
-      return thresholdStates.ACTIVE;
-
     let window = this.network.minerWindow;
     let threshold = this.network.activationThreshold;
 

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -639,13 +639,13 @@ class ChainDB {
    */
 
   writeDeployments(b) {
-    const bw = bio.write(1 + 17 * this.network.deploys.length);
+    const bw = bio.write(1 + 21 * this.network.deploys.length);
 
     bw.writeU8(this.network.deploys.length);
 
     for (const deployment of this.network.deploys) {
       bw.writeU8(deployment.bit);
-      bw.writeU32(deployment.startTime);
+      bw.writeI64(deployment.startTime);
       bw.writeU32(deployment.timeout);
       bw.writeI32(deployment.threshold);
       bw.writeI32(deployment.window);
@@ -671,7 +671,7 @@ class ChainDB {
 
     for (let i = 0; i < count; i++) {
       const bit = br.readU8();
-      const start = br.readU32();
+      const start = br.readI64();
       const timeout = br.readU32();
       const threshold = br.readI32();
       const window = br.readI32();

--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -720,7 +720,7 @@ regtest.seeds = [
 
 regtest.magic = 0xdab5bffa;
 
-regtest.port = 18444;
+regtest.port = 48444;
 
 regtest.checkpointMap = {};
 regtest.lastCheckpoint = 0;
@@ -856,7 +856,7 @@ regtest.addressPrefix = {
 
 regtest.requireStandard = false;
 
-regtest.rpcPort = 18443;
+regtest.rpcPort = 48332;
 
 regtest.walletPort = 48334;
 

--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -801,7 +801,7 @@ regtest.deployments = {
   segwit: {
     name: 'segwit',
     bit: 1,
-    startTime: 0,
+    startTime: -1,
     timeout: 0xffffffff,
     threshold: -1,
     window: -1,

--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -720,7 +720,7 @@ regtest.seeds = [
 
 regtest.magic = 0xdab5bffa;
 
-regtest.port = 48444;
+regtest.port = 18444;
 
 regtest.checkpointMap = {};
 regtest.lastCheckpoint = 0;
@@ -838,25 +838,25 @@ regtest.deploys = [
 ];
 
 regtest.keyPrefix = {
-  privkey: 0x5a,
-  xpubkey: 0xeab4fa05,
-  xprivkey: 0xeab404c7,
-  xpubkey58: 'rpub',
-  xprivkey58: 'rprv',
+  privkey: 0xef,
+  xpubkey: 0x043587cf,
+  xprivkey: 0x04358394,
+  xpubkey58: 'tpub',
+  xprivkey58: 'tprv',
   coinType: 1
 };
 
 regtest.addressPrefix = {
-  pubkeyhash: 0x3c,
-  scripthash: 0x26,
-  witnesspubkeyhash: 0x7a,
-  witnessscripthash: 0x14,
-  bech32: 'rb'
+  pubkeyhash: 0x6f,
+  scripthash: 0xc4,
+  witnesspubkeyhash: 0x03,
+  witnessscripthash: 0x28,
+  bech32: 'bcrt'
 };
 
 regtest.requireStandard = false;
 
-regtest.rpcPort = 48332;
+regtest.rpcPort = 18443;
 
 regtest.walletPort = 48334;
 

--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -801,7 +801,7 @@ regtest.deployments = {
   segwit: {
     name: 'segwit',
     bit: 1,
-    startTime: -1,
+    startTime: 0,
     timeout: 0xffffffff,
     threshold: -1,
     window: -1,

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -203,12 +203,14 @@ describe('HTTP', function() {
   });
 
   it('should get a block template', async () => {
-    const json = await nclient.execute('getblocktemplate', []);
+    const json = await nclient.execute('getblocktemplate', [{
+      rules: ['segwit']
+    }]);
     assert.deepStrictEqual(json, {
       capabilities: ['proposal'],
       mutable: ['time', 'transactions', 'prevblock'],
       version: 536870912,
-      rules: [],
+      rules: ['!segwit'],
       vbavailable: {},
       vbrequired: 0,
       height: 1,
@@ -222,15 +224,19 @@ describe('HTTP', function() {
       mintime: 1296688603,
       maxtime: json.maxtime,
       expires: json.expires,
-      sigoplimit: 20000,
-      sizelimit: 1000000,
+      sigoplimit: 80000,
+      sizelimit: 4000000,
+      weightlimit: 4000000,
       longpollid:
         '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206'
         + '00000000',
       submitold: false,
       coinbaseaux: { flags: '6d696e65642062792062636f696e' },
       coinbasevalue: 5000000000,
-      transactions: []
+      transactions: [],
+      default_witness_commitment:
+        '6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48beb'
+        + 'd836974e8cf9'
     });
   });
 


### PR DESCRIPTION
This pull request updates the key prefixes and address prefixes to match `bitcoind` and `btcd`.
Addresses this issue: https://github.com/bcoin-org/bcoin/issues/579
See https://github.com/satoshilabs/slips/blob/master/slip-0173.md for a list of human readable prefixes


It build on https://github.com/bcoin-org/bcoin/pull/580 and reverts the change that sets the segwit`startTime` to `-1`
https://github.com/bcoin-org/bcoin/pull/580/files#diff-44d3bcd9142fb799b54cb36cac72561eR804.

`startTime` is written and read from leveldb as a `uint`, as seen here:
https://github.com/bcoin-org/bcoin/blob/master/lib/blockchain/chaindb.js#L648
so setting it to `-1` will cause an underflow and breaks some tests