### PR TITLE
txdb: Ignore coin if it suddenly doesn't exist

### DIFF
--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1615,7 +1615,8 @@ class TXDB {
 
     for (const {hash, index} of outpoints) {
       const credit = await this.getCredit(hash, index);
-      assert(credit);
+      if (!credit)
+        continue;
       credits.push(credit);
     }
 


### PR DESCRIPTION
Solves a rare race condition between block processing and spending.

**Error:**
Assertion failure @ bcoin/lib/wallet/txdb.js:1618

Stack trace with `--async-stack-traces`:
```
AssertionError [ERR_ASSERTION]: Assertion failed.
    at TXDB.getAccountCredits (bcoin/bcoin/lib/wallet/txdb.js:1620:7)
    at async TXDB.getCoins (bcoin/bcoin/lib/wallet/txdb.js:1667:21)
    at async Wallet._fund (bcoin/bcoin/lib/wallet/wallet.js:1119:15)
    at async Wallet.fund (bcoin/bcoin/lib/wallet/wallet.js:1088:14)
    at async Wallet.createTX (bcoin/bcoin/lib/wallet/wallet.js:1273:5)
    at async Wallet._send (bcoin/bcoin/lib/wallet/wallet.js:1327:17)
    at async Wallet.send (bcoin/bcoin/lib/wallet/wallet.js:1312:14)
```

Issue triggered by call to `getAccountCredits`:

Calls `getAccountOutpoints` (txdb `layout.C` w/ bucket.keys) returns list of
outpoints.

Then `getCredit` tries to load same record a second time (txdb `layout.C` w/ bucket.get)
which then returns null, even though that record existed in previous call.

**Reproduce:**
Use this test script. Assertion failure should show within ~15 seconds.
https://gist.github.com/BluSyn/fe802b19df3c5ddf652d925e9f0db5f9

**Cause:**
It appears that `Wallet.send` is trying to spend a credit  while at the same time
that same credit was marked as confirmed and deleted when processing
an incoming block. This appears to be a race condition between
spending coins and processing blocks. The chances of this happening in a
production scenario are extremely slim, but in this test case it happens very
easily due to the speed at which txs and blocks are created.

**Fix:**
Changing assertion in `getAccountCredits` to just ignore the credit
if it doesn't exist. However, it's not clear if this is the perfect solution.
We may want to consider locks between sending and processing instead,
but this may add unnecessary complexity.
