### PR TITLE
util: reverse buffers instead of strings

### DIFF
--- a/bench/hexstring.js
+++ b/bench/hexstring.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const random = require('bcrypto/lib/random');
+const util = require('../lib/utils/util');
+const bench = require('./bench');
+
+const hashes = [];
+
+for (let i = 0; i < 100000; i++)
+  hashes.push(random.randomBytes(32));
+
+{
+  const end = bench('hexstring');
+  for (let i = 0; i < hashes.length; i++)
+    util.fromRev(util.revHex(hashes[i]));
+  end(100000);
+}

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -96,31 +96,19 @@ util.time = function time(date) {
 
 /**
  * Reverse a hex-string.
- * @param {String} str - Hex string.
+ * @param {Buffer}
  * @returns {String} Reversed hex string.
  */
 
 util.revHex = function revHex(buf) {
   assert(Buffer.isBuffer(buf));
 
-  const str = buf.toString('hex');
-
-  let out = '';
-
-  for (let i = str.length - 2; i >= 0; i -= 2)
-    out += str[i] + str[i + 1];
-
-  return out;
+  return Buffer.from(buf).reverse().toString('hex');
 };
 
 util.fromRev = function fromRev(str) {
   assert(typeof str === 'string');
   assert((str.length & 1) === 0);
 
-  let out = '';
-
-  for (let i = str.length - 2; i >= 0; i -= 2)
-    out += str[i] + str[i + 1];
-
-  return Buffer.from(out, 'hex');
+  return Buffer.from(str, 'hex').reverse();
 };


### PR DESCRIPTION
This PR is just a cleanup from the recent buffers-instead-of-strings switchover.
Although these methods do not get called rapidly (they're mainly for JSON responses and API calls)
@BluSyn was able to observe a performance improvement:

> ~50% faster when compared over 1000000 iterations
> difference is ~1300ms vs. ~600ms over 1m iterations