### PR TITLE
linting: temporarily remove missing files

### DIFF
--- a/.eslintfiles
+++ b/.eslintfiles
@@ -9,5 +9,3 @@ lib/
 migrate/
 scripts/
 test/
-webpack.browser.js
-webpack.compat.js


### PR DESCRIPTION
This commit https://github.com/bcoin-org/bcoin/commit/0a71b445e0c12819e417bdf1df018fcb7bed4f0c removes `webpack` related files. The CI uses the the npm script `lint-ci`, which exits with a non zero code due to `eslint` looking for files that were removed from the project.

The commit message says that the files were removed temporarily, but the CI shouldn't fail temporarily. This commit removes the references to the files that no longer exist from `.eslintfiles` so that the CI can pass again