### PR TITLE
 Fix spelling errors

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -812,7 +812,7 @@ class Chain extends AsyncEmitter {
   }
 
   /**
-   * Find the block at which a fork ocurred.
+   * Find the block at which a fork occurred.
    * @private
    * @param {ChainEntry} fork - The current chain.
    * @param {ChainEntry} longer - The competing chain.


### PR DESCRIPTION
The word ocurred should be occurred.