### PR TITLE
pkg: link bclient to bin

### DIFF
--- a/bin/bcoin-cli
+++ b/bin/bcoin-cli
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+'use strict';
+
+require('bclient/bin/bcoin-cli');

--- a/bin/bwallet-cli
+++ b/bin/bwallet-cli
@@ -3,4 +3,3 @@
 'use strict';
 
 require('bclient/bin/bwallet-cli');
-

--- a/bin/bwallet-cli
+++ b/bin/bwallet-cli
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+'use strict';
+
+require('bclient/bin/bwallet-cli');
+

--- a/bin/cli
+++ b/bin/cli
@@ -4,11 +4,4 @@
 
 console.error('%s%s',
   'Warning: The `bcoin cli` interface is deprecated.\n',
-  'Please use `bcoin-cli` ($ npm install bclient).');
-
-if (process.argv.length > 2 && process.argv[2] === 'wallet') {
-  process.argv.splice(2, 1); // Evil hack.
-  require('bclient/bin/bwallet-cli');
-} else {
-  require('bclient/bin/bcoin-cli');
-}
+  'Please use `bcoin-cli` and `bwallet-cli` instead.');

--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
     "bcoin": "./bin/bcoin",
     "bcoin-node": "./bin/node",
     "bcoin-spvnode": "./bin/spvnode",
-    "bwallet": "./bin/bwallet"
+    "bwallet": "./bin/bwallet",
+    "bcoin-cli": "./bin/bcoin-cli",
+    "bwallet-cli": "./bin/bwallet-cli"
   },
   "scripts": {
     "browserify": "browserify -s bcoin lib/bcoin-browser.js | uglifyjs -c > bcoin.js",


### PR DESCRIPTION
After installation, links `bcoin-cli` and `bwallet-cli` directly to bclient bin, already installed