### PR TITLE
Always give stack traces for error logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,9 +101,8 @@
       }
     },
     "blgr": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.1.7.tgz",
-      "integrity": "sha512-+jSaU2jnYqF+ec9e8nzjfjU7QhZIntkDNG8/AEwoxW7J3mmwvmUfAI5lm9BFYs1OzT+1UgIZTFHa2qWjTBURfw==",
+      "version": "github:bcoin-org/blgr#5242a72a16daf9b53ffc456ca23658edf8819aed",
+      "from": "github:bcoin-org/blgr#5242a72a16daf9b53ffc456ca23658edf8819aed",
       "requires": {
         "bsert": "~0.0.10"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bfilter": "~1.0.5",
     "bheep": "~0.1.5",
     "binet": "~0.3.5",
-    "blgr": "~0.1.7",
+    "blgr": "bcoin-org/blgr#5242a72a16daf9b53ffc456ca23658edf8819aed",
     "blru": "~0.1.6",
     "blst": "~0.1.5",
     "bmutex": "~0.1.6",


### PR DESCRIPTION
This update will log stack traces for errors (e.g. `this.logger.error`).