### PR TITLE
wallet: add "accountPath" attribute to handle edges cases with watch-only accountKeys

### DIFF
--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -13,6 +13,7 @@ const Path = require('./path');
 const common = require('./common');
 const Script = require('../script/script');
 const WalletKey = require('./walletkey');
+const HDCommon = require('../hd/common');
 const {HDPublicKey} = require('../hd/hd');
 
 /**
@@ -40,6 +41,7 @@ class Account {
     this.wid = 0;
     this.id = null;
     this.accountIndex = 0;
+    this.accountPath = 0;
     this.name = null;
     this.initialized = false;
     this.witness = wdb.options.witness === true;
@@ -145,6 +147,11 @@ class Account {
     }
 
     this.accountKey = options.accountKey;
+
+    // for watch-only wallets, accountPath is derived from accountKey
+    this.accountPath = this.watchOnly ?
+      this.accountKey.childIndex ^ HDCommon.HARDENED :
+      this.accountIndex;
 
     if (this.n > 1)
       this.type = Account.types.MULTISIG;
@@ -789,6 +796,7 @@ class Account {
       m: this.m,
       n: this.n,
       accountIndex: this.accountIndex,
+      accountPath: this.accountPath,
       receiveDepth: this.receiveDepth,
       changeDepth: this.changeDepth,
       nestedDepth: this.nestedDepth,
@@ -821,6 +829,7 @@ class Account {
       m: this.m,
       n: this.n,
       accountIndex: this.accountIndex,
+      accountPath: this.accountPath,
       receiveDepth: this.receiveDepth,
       changeDepth: this.changeDepth,
       nestedDepth: this.nestedDepth,

--- a/lib/wallet/path.js
+++ b/lib/wallet/path.js
@@ -32,6 +32,7 @@ class Path {
 
     this.name = null; // Passed in by caller.
     this.account = 0;
+    this.accountPath = 0;
 
     this.type = Address.types.PUBKEYHASH;
     this.version = -1;
@@ -60,6 +61,7 @@ class Path {
 
     this.name = options.name;
     this.account = options.account;
+    this.accountPath = options.account;
     this.branch = options.branch;
     this.index = options.index;
 
@@ -238,6 +240,7 @@ class Path {
     this.keyType = Path.types.ADDRESS;
     this.name = account.name;
     this.account = account.accountIndex;
+    this.accountPath = account.account;
     this.version = address.version;
     this.type = address.type;
     this.hash = address.getHash();
@@ -264,7 +267,7 @@ class Path {
     if (this.keyType !== Path.types.HD)
       return null;
 
-    return `m/${this.account}'/${this.branch}/${this.index}`;
+    return `m/${this.accountPath}'/${this.branch}/${this.index}`;
   }
 
   /**
@@ -285,6 +288,7 @@ class Path {
     return {
       name: this.name,
       account: this.account,
+      accountPath: this.accountPath || this.account,
       change: this.branch === 1,
       derivation: this.toPath()
     };

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -22,6 +22,7 @@ const Path = require('./path');
 const common = require('./common');
 const Wallet = require('./wallet');
 const Account = require('./account');
+const HDCommon = require('../hd/common');
 const Outpoint = require('../primitives/outpoint');
 const layouts = require('./layout');
 const records = require('./records');
@@ -1117,7 +1118,9 @@ class WalletDB extends EventEmitter {
     assert(data);
 
     const account = Account.fromRaw(this, data);
+    const childIndex = account.accountKey.childIndex;
 
+    account.accountPath = childIndex ^ HDCommon.HARDENED;
     account.accountIndex = index;
     account.name = name;
 
@@ -1250,7 +1253,9 @@ class WalletDB extends EventEmitter {
     if (!path)
       return null;
 
-    path.name = await this.getAccountName(wid, path.account);
+    const account = await this.getAccount(wid, path.account);
+    path.name = account.name;
+    path.accountPath = account.accountPath;
     assert(path.name);
 
     return path;

--- a/lib/wallet/walletkey.js
+++ b/lib/wallet/walletkey.js
@@ -32,6 +32,7 @@ class WalletKey extends KeyRing {
 
     this.name = null;
     this.account = -1;
+    this.accountPath = -1;
     this.branch = -1;
     this.index = -1;
   }
@@ -45,6 +46,7 @@ class WalletKey extends KeyRing {
     return {
       name: this.name,
       account: this.account,
+      accountPath: this.accountPath || this.account,
       branch: this.branch,
       index: this.index,
       witness: this.witness,
@@ -71,6 +73,7 @@ class WalletKey extends KeyRing {
     this.keyType = Path.types.HD;
     this.name = account.name;
     this.account = account.accountIndex;
+    this.accountPath = account.accountPath;
     this.branch = branch;
     this.index = index;
     this.witness = account.witness;
@@ -107,6 +110,7 @@ class WalletKey extends KeyRing {
     this.keyType = Path.types.KEY;
     this.name = account.name;
     this.account = account.accountIndex;
+    this.accountPath = account.accountIndex;
     this.witness = account.witness;
     return this.fromRaw(data);
   }
@@ -134,6 +138,7 @@ class WalletKey extends KeyRing {
     this.keyType = Path.types.KEY;
     this.name = account.name;
     this.account = account.accountIndex;
+    this.accountPath = account.accountIndex;
     this.witness = account.witness;
     return this.fromOptions(ring);
   }
@@ -159,6 +164,7 @@ class WalletKey extends KeyRing {
 
     path.name = this.name;
     path.account = this.account;
+    path.accountPath = this.account;
 
     switch (this.keyType) {
       case Path.types.HD:


### PR DESCRIPTION
Motivation:
In case of watch-only wallets, accountIndex is "arbitrary".
It simply maps to internal walletdb account instead of
BIP44 account path as defined in original accountKey.

It is important to return the actual accountIndex for use-cases
such as hardware-wallets, so clients can easily reproduce the
original path for this account.

To maintain backwards compatbility with existing wallets,
it is easiest to add this as a separate accountPath field
instead of refactoring all the existing uses of accountIndex.


Note: This was discussed out-of-band and after many iterations we decided adding a new field is probably the simplest solution. At the very least it results in the fewest code changes.