### PR TITLE
linter: cover docs/examples

### DIFF
--- a/.eslintfiles
+++ b/.eslintfiles
@@ -10,3 +10,4 @@ lib/
 migrate/
 scripts/
 test/
+docs/examples

--- a/docs/examples/client-api.js
+++ b/docs/examples/client-api.js
@@ -96,7 +96,7 @@ async function callNodeApi() {
   await walletClient.open();
 
   // subscribe to events from all wallets
-  walletClient.all()
+  walletClient.all();
 
   // Fund default account.
   // API call: walletClient.createAddress('test', 'default')

--- a/docs/examples/create-sign-tx.js
+++ b/docs/examples/create-sign-tx.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 
 (async () => {
   const master = bcoin.hd.generate();
-  const key = master.derivePath("m/44'/0'/0'/0/0");
+  const key = master.derivePath('m/44\'/0\'/0\'/0/0');
   const keyring = new bcoin.wallet.WalletKey(key.privateKey);
   const cb = new bcoin.MTX();
 

--- a/docs/examples/wallet.js
+++ b/docs/examples/wallet.js
@@ -36,7 +36,7 @@ const walletdb = new bcoin.wallet.WalletDB({
 
   wallet.on('tx', (tx) => {
     console.log('Received transaciton:\n', tx);
-  })
+  });
 
   await walletdb.addTX(tx);
 })().catch((err) => {


### PR DESCRIPTION
Missed a few nits in the `docs/examples` merged in #699.
Adds that directory to the `.eslintfiles` to prevent recurrence. 