### PR TITLE
mempool: turn on replace by fee by default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,7 +97,7 @@ database and must be passed in consistently.
 ## Mempool options
 
 - `mempool-size`: Max mempool size in MB (default: 100).
-- `replace-by-fee`: Allow replace-by-fee transactions (default: false).
+- `replace-by-fee`: Allow replace-by-fee transactions (default: true).
 - `persistent-mempool`: Save mempool to disk and read into memory on boot
   (default: false).
 

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -2011,7 +2011,7 @@ class MempoolOptions {
     this.rejectAbsurdFees = true;
     this.prematureWitness = false;
     this.paranoidChecks = false;
-    this.replaceByFee = false;
+    this.replaceByFee = true;
 
     this.maxSize = policy.MEMPOOL_MAX_SIZE;
     this.maxOrphans = policy.MEMPOOL_MAX_ORPHANS;


### PR DESCRIPTION
This matches Bitcoin Core's policy of allowing transactions to be replaced via replace by fee in the mempool by default. Turning off this policy results in many transactions being rejected from the mempool. `bitcoind` refers to this setting as `-mempoolreplacement`. See `bitcoind` v0.12.0 release notes:

https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.12.0.md

See https://github.com/bitcoin/bitcoin/blob/master/src/validation.h#L125-L126
```c++
/** Default for -mempoolreplacement */
static const bool DEFAULT_ENABLE_REPLACEMENT = true;
```

Thanks to @pinheadmz for finding the code snippet in `bitcoind`