### PR TITLE
add ability to track listeners and remove them on close for indexer

### DIFF
--- a/lib/indexer/indexer.js
+++ b/lib/indexer/indexer.js
@@ -52,6 +52,7 @@ class Indexer extends EventEmitter {
 
     this.db = null;
     this.batch = null;
+    this.bound = [];
     this.syncing = false;
     this.height = 0;
   }
@@ -122,12 +123,17 @@ class Indexer extends EventEmitter {
   }
 
   /**
-   * Close the indexer, wait for the database to close.
+   * Close the indexer, wait for the database to close,
+   * unbind all events.
    * @returns {Promise}
    */
 
   async close() {
-    return this.db.close();
+    await this.db.close();
+    for (const [event, listener] of this.bound)
+      this.chain.removeListener(event, listener);
+
+    this.bound.length = 0;
   }
 
   /**
@@ -187,7 +193,7 @@ class Indexer extends EventEmitter {
   }
 
   /**
-   * Bind to chain events.
+   * Bind to chain events and save listeners for removal on close
    * @private
    */
 
@@ -202,9 +208,10 @@ class Indexer extends EventEmitter {
       }
     };
 
-    this.chain.on('connect', listener);
-    this.chain.on('disconnect', listener);
-    this.chain.on('reset', listener);
+    for (const event of ['connect', 'disconnect', 'reset']) {
+      this.bound.push([event, listener]);
+      this.chain.on(event, listener);
+    }
   }
 
   /**

--- a/test/indexer-test.js
+++ b/test/indexer-test.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const assert = require('bsert');
+const EventEmitter = require('events');
 const reorg = require('./util/reorg');
 const Script = require('../lib/script/script');
 const Opcode = require('../lib/script/opcode');
@@ -319,6 +320,25 @@ describe('Indexer', function() {
         name: 'Error',
         message: 'Limit above max of 10.'
       });
+    });
+
+    it('should track bound chain events and remove on close', async () => {
+      const indexer = new AddrIndexer({
+        blocks: {},
+        chain: new EventEmitter()
+      });
+
+      const events = ['connect', 'disconnect', 'reset'];
+
+      await indexer.open();
+
+      for (const event of events)
+        assert.equal(indexer.chain.listeners(event).length, 1);
+
+      await indexer.close();
+
+      for (const event of events)
+        assert.equal(indexer.chain.listeners(event).length, 0);
     });
   });
 


### PR DESCRIPTION
This fix is for a pretty obscure edge case that I ran into when building out a custom indexer but found it did affect the built-in indexers as well so thought it might be worth integrating as a fix. 

The problem comes up when you close a node with indexers, re-open it after other blocks on the network have been added, and then resync. What happens is that the indexer can have multiple listeners for when a block comes in. To the indexer, this looks like duplicate blocks have come in and it will remove a block. This will then cause `rollforward` to be called on a subsequent block as it continues to sync. In the case of my custom indexer, there was some side behavior that was causing `rollforward` to fail in this particular case on the resync and so after the block gets removed, the indexer couldn't catch back up. This isn't an issue for the tx and addr indexers, however, it didn't really seem like desirable behavior to have the indexer add, remove, and then rollforward on nearly every new block it resyncs from the network so I thought I'd add a patch to deal with it. 

I wrote a test that duplicates the behavior to demonstrate the problem. Note that you have to add an `on block` emitter to the indexers `addBlock` for the tests to work properly since we only want to finish when the indexer's height matches the expected chain height. 

If you just want to observe the behavior with the rollover, then `x` out the second to last test, remove the `x` from the last one and change the logLevel to `debug`. There in the logs you'll see all the unnecessary work described above after the `disconnect` and reconnect.

https://gist.github.com/bucko13/12bcb552f2da0a0dc911a317da151d51

The fix was pretty simple. I just copied the `bound` array for tracking listeners from the `node` object, and added a handleClose for removing them when the node is closed (same as what sockets and the node do). 

Running some benchmarks with the above test, there were some admittedly very minor performance improvements when resyncing 500 blocks after reconnecting. 

```
# Benchmarks
## Mine 500 blocks while indexer node is disconnected

### without removeListener
real    0m5.368s
user    0m4.180s
sys     0m1.058s

real    0m5.075s
user    0m3.881s
sys     0m0.966s

real    0m5.033s
user    0m3.868s
sys     0m0.960s

real    0m5.000s
user    0m3.837s
sys     0m0.938s

real    0m5.093s
user    0m3.899s
sys     0m0.976s


### with removeListener
real    0m5.100s
user    0m3.932s
sys     0m0.966s

real    0m5.024s
user    0m3.824s
sys     0m0.949s

real    0m5.010s
user    0m3.860s
sys     0m0.957s

real    0m5.051s
user    0m3.943s
sys     0m0.977s

real    0m4.939s
user    0m3.834s
sys     0m0.923s
```
