### PR TITLE
Fix Keyring public key import

### DIFF
--- a/lib/primitives/keyring.js
+++ b/lib/primitives/keyring.js
@@ -77,8 +77,10 @@ class KeyRing {
       this.nested = options.nested;
     }
 
+    const compress = options.compressed;
+    
     if (Buffer.isBuffer(key))
-      return this.fromKey(key);
+      return this.fromKey(key, compress);
 
     key = toKey(options.key);
 
@@ -89,7 +91,6 @@ class KeyRing {
       key = toKey(options.privateKey);
 
     const script = options.script;
-    const compress = options.compressed;
 
     if (script)
       return this.fromScript(key, script, compress);
@@ -154,19 +155,21 @@ class KeyRing {
    * Inject data from public key.
    * @private
    * @param {Buffer} key
+   * @param {Boolean?} compress (default = true)
+   * @returns {KeyRing}
    */
 
-  fromPublic(key) {
+  fromPublic(key, compress) {
     assert(Buffer.isBuffer(key), 'Public key must be a buffer.');
     assert(secp256k1.publicKeyVerify(key), 'Not a valid public key.');
-    this.publicKey = key;
+    this.publicKey = secp256k1.publicKeyConvert(key, compress !== false);
     return this;
   }
 
   /**
    * Generate a keyring.
    * @private
-   * @param {Boolean?} compress
+   * @param {Boolean?} compress (default = true)
    * @returns {KeyRing}
    */
 
@@ -177,7 +180,7 @@ class KeyRing {
 
   /**
    * Generate a keyring.
-   * @param {Boolean?} compress
+   * @param {Boolean?} compress (default = true)
    * @returns {KeyRing}
    */
 
@@ -188,18 +191,19 @@ class KeyRing {
   /**
    * Instantiate keyring from a public key.
    * @param {Buffer} publicKey
+   * @param {Boolean?} compress (default = true)
    * @returns {KeyRing}
    */
 
-  static fromPublic(key) {
-    return new this().fromPublic(key);
+  static fromPublic(key, compress) {
+    return new this().fromPublic(key, compress !== false);
   }
 
   /**
    * Inject data from public key.
    * @private
    * @param {Buffer} privateKey
-   * @param {Boolean?} compress
+   * @param {Boolean?} compress (default = true)
    */
 
   fromKey(key, compress) {
@@ -208,7 +212,7 @@ class KeyRing {
     if (key.length === 32)
       return this.fromPrivate(key, compress !== false);
 
-    return this.fromPublic(key);
+    return this.fromPublic(key, compress !== false);
   }
 
   /**


### PR DESCRIPTION
Related to #732: the "compressed" option had no effect for public key import.

A "compress" parameter is added on `fromPublic` and `static fromPublic` methods, it default to `true`, but it is backward compatible as these methods were systematically creating compressed keys.