### PR TITLE
node: default memory config to false.

### DIFF
--- a/lib/blockstore/file.js
+++ b/lib/blockstore/file.js
@@ -189,7 +189,13 @@ class FileBlockStore extends AbstractBlockStore {
    */
 
   async ensure() {
-    return fs.mkdirp(this.indexLocation);
+    if (this.options.memory)
+      throw new Error('Memory is unsupported in FileBlockStore.');
+
+    if (fs.unsupported)
+      throw new Error('Can not use FileBlockStore without FS support.');
+
+    await fs.mkdirp(this.indexLocation);
   }
 
   /**

--- a/lib/blockstore/level.js
+++ b/lib/blockstore/level.js
@@ -45,7 +45,13 @@ class LevelBlockStore extends AbstractBlockStore {
    */
 
   async ensure() {
-    return fs.mkdirp(this.location);
+    if (this.options.memory)
+      return;
+
+    if (fs.unsupported)
+      throw new Error('Can not use disk LevelBlockStore without FS support.');
+
+    await fs.mkdirp(this.location);
   }
 
   /**

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -47,7 +47,7 @@ class Node extends EventEmitter {
       this.config.open(config);
 
     this.network = Network.get(this.config.getSuffix());
-    this.memory = this.config.bool('memory', true);
+    this.memory = this.config.bool('memory');
     this.startTime = -1;
     this.bound = [];
     this.plugins = Object.create(null);

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -132,14 +132,14 @@ class Node extends EventEmitter {
    */
 
   async ensure() {
+    if (this.blocks)
+      await this.blocks.ensure();
+
     if (fs.unsupported)
       return undefined;
 
     if (this.memory)
       return undefined;
-
-    if (this.blocks)
-      await this.blocks.ensure();
 
     return fs.mkdirp(this.config.prefix);
   }


### PR DESCRIPTION
If there are no options passed to `FullNode`: `fullnode.memory` will be true, while everything else will be false.

e.g. blockstore.open will try to open the file, but fullnode.ensure wont call `blockstore.ensure`

- Make sure `node.memory` matches all other config definitions.
- Move ensure checks in blockstore backends and always call `block.ensure` in `node`. 