### PR TITLE
Quit if native bcrypto bindings are missing

### DIFF
--- a/bin/node
+++ b/bin/node
@@ -19,6 +19,23 @@ if (process.argv.indexOf('--version') !== -1
   throw new Error('Could not exit.');
 }
 
+const sha256 = require('bcrypto/lib/sha256');
+const secp256k1 = require('bcrypto/lib/secp256k1');
+
+if (sha256.native !== 2) {
+  console.error('Bindings for bcrypto were not built.');
+  console.error('Please build them before continuing.');
+  process.exit(1);
+  return;
+}
+
+if (secp256k1.native !== 2) {
+  console.error('Bindings for libsecp256k1 were not built.');
+  console.error('Please build them before continuing.');
+  process.exit(1);
+  return;
+}
+
 const FullNode = require('../lib/node/fullnode');
 
 const node = new FullNode({

--- a/bin/spvnode
+++ b/bin/spvnode
@@ -8,6 +8,23 @@ const assert = require('assert');
 const SPVNode = require('../lib/node/spvnode');
 const Outpoint = require('../lib/primitives/outpoint');
 
+const sha256 = require('bcrypto/lib/sha256');
+const secp256k1 = require('bcrypto/lib/secp256k1');
+
+if (sha256.native !== 2) {
+  console.error('Bindings for bcrypto were not built.');
+  console.error('Please build them before continuing.');
+  process.exit(1);
+  return;
+}
+
+if (secp256k1.native !== 2) {
+  console.error('Bindings for libsecp256k1 were not built.');
+  console.error('Please build them before continuing.');
+  process.exit(1);
+  return;
+}
+
 const node = new SPVNode({
   file: true,
   argv: true,


### PR DESCRIPTION
This addresses user concern https://github.com/bcoin-org/bcoin/issues/572
and replaces https://github.com/bcoin-org/bcrypto/pull/9

Test by moving or renaming the `build` directory in `bcrypto` which will force bcrypto to use nodejs crypto or proprietary crypto scripts for everything.

This PR throws an Error during `handleOpen()` that the bindings could not be found unless user explicitly sets `NODE_BACKEND=js` or `NODE_BACKEND=node`