### PR TITLE
node-http: use addresses instead of strings

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -195,7 +195,8 @@ class HTTP extends Server {
       enforce(address, 'Address is required.');
       enforce(!this.chain.options.spv, 'Cannot get coins in SPV mode.');
 
-      const coins = await this.node.getCoinsByAddress(address);
+      const addrs = address.map(a => Address.fromString(a, this.network));
+      const coins = await this.node.getCoinsByAddress(addrs);
       const result = [];
 
       for (const coin of coins)


### PR DESCRIPTION
I think this bug was missed in #581, which was in turn part of a cleanup of the buffers-not-strings upgrade. A user reached out to me on slack getting the `Object is not an address` error, but this time it was for the `POST` endpoint to [get coins by _multiple_ addresses](http://bcoin.io/api-docs/?shell--curl#get-coins-by-addresses) which didn't get patched.

To reproduce:
- Generate a regtest chain with transactions sent to multiple addresses.
- Query the HTTP endpoint:

(example)
```
curl x:x@127.0.0.1:48332/coin/address -X POST   \
--data '{ "addresses":["mwGsLVgyPf25vQjuqgzRHw156Yrb7QpeMX", "mpCxS8YUzVXiGW8DG4VHVNzYDSbcEP4rst" ]}'
```