### PR TITLE
Indexer getPrefix

### DIFF
--- a/lib/indexer/addrindexer.js
+++ b/lib/indexer/addrindexer.js
@@ -211,8 +211,6 @@ class AddrIndexer extends Indexer {
    */
 
   async getHashesByAddress(addr, options = {}) {
-    const txs = [];
-
     const {after, reverse} = options;
     let {limit} = options;
 
@@ -230,7 +228,7 @@ class AddrIndexer extends Indexer {
       reverse,
       parse: (key) => {
         const [,, height, index] = layout.A.decode(key);
-        txs.push([height, index]);
+        return [height, index];
       }
     };
 
@@ -265,8 +263,7 @@ class AddrIndexer extends Indexer {
       opts.lte = layout.A.max(prefix, hash);
     }
 
-    await this.db.keys(opts);
-
+    const txs = await this.db.keys(opts);
     const hashes = [];
 
     for (const [height, index] of txs)

--- a/lib/indexer/addrindexer.js
+++ b/lib/indexer/addrindexer.js
@@ -141,7 +141,7 @@ class AddrIndexer extends Indexer {
       let hasAddress = false;
 
       for (const addr of tx.getAddresses(view)) {
-        const prefix = addr.getPrefix();
+        const prefix = addr.getPrefix(this.network);
 
         if (prefix < 0)
           continue;
@@ -178,7 +178,7 @@ class AddrIndexer extends Indexer {
       let hasAddress = false;
 
       for (const addr of tx.getAddresses(view)) {
-        const prefix = addr.getPrefix();
+        const prefix = addr.getPrefix(this.network);
 
         if (prefix < 0)
           continue;
@@ -223,7 +223,7 @@ class AddrIndexer extends Indexer {
       throw new Error('Limit above max of ${this.maxTxs}.');
 
     const hash = Address.getHash(addr);
-    const prefix = addr.getPrefix();
+    const prefix = addr.getPrefix(this.network);
 
     const opts = {
       limit,

--- a/lib/mempool/addrindexer.js
+++ b/lib/mempool/addrindexer.js
@@ -20,9 +20,12 @@ class AddrIndexer {
   /**
    * Create TX address index.
    * @constructor
+   * @param {Network} network
    */
 
-  constructor() {
+  constructor(network) {
+    this.network = network;
+
     // Map of addr->entries.
     this.index = new BufferMap();
 
@@ -36,7 +39,7 @@ class AddrIndexer {
   }
 
   getKey(addr) {
-    const prefix = addr.getPrefix();
+    const prefix = addr.getPrefix(this.network);
 
     if (prefix < 0)
       return null;

--- a/lib/mempool/addrindexer.js
+++ b/lib/mempool/addrindexer.js
@@ -44,10 +44,15 @@ class AddrIndexer {
     if (prefix < 0)
       return null;
 
-    const raw = Buffer.allocUnsafe(1);
-    raw.writeUInt8(prefix);
+    const hash = addr.getHash();
+    const size = hash.length + 1;
+    const raw = Buffer.allocUnsafe(size);
 
-    return Buffer.concat([raw, addr.getHash()]);
+    let written = raw.writeUInt8(prefix);
+    written += hash.copy(raw, 1);
+    assert(written === size);
+
+    return raw;
   }
 
   /**

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -73,7 +73,7 @@ class Mempool extends EventEmitter {
     this.spents = new BufferMap();
     this.rejects = new RollingFilter(120000, 0.000001);
 
-    this.addrindex = new AddrIndexer();
+    this.addrindex = new AddrIndexer(this.network);
   }
 
   /**


### PR DESCRIPTION
After discussing reviews with @braydonf, we found that we need to pass network to getPrefix even if it's used internally. If network is not passed getPrefix will use Network.primary which can change using `Network.set` or manually, so instead we will just use network from the node and mempool.

Changes:
  - minor(bug): pass network to addr.getPrefix
  - minor(style): return arrays and don't mutate txs array
  - minor(perf): Don't allocate extra buffer