### PR TITLE
protocol: clear regtest seeds

### DIFF
--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -714,9 +714,7 @@ const regtest = {};
 
 regtest.type = 'regtest';
 
-regtest.seeds = [
-  '127.0.0.1'
-];
+regtest.seeds = [];
 
 regtest.magic = 0xdab5bffa;
 


### PR DESCRIPTION
This prevents attempts to add itself as a peer that would
generate unnecessary error log messages when running a regtest node.