### PR TITLE
blockstore-test: use try/catch instead of promise.catch/finally.

### DIFF
--- a/test/blockstore-test.js
+++ b/test/blockstore-test.js
@@ -813,17 +813,20 @@ describe('BlockStore', function() {
         // Accidentally don't use `await` and attempt to
         // write multiple blocks in parallel and at the
         // same file position.
-        const promise = store.write(hash, block);
-        promise.catch((e) => {
-          err = e;
-        }).finally(() => {
-          finished += 1;
-          if (finished >= 16) {
-            assert(err);
-            assert(err.message, 'Already writing.');
-            done();
+        (async () => {
+          try {
+            await store.write(hash, block);
+          } catch (e) {
+            err = e;
+          } finally {
+            finished += 1;
+            if (finished >= 16) {
+              assert(err);
+              assert(err.message, 'Already writing.');
+              done();
+            }
           }
-        });
+        })();
       }
     });
 


### PR DESCRIPTION
promise.finally was introduce in node v10, so this test will fail on v8.6.0 node.

We support node from v8.6.0 (will update engine in different PR, currently doing tests on that topic),
so this fixes that minor issue in test.