### PR TITLE
Fix lint configs

### DIFF
--- a/.eslintfiles
+++ b/.eslintfiles
@@ -5,9 +5,8 @@ bin/spvnode
 bin/wallet
 browser/server.js
 browser/wsproxy.js
+browser/src/app.js
 lib/
 migrate/
 scripts/
 test/
-webpack.browser.js
-webpack.compat.js

--- a/browser/src/app.js
+++ b/browser/src/app.js
@@ -1,3 +1,4 @@
+/* eslint-env browser */
 'use strict';
 
 const Logger = require('blgr');


### PR DESCRIPTION
This commit https://github.com/bcoin-org/bcoin/commit/0a71b445e0c12819e417bdf1df018fcb7bed4f0c removes `webpack` related files. The CI uses the the npm script `lint-ci`, which exits with a non zero code due to `eslint` looking for files that were removed from the project.

The commit message says that the files were removed temporarily, but the CI shouldn't fail temporarily. This commit removes the references to the files that no longer exist from `.eslintfiles` so that the CI can pass again.

description from: #678 