### PR TITLE
Keep event loop alive for workers

### DIFF
--- a/lib/workers/child.js
+++ b/lib/workers/child.js
@@ -60,11 +60,6 @@ class Child extends EventEmitter {
 
     this.child = cp.spawn(bin, [filename], options);
 
-    this.child.unref();
-    this.child.stdin.unref();
-    this.child.stdout.unref();
-    this.child.stderr.unref();
-
     this.child.on('error', (err) => {
       this.emit('error', err);
     });

--- a/test/chain-test.js
+++ b/test/chain-test.js
@@ -886,5 +886,6 @@ describe('Chain', function() {
   it('should cleanup', async () => {
     await miner.close();
     await chain.close();
+    await workers.close();
   });
 });

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -1644,6 +1644,7 @@ describe('Wallet', function() {
 
   it('should cleanup', async () => {
     consensus.COINBASE_MATURITY = 100;
+    await workers.close();
     // await wdb.close();
   });
 });

--- a/test/workers-test.js
+++ b/test/workers-test.js
@@ -1,0 +1,51 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('./util/assert');
+const WorkerPool = require('../lib/workers/workerpool');
+const Miner = require('../lib/mining/miner');
+const Chain = require('../lib/blockchain/chain');
+
+const workers = new WorkerPool({
+  enabled: true,
+  size: 1
+});
+
+const chain = new Chain({
+  network: 'regtest'
+});
+
+const miner = new Miner({
+  chain: chain,
+  workers: workers
+});
+
+describe('Workers', function() {
+  it('should spawn workers', async () => {
+    await miner.open();
+    await chain.open();
+
+    assert(workers.children.size === 0);
+
+    const job = await miner.createJob();
+    const block = await job.mineAsync();
+    assert(block);
+
+    assert(workers.children.size === 1);
+
+    const cp = workers.children.get(0).child.child;
+    assert(!cp.killed);
+  });
+
+  it('should cleanup', async () => {
+    // Close worker threads.
+    // Testing framework will hang if this fails
+    // https://boneskull.com/mocha-v4-nears-release/#mochawontforceexit
+    await workers.close();
+
+    const cp = workers.children.get(0).child.child;
+    assert(cp.killed);
+  });
+});


### PR DESCRIPTION
What this PR does is remove the `unref()` calls from `child_process`'s that are spawned to run workers in parallel threads.

Currently in bcoin workers are not referenced by the main thread. This means that there must be _something else in the event loop_ to keep the process alive long enough to _receive_ output generated by workers. Otherwise, nodejs will exit before the main thread has a chance to catch packets emitted by the worker.

[From the docs:](https://nodejs.org/api/child_process.html#child_process_subprocess_unref)
> By default, the parent will wait for the detached child to exit. To prevent the parent from waiting for a given subprocess to exit, use the subprocess.unref() method. Doing so will cause the parent's event loop to not include the child in its reference count, allowing the parent to exit independently of the child, unless there is an established IPC channel between the child and the parent.

Consider the script at https://github.com/bcoin-org/bcoin/blob/65d598ba5ab2c041f0bb9bc29ac5c0a5e090a173/docs/Examples/miner-configs.js

This is a minimal use-case without a `FullNode`. Workers are spawned by `mineAsync()`, but code execution will terminate before the workers can respond with a nonce, which the main thread is waiting for to complete the block. If a `FullNode` object were used here instead of `chain` + `miner` + `workers`, the script would finish with a complete block. In that case, the reason the process stays alive long enough to do so is because  _`FullNode` objects also open an http server_. [The http server keeps the event loop alive even if bcoin isn't actually doing any networking.](https://stackoverflow.com/questions/52771650/how-server-listen-method-keep-node-process-still-running)

This PR keeps references to the `child_process`'s on the main thread's event loop so even without any other objects being created or other bcoin stuff happening, a `WorkerPool` can operate on its own.

The downside to this is that bcoin will wait for the child threads to terminate before terminating itself. However, this is the case with many objects in the library, and there's examples of necessary `.close()` functions for all the servers and databases we use.

The `unref()`'s were added at this commit (with link to an issue about closing cleanly):
https://github.com/bcoin-org/bcoin/commit/4f09065a3e1538f3395189beba0eb2396880555d

...but I'm not entirely sure why, or if the `unref` is needed for anything else. Since we now also have `SIGINT` listeners (https://github.com/bcoin-org/bcoin/commit/8630a8ee51dd9378f2cf65da87c3d21bf76f566a) which close `node`'s, which close `workers`, I think the `unref` calls maybe unnecessary.