### PR TITLE
blockstore: browser fallback to indexdb via bdb

### DIFF
--- a/lib/blockstore/index-browser.js
+++ b/lib/blockstore/index-browser.js
@@ -1,0 +1,31 @@
+/*!
+ * blockstore/index.js - bitcoin blockstore for bcoin
+ * Copyright (c) 2019, Braydon Fuller (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const {join} = require('path');
+
+const AbstractBlockStore = require('./abstract');
+const LevelBlockStore = require('./level');
+
+/**
+ * @module blockstore
+ */
+
+exports.create = (options) => {
+  const location = join(options.prefix, 'blocks');
+
+  return new LevelBlockStore({
+    network: options.network,
+    logger: options.logger,
+    location: location,
+    cacheSize: options.cacheSize,
+    memory: options.memory
+  });
+};
+
+exports.AbstractBlockStore = AbstractBlockStore;
+exports.LevelBlockStore = LevelBlockStore;

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "./lib/hd/wordlist": "./lib/hd/wordlist-browser.js",
     "./lib/workers/child": "./lib/workers/child-browser.js",
     "./lib/workers/parent": "./lib/workers/parent-browser.js",
-    "./lib/bcoin": "./lib/bcoin-browser.js"
+    "./lib/bcoin": "./lib/bcoin-browser.js",
+    "./lib/blockstore/index.js": "./lib/blockstore/index-browser.js"
   }
 }


### PR DESCRIPTION
This PR adds an `index-browser.js` file to `blockstore/` that creates `LevelBlockStore` for chainDB, which is browser compatible.