### PR TITLE
blockchain: do not accept forked chain older than last checkpoint

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -1104,6 +1104,16 @@ class Chain extends AsyncEmitter {
    */
 
   async saveAlternate(entry, block, prev, flags) {
+    // Do not accept forked chain older than the
+    // last checkpoint.
+    if (this.options.checkpoints) {
+      if (prev.height + 1 < this.network.lastCheckpoint)
+        throw new VerifyError(block,
+          'checkpoint',
+          'bad-fork-prior-to-checkpoint',
+          100);
+    }
+
     try {
       // Do as much verification
       // as we can before saving.


### PR DESCRIPTION
This has been patched in both bitcoind and btcd around February 20th, 2014. It was
shortly followed by a headers-first synchronization of blocks.

- https://github.com/bitcoin/bitcoin/commit/d8b4b49667f3eaf5ac16c218aaba2136ece907d8
- https://github.com/btcsuite/btcd/commit/50b6e10b5781772b0f6a506535f575d81a95dc7a