### PR TITLE
mempool: implement replace-by-fee (BIP 125)

### DIFF
--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -817,17 +817,6 @@ class Mempool extends EventEmitter {
         0);
     }
 
-    // Quick and dirty test to verify we're
-    // not double-spending an output in the
-    // mempool.
-    if (this.isDoubleSpend(tx)) {
-      this.emit('conflict', tx);
-      throw new VerifyError(tx,
-        'duplicate',
-        'bad-txns-inputs-spent',
-        0);
-    }
-
     // Get coin viewpoint as it
     // pertains to the mempool.
     const view = await this.getCoinView(tx);
@@ -842,6 +831,17 @@ class Mempool extends EventEmitter {
     // Create a new mempool entry
     // at current chain height.
     const entry = MempoolEntry.fromTX(tx, view, height);
+
+    // Quick and dirty test to verify we're
+    // not double-spending an output in the
+    // mempool.
+    if (this.isDoubleSpend(entry)) {
+      this.emit('conflict', tx);
+      throw new VerifyError(tx,
+        'duplicate',
+        'bad-txns-inputs-spent',
+        0);
+    }
 
     // Contextual verification.
     await this.verify(entry, view);
@@ -1652,17 +1652,35 @@ class Mempool extends EventEmitter {
    * blockchain's. The blockchain spents are not checked against because
    * the blockchain does not maintain a spent list. The transaction will
    * be seen as an orphan rather than a double spend.
-   * @param {TX} tx
+   * @param {MempoolEntry} entry
    * @returns {Promise} - Returns Boolean.
    */
 
-  isDoubleSpend(tx) {
+  isDoubleSpend(entry) {
+    const tx = entry.tx;
     for (const {prevout} of tx.inputs) {
       const {hash, index} = prevout;
-      if (this.isSpent(hash, index))
-        return true;
-    }
+      if (this.isSpent(hash, index)) {
+        // RBF is enabled in mempool
+        if (this.options.replaceByFee) {
+          // Get the original spend.
+          const key = Outpoint.toKey(hash, index);
+          const original = this.spents.get(key);
 
+          // The original spend wasn't RBF!
+          if (!original.tx.isRBF())
+            return true;
+
+          // Compare old and new fees.
+          if (entry.fee > original.fee)
+            return false;
+          else
+            return true;
+        }
+
+        return true;
+      }
+    }
     return false;
   }
 

--- a/test/mempool-test.js
+++ b/test/mempool-test.js
@@ -1055,4 +1055,201 @@ describe('Mempool', function() {
         throw err;
     });
   });
+
+  describe('Replace-by-fee', function () {
+    const workers = new WorkerPool({
+      enabled: true,
+      size: 2
+    });
+
+    const blocks = new BlockStore({
+      memory: true
+    });
+
+    const chain = new Chain({
+      memory: true,
+      workers,
+      blocks
+    });
+
+    const mempool = new Mempool({
+      chain,
+      workers,
+      memory: true,
+      indexAddress: true
+    });
+
+    before(async () => {
+      await blocks.open();
+      await mempool.open();
+      await chain.open();
+      await workers.open();
+    });
+
+    after(async () => {
+      await workers.close();
+      await chain.close();
+      await mempool.close();
+      await blocks.close();
+    });
+
+    // Number of coins available in
+    // chaincoins (100k satoshi per coin).
+    const N = 100;
+    const chaincoins = new MemWallet();
+    const wallet = new MemWallet();
+
+    it('should create coins in chain', async () => {
+      const mtx = new MTX();
+      mtx.addInput(new Input());
+
+      for (let i = 0; i < N; i++) {
+        const addr = chaincoins.createReceive().getAddress();
+        mtx.addOutput(addr, 100000);
+      }
+
+      const cb = mtx.toTX();
+      const block = await getMockBlock(chain, [cb], false);
+      const entry = await chain.add(block, VERIFY_NONE);
+
+      await mempool._addBlock(entry, block.txs);
+
+      // Add 100 blocks so we don't get
+      // premature spend of coinbase.
+      for (let i = 0; i < 100; i++) {
+        const block = await getMockBlock(chain);
+        const entry = await chain.add(block, VERIFY_NONE);
+
+        await mempool._addBlock(entry, block.txs);
+      }
+
+      chaincoins.addTX(cb);
+    });
+
+    it('should not accept RBF tx', async() => {
+      assert(!mempool.options.replaceByFee);
+
+      const mtx = new MTX();
+      const coin = chaincoins.getCoins()[0];
+      mtx.addCoin(coin);
+      mtx.inputs[0].sequence = 0xfffffffd;
+
+      const addr = wallet.createReceive().getAddress();
+      mtx.addOutput(addr, 90000);
+
+      chaincoins.sign(mtx);
+
+      assert(mtx.verify());
+      const tx = mtx.toTX();
+
+      let e = null;
+      try {
+        await mempool.addTX(tx);
+      } catch (err) {
+        e = err;
+      }
+      assert(e);
+      assert.strictEqual(e.type, 'VerifyError');
+      assert.strictEqual(e.reason, 'replace-by-fee');
+
+      assert(!mempool.hasCoin(tx.hash(), 0));
+    });
+
+    it('should accept RBF tx with RBF option enabled', async() => {
+      mempool.options.replaceByFee = true;
+
+      const mtx = new MTX();
+      const coin = chaincoins.getCoins()[0];
+      mtx.addCoin(coin);
+      mtx.inputs[0].sequence = 0xfffffffd;
+
+      const addr = wallet.createReceive().getAddress();
+      mtx.addOutput(addr, coin.value - 1000); // fee = 1000
+
+      chaincoins.sign(mtx);
+
+      assert(mtx.verify());
+      const tx = mtx.toTX();
+
+      await mempool.addTX(tx);
+
+      assert(mempool.hasCoin(tx.hash(), 0));
+    });
+
+    it('should reject an RBF tx replacement with a lower fee', async() => {
+      mempool.options.replaceByFee = true;
+
+      const mtx = new MTX();
+      const coin = chaincoins.getCoins()[0];
+      mtx.addCoin(coin);
+
+      const addr = chaincoins.createReceive().getAddress();
+      mtx.addOutput(addr, coin.value - 1); // fee = 1 single satoshi
+
+      chaincoins.sign(mtx);
+
+      assert(mtx.verify());
+      const tx = mtx.toTX();
+
+      let e = null;
+      try {
+        await mempool.addTX(tx);
+      } catch (err) {
+        e = err;
+      }
+      assert(e);
+      assert.strictEqual(e.type, 'VerifyError');
+      assert.strictEqual(e.reason, 'bad-txns-inputs-spent');
+
+      assert(!mempool.hasCoin(tx.hash(), 0));
+    });
+
+    it('should replace an RBF tx with a higher fee', async() => {
+      mempool.options.replaceByFee = true;
+
+      const mtx = new MTX();
+      const coin = chaincoins.getCoins()[0];
+      mtx.addCoin(coin);
+
+      const addr = chaincoins.createReceive().getAddress();
+      mtx.addOutput(addr, coin.value - 2000); // fee = 2000
+
+      chaincoins.sign(mtx);
+
+      assert(mtx.verify());
+      const tx = mtx.toTX();
+
+      await mempool.addTX(tx);
+
+      assert(mempool.hasCoin(tx.hash(), 0));
+    });
+
+    it('should reject a replacement for non-RBF tx', async() => {
+      mempool.options.replaceByFee = true;
+
+      const mtx = new MTX();
+      const coin = chaincoins.getCoins()[0];
+      mtx.addCoin(coin);
+
+      const addr = chaincoins.createReceive().getAddress();
+      mtx.addOutput(addr, coin.value - 10000); // fee = 10000, won't matter
+
+      chaincoins.sign(mtx);
+
+      assert(mtx.verify());
+      const tx = mtx.toTX();
+
+      let e = null;
+      try {
+        await mempool.addTX(tx);
+      } catch (err) {
+        e = err;
+      }
+      assert(e);
+      assert.strictEqual(e.type, 'VerifyError');
+      assert.strictEqual(e.reason, 'bad-txns-inputs-spent');
+
+      assert(!mempool.hasCoin(tx.hash(), 0));
+    });
+  });
 });


### PR DESCRIPTION
Enables mempool replacement of opt-in RBF transactions with higher-fee variants.

Tests `isDoubleSpend()` AFTER creating a MempoolEntry entry now, so we can pass it that entry and examine its fee. If `isDoubleSpend()` encounters a double-spend, mempool options are checked and then the original spend is retrieved to compare fees.

Probably good to merge this kind of thing before we merge setting it as default (https://github.com/bcoin-org/bcoin/pull/737)

References:
https://github.com/bitcoin/bitcoin/pull/6871
https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki