### PR TITLE
node-http: add check for height being below tip

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -339,6 +339,8 @@ class HTTP extends Server {
       const height = valid.u32('height');
 
       enforce(height != null, 'Height is required.');
+      enforce(height <= this.chain.height,
+        'Height cannot be greater than chain tip.');
 
       await this.chain.reset(height);
 


### PR DESCRIPTION
This commit simply adds an enforce line to check that the height being
requested to reset to is below the chain tip. This way we return a bad
request error rather than an internal server error.

Ported from https://github.com/handshake-org/hsd/pull/156