### PR TITLE
mempool: implement replace-by-fee (BIP 125)

### DIFF
--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -817,17 +817,6 @@ class Mempool extends EventEmitter {
         0);
     }
 
-    // Quick and dirty test to verify we're
-    // not double-spending an output in the
-    // mempool.
-    if (this.isDoubleSpend(tx)) {
-      this.emit('conflict', tx);
-      throw new VerifyError(tx,
-        'duplicate',
-        'bad-txns-inputs-spent',
-        0);
-    }
-
     // Get coin viewpoint as it
     // pertains to the mempool.
     const view = await this.getCoinView(tx);
@@ -842,6 +831,17 @@ class Mempool extends EventEmitter {
     // Create a new mempool entry
     // at current chain height.
     const entry = MempoolEntry.fromTX(tx, view, height);
+
+    // Quick and dirty test to verify we're
+    // not double-spending an output in the
+    // mempool.
+    if (this.isDoubleSpend(entry)) {
+      this.emit('conflict', tx);
+      throw new VerifyError(tx,
+        'duplicate',
+        'bad-txns-inputs-spent',
+        0);
+    }
 
     // Contextual verification.
     await this.verify(entry, view);
@@ -1652,17 +1652,43 @@ class Mempool extends EventEmitter {
    * blockchain's. The blockchain spents are not checked against because
    * the blockchain does not maintain a spent list. The transaction will
    * be seen as an orphan rather than a double spend.
-   * @param {TX} tx
+   * @param {MempoolEntry} entry
    * @returns {Promise} - Returns Boolean.
    */
 
-  isDoubleSpend(tx) {
+  isDoubleSpend(entry) {
+    const tx = entry.tx;
     for (const {prevout} of tx.inputs) {
       const {hash, index} = prevout;
-      if (this.isSpent(hash, index))
-        return true;
-    }
+      if (this.isSpent(hash, index)) {
+        // RBF is enabled in mempool
+        if (this.options.replaceByFee) {
+          // Get the original spend.
+          const key = Outpoint.toKey(hash, index);
+          const original = this.spents.get(key);
 
+          // The original spend wasn't RBF!
+          if (!original.tx.isRBF())
+            return true;
+
+          // Compare old and new fees.
+          if (entry.fee > original.fee) {
+            this.logger.debug(
+              'Replacing mempool tx %h (fee: %d) with %h (fee: %d)',
+              original.hash,
+              original.fee,
+              entry.hash,
+              entry.fee);
+            this.removeEntry(original);
+            return false;
+          } else {
+            return true;
+          }
+        }
+
+        return true;
+      }
+    }
     return false;
   }
 


### PR DESCRIPTION
Enables mempool replacement of opt-in RBF transactions with higher-fee variants.

Tests `isDoubleSpend()` AFTER creating a MempoolEntry entry now, so we can pass it that entry and examine its fee. If `isDoubleSpend()` encounters a double-spend, mempool options are checked and then the original spend is retrieved to compare fees.

Probably good to merge this kind of thing before we merge setting it as default (https://github.com/bcoin-org/bcoin/pull/737)

References:
https://github.com/bitcoin/bitcoin/pull/6871
https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki

TODO:
- [ ] check ancestors 
- [ ] check fee bump is the right amount according to BIP125