### PR TITLE
Remove coin cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
 
 - Pool options now has a `--discover` option exposed, and the `--only` node
   option will disable discovery of new nodes.
+- The option for `coin-cache` has been removed, this setting was causing
+  issues during the sync with out-of-memory errors and was making performance
+  worse instead of better.
 
 ### Script changes
 

--- a/browser/src/app.js
+++ b/browser/src/app.js
@@ -61,7 +61,6 @@ const node = new FullNode({
   prune: true,
   network: 'main',
   memory: false,
-  coinCache: 30,
   logConsole: true,
   workers: true,
   workerFile: '/worker.js',

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,9 +87,6 @@ database and must be passed in consistently.
 - `prune`: Prune from the last 288 blocks (default: false).
 - `checkpoints`: Use checkpoints and getheaders for the initial
   sync (default: true).
-- `coin-cache`: The size (in MB) of the in-memory UTXO cache. By default,
-  there is no UTXO cache enabled. To get a good number of cache hits per
-  block, the coin cache has to be fairly large (60-100mb recommended at least).
 - `index-tx`: Index transactions (enables transaction endpoints in REST api)
   (default: false).
 - `index-address`: Index transactions and utxos by address (default: false).

--- a/etc/sample.conf
+++ b/etc/sample.conf
@@ -37,7 +37,6 @@ log-file: true
 
 prune: false
 checkpoints: true
-coin-cache: 0
 entry-cache: 5000
 index-tx: false
 index-address: false

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -79,9 +79,6 @@ class Chain extends AsyncEmitter {
     if (this.options.checkpoints)
       this.logger.info('Checkpoints are enabled.');
 
-    if (this.options.coinCache)
-      this.logger.info('Coin cache is enabled.');
-
     if (this.options.bip91)
       this.logger.warning('BIP91 enabled. Segsignal will be enforced.');
 
@@ -1535,11 +1532,6 @@ class Chain extends AsyncEmitter {
       block.getSize(),
       block.txs.length,
       elapsed);
-
-    if (this.db.coinCache.capacity > 0) {
-      this.logger.debug('Coin Cache: size=%dmb, items=%d.',
-        this.db.coinCache.size / (1 << 20), this.db.coinCache.items);
-    }
   }
 
   /**
@@ -2687,7 +2679,6 @@ class ChainOptions {
     this.indexAddress = false;
     this.forceFlags = false;
 
-    this.coinCache = 0;
     this.entryCache = 5000;
     this.maxOrphans = 20;
     this.checkpoints = true;
@@ -2784,11 +2775,6 @@ class ChainOptions {
     if (options.bip148 != null) {
       assert(typeof options.bip148 === 'boolean');
       this.bip148 = options.bip148;
-    }
-
-    if (options.coinCache != null) {
-      assert((options.coinCache >>> 0) === options.coinCache);
-      this.coinCache = options.coinCache;
     }
 
     if (options.entryCache != null) {

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -47,7 +47,6 @@ class ChainDB {
     this.pending = null;
     this.current = null;
 
-    this.coinCache = new LRU(this.options.coinCache, getSize, BufferMap);
     this.cacheHash = new LRU(this.options.entryCache, null, BufferMap);
     this.cacheHeight = new LRU(this.options.entryCache);
   }
@@ -118,7 +117,6 @@ class ChainDB {
     this.current = this.db.batch();
     this.pending = this.state.clone();
 
-    this.coinCache.start();
     this.cacheHash.start();
     this.cacheHeight.start();
 
@@ -170,7 +168,6 @@ class ChainDB {
     this.current = null;
     this.pending = null;
 
-    this.coinCache.drop();
     this.cacheHash.drop();
     this.cacheHeight.drop();
     this.stateCache.drop();
@@ -192,7 +189,6 @@ class ChainDB {
     } catch (e) {
       this.current = null;
       this.pending = null;
-      this.coinCache.drop();
       this.cacheHash.drop();
       this.cacheHeight.drop();
       throw e;
@@ -209,7 +205,6 @@ class ChainDB {
     this.current = null;
     this.pending = null;
 
-    this.coinCache.commit();
     this.cacheHash.commit();
     this.cacheHeight.commit();
     this.stateCache.commit();
@@ -923,21 +918,11 @@ class ChainDB {
       return null;
 
     const {hash, index} = prevout;
-    const key = prevout.toKey();
-    const state = this.state;
-
-    const cache = this.coinCache.get(key);
-
-    if (cache)
-      return CoinEntry.fromRaw(cache);
 
     const raw = await this.db.get(layout.c.encode(hash, index));
 
     if (!raw)
       return null;
-
-    if (state === this.state)
-      this.coinCache.set(key, raw);
 
     return CoinEntry.fromRaw(raw);
   }
@@ -1722,17 +1707,12 @@ class ChainDB {
       for (const [index, coin] of coins.outputs) {
         if (coin.spent) {
           this.del(layout.c.encode(hash, index));
-          if (this.coinCache.capacity > 0)
-            this.coinCache.unpush(Outpoint.toKey(hash, index));
           continue;
         }
 
         const raw = coin.toRaw();
 
         this.put(layout.c.encode(hash, index), raw);
-
-        if (this.coinCache.capacity > 0)
-          this.coinCache.push(Outpoint.toKey(hash, index), raw);
       }
     }
   }
@@ -2280,10 +2260,6 @@ class CacheUpdate {
 /*
  * Helpers
  */
-
-function getSize(value) {
-  return value.length + 80;
-}
 
 function fromU32(num) {
   const data = Buffer.allocUnsafe(4);

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -54,7 +54,6 @@ class FullNode extends Node {
       bip148: this.config.bool('bip148'),
       prune: this.config.bool('prune'),
       checkpoints: this.config.bool('checkpoints'),
-      coinCache: this.config.mb('coin-cache'),
       entryCache: this.config.uint('entry-cache'),
       indexTX: this.config.bool('index-tx'),
       indexAddress: this.config.bool('index-address')


### PR DESCRIPTION
Closes https://github.com/bcoin-org/bcoin/issues/626 and https://github.com/bcoin-org/bcoin/issues/625

A few reasons why the coin cache should be removed:
- Performance actually decreases when the `coin-cache` setting increased, often times it's faster at a value of 0 (see discussion at https://github.com/bcoin-org/bcoin/pull/672).
- The JS heap is limited _(around 1.4GB)_, so the cache would be better _outside_ the JS heap, where the value can be raised to be larger without causing "heap out of memory" issues. LevelDB already does it's own caching, this can be adjusted with `cache-size` and that cache can be used to keep data in memory. Initial tests show that increasing `cache-size` doesn't have an effect on performance, so there could be other bottlenecks.
- A coin during sync is likely to be requested _once_, when it's being spent, and then deleted. So an LRU may not really be useful here. It may be more likely that a more recently added coin will be spent, further analysis would be needed to confirm.
- The cached item is still deserialized, so it's not saving CPU or GC overhead.