### PR TITLE
bcoin: use cryptographic randomness

### DIFF
--- a/lib/mining/miner.js
+++ b/lib/mining/miner.js
@@ -11,6 +11,7 @@ const assert = require('bsert');
 const EventEmitter = require('events');
 const Heap = require('bheep');
 const {BufferMap} = require('buffer-map');
+const random = require('bcrypto/lib/random');
 const Amount = require('../btc/amount');
 const Address = require('../primitives/address');
 const BlockTemplate = require('./template');
@@ -235,7 +236,7 @@ class Miner extends EventEmitter {
   getAddress() {
     if (this.addresses.length === 0)
       return new Address();
-    return this.addresses[Math.random() * this.addresses.length | 0];
+    return this.addresses[random.randomRange(0, this.addresses.length)];
   }
 
   /**

--- a/lib/mining/template.js
+++ b/lib/mining/template.js
@@ -11,6 +11,7 @@ const assert = require('bsert');
 const bio = require('bufio');
 const hash256 = require('bcrypto/lib/hash256');
 const merkle = require('bcrypto/lib/merkle');
+const random = require('bcrypto/lib/random');
 const util = require('../utils/util');
 const Address = require('../primitives/address');
 const TX = require('../primitives/tx');
@@ -253,7 +254,7 @@ class BlockTemplate {
 
     // Smaller nonce for good measure.
     const nonce = Buffer.allocUnsafe(4);
-    nonce.writeUInt32LE(Math.random() * 0x100000000, 0, true);
+    nonce.writeUInt32LE(random.randomInt(), 0, true);
     input.script.pushData(nonce);
 
     // Extra nonce: incremented when

--- a/lib/net/common.js
+++ b/lib/net/common.js
@@ -11,6 +11,7 @@
  * @module net/common
  */
 
+const random = require('bcrypto/lib/random');
 const pkg = require('../pkg');
 
 /**
@@ -166,10 +167,7 @@ exports.BAN_SCORE = 100;
  */
 
 exports.nonce = function nonce() {
-  const data = Buffer.allocUnsafe(8);
-  data.writeUInt32LE((Math.random() * 0x100000000) >>> 0, 0, true);
-  data.writeUInt32LE((Math.random() * 0x100000000) >>> 0, 4, true);
-  return data;
+  return random.randomBytes(8);
 };
 
 /**

--- a/lib/net/hostlist.js
+++ b/lib/net/hostlist.js
@@ -14,6 +14,7 @@ const dns = require('bdns');
 const Logger = require('blgr');
 const murmur3 = require('mrmr');
 const List = require('blst');
+const bcrypto = require('bcrypto');
 const util = require('../utils/util');
 const Network = require('../protocol/network');
 const NetAddress = require('./netaddress');
@@ -1635,7 +1636,7 @@ function concat32(left, right) {
 }
 
 function random(max) {
-  return Math.floor(Math.random() * max);
+  return bcrypto.random.randomRange(0, max);
 }
 
 /*


### PR DESCRIPTION
Use `bcrypto` as a source of randomness over `Math.random`.
This is based on work by chjj on hsd. 

See https://github.com/handshake-org/hsd/commit/f36670bd5d12b69bf53a7351da5dd1f77986e0d4

Addresses https://github.com/handshake-org/hsd/issues/107