### PR TITLE
RPC signmessage

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -13,10 +13,10 @@ const IP = require('binet');
 const Validator = require('bval');
 const {BufferMap, BufferSet} = require('buffer-map');
 const hash160 = require('bcrypto/lib/hash160');
-const hash256 = require('bcrypto/lib/hash256');
 const {safeEqual} = require('bcrypto/lib/safe');
 const secp256k1 = require('bcrypto/lib/secp256k1');
 const util = require('../utils/util');
+const messageUtil = require('../utils/message');
 const common = require('../blockchain/common');
 const Amount = require('../btc/amount');
 const NetAddress = require('../net/netaddress');
@@ -72,8 +72,6 @@ const errs = {
   CLIENT_INVALID_IP_OR_SUBNET: -30,
   CLIENT_P2P_DISABLED: -31
 };
-
-const MAGIC_STRING = 'Bitcoin Signed Message:\n';
 
 /**
  * Bitcoin RPC
@@ -2128,15 +2126,12 @@ class RPC extends RPCBase {
       throw new RPCError(errs.TYPE_ERROR, 'Invalid parameters.');
 
     const addr = parseAddress(b58, this.network);
-    const msg = Buffer.from(MAGIC_STRING + str, 'utf8');
-    const hash = hash256.digest(msg);
-
-    const key = secp256k1.recoverDER(hash, sig, 0, true);
+    const key = messageUtil.recover(str, sig);
 
     if (!key)
       return false;
 
-    return safeEqual(hash160.digest(key), addr.hash);
+    return safeEqual(hash160.digest(key), addr.hash) === 1;
   }
 
   async signMessageWithPrivkey(args, help) {
@@ -2150,9 +2145,7 @@ class RPC extends RPCBase {
     const str = valid.str(1, '');
 
     const key = parseSecret(wif, this.network);
-    const msg = Buffer.from(MAGIC_STRING + str, 'utf8');
-    const hash = hash256.digest(msg);
-    const sig = key.sign(hash);
+    const sig = messageUtil.sign(str, key);
 
     return sig.toString('base64');
   }

--- a/lib/utils/message.js
+++ b/lib/utils/message.js
@@ -1,0 +1,95 @@
+/*!
+ * message.js - message signing utilities.
+ * Copyright (c) 2019, The Bcoin Developers (MIT License).
+ */
+
+'use strict';
+
+const assert = require('bsert');
+const bufio = require('bufio');
+const hash256 = require('bcrypto/lib/hash256');
+const secp256k1 = require('bcrypto/lib/secp256k1');
+
+/**
+ * @exports utils/message
+ */
+
+const message = exports;
+
+/**
+ * Bitcoin signing magic string.
+ * @const {String}
+ * @default
+ */
+
+message.MAGIC_STRING = 'Bitcoin Signed Message:\n';
+
+/**
+ * Hash message with magic string.
+ * @param {String} message
+ * @param {String} [prefix = message.MAGIC_STRING]
+ * @returns {Hash}
+ */
+
+message.magicHash = (msg, prefix = message.MAGIC_STRING) => {
+  assert(typeof prefix === 'string', 'prefix must be a string.');
+  assert(typeof msg === 'string', 'message must be a string');
+
+  const bw = bufio.write();
+
+  bw.writeVarString(prefix);
+  bw.writeVarString(msg, 'utf8');
+
+  return hash256.digest(bw.render());
+};
+
+/**
+ * Sign message with key.
+ * @param {String} msg
+ * @param {KeyRing} ring
+ * @param {String} [prefix = message.MAGIC_STRING]
+ * @returns {Buffer}
+ */
+
+message.sign = (msg, ring, prefix) => {
+  assert(ring.getPrivateKey(), 'Cannot sign without private key.');
+
+  const hash = message.magicHash(msg, prefix);
+  const compress = 0x04 !== ring.getPublicKey().readInt8(0);
+  const {
+    signature,
+    recovery
+  } = secp256k1.signRecoverable(hash, ring.getPrivateKey());
+
+  const bw = bufio.write();
+
+  bw.writeI8(recovery + 27 + (compress ? 4 : 0));
+  bw.writeBytes(signature);
+
+  return bw.render();
+};
+
+/**
+ * Recover raw public key from message and signature.
+ * @param {String} msg
+ * @param {Buffer} signature
+ * @param {String} [prefix = MAGIC_STRING]
+ */
+
+message.recover = (msg, signature, prefix) => {
+  assert(typeof msg === 'string', 'msg must be a string');
+  assert(Buffer.isBuffer(signature), 'sig must be a buffer');
+
+  const hash = message.magicHash(msg, prefix);
+
+  assert.strictEqual(signature.length, 65, 'Invalid signature length');
+
+  const flagByte = signature.readUInt8(0) - 27;
+
+  assert(flagByte < 8, 'Invalid signature parameter');
+
+  const compressed = Boolean(flagByte & 4);
+  const recovery = flagByte & 3;
+
+  return secp256k1.recover(hash, signature.slice(1), recovery, compressed);
+};

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -12,9 +12,9 @@ const bweb = require('bweb');
 const {Lock} = require('bmutex');
 const fs = require('bfile');
 const Validator = require('bval');
-const hash256 = require('bcrypto/lib/hash256');
 const {BufferMap, BufferSet} = require('buffer-map');
 const util = require('../utils/util');
+const messageUtil = require('../utils/message');
 const Amount = require('../btc/amount');
 const Script = require('../script/script');
 const Address = require('../primitives/address');
@@ -67,8 +67,6 @@ const errs = {
   WALLET_ENCRYPTION_FAILED: -16,
   WALLET_ALREADY_UNLOCKED: -17
 };
-
-const MAGIC_STRING = 'Bitcoin Signed Message:\n';
 
 /**
  * Wallet RPC
@@ -1519,10 +1517,7 @@ class RPC extends RPCBase {
     if (!wallet.master.key)
       throw new RPCError(errs.WALLET_UNLOCK_NEEDED, 'Wallet is locked.');
 
-    const msg = Buffer.from(MAGIC_STRING + str, 'utf8');
-    const hash = hash256.digest(msg);
-
-    const sig = ring.sign(hash);
+    const sig = messageUtil.sign(str, ring);
 
     return sig.toString('base64');
   }

--- a/test/node-rpc-test.js
+++ b/test/node-rpc-test.js
@@ -87,37 +87,30 @@ describe('RPC', function() {
 
     it('should fail on invalid privkey', async () => {
       const privKey = 'invalid priv key';
-      let err;
 
-      try {
+      await assert.rejects(async () => {
         await nclient.execute('signmessagewithprivkey', [
           privKey,
           message
         ]);
-      } catch (e) {
-        err = e;
-      }
-
-      assert.ok(err);
-      assert.strictEqual(err.message, 'Invalid key.');
+      }, {
+        type: 'RPCError',
+        message: 'Invalid key.'
+      });
     });
 
     it('should fail on wrong network privkey', async () => {
       const privKeyWIF = ring.toSecret('main');
 
-      let err;
-
-      try {
+      await assert.rejects(async () => {
         await nclient.execute('signmessagewithprivkey', [
           privKeyWIF,
           message
         ]);
-      } catch (e) {
-        err = e;
-      }
-
-      assert.ok(err);
-      assert.strictEqual(err.message, 'Invalid key.');
+      }, {
+        type: 'RPCError',
+        message: 'Invalid key.'
+      });
     });
   });
 
@@ -148,37 +141,29 @@ describe('RPC', function() {
     });
 
     it('should fail on invalid address', async () => {
-      let err;
-
-      try {
+      await assert.rejects(async () => {
         await nclient.execute('verifymessage', [
           'Invalid address',
           signature,
           message
         ]);
-      } catch (e) {
-        err = e;
-      }
-
-      assert.ok(err);
-      assert.strictEqual(err.message, 'Invalid address.');
+      }, {
+        type: 'RPCError',
+        message: 'Invalid address.'
+      });
     });
 
     it('should fail on invalid signature', async () => {
-      let err;
-
-      try {
+      await assert.rejects(async () => {
         await nclient.execute('verifymessage', [
           address,
           '.',
           message
         ]);
-      } catch (e) {
-        err = e;
-      }
-
-      assert.ok(err);
-      assert.strictEqual(err.message, 'Invalid signature length');
+      }, {
+        type: 'RPCError',
+        message: 'Invalid signature length'
+      });
     });
   });
 });

--- a/test/node-rpc-test.js
+++ b/test/node-rpc-test.js
@@ -6,6 +6,7 @@
 const assert = require('bsert');
 const FullNode = require('../lib/node/fullnode');
 const NodeClient = require('../lib/client/node');
+const KeyRing = require('../lib/primitives/keyring');
 
 const ports = {
   p2p: 49331,
@@ -65,5 +66,119 @@ describe('RPC', function() {
     const info = await nclient.execute('getnetworkinfo', []);
 
     assert.deepEqual(info.localservicenames, ['NETWORK', 'WITNESS']);
+  });
+
+  describe('signmessagewithprivkey', function () {
+    const message = 'This is just a test message';
+    const privKeyWIF = 'cUeKHd5orzT3mz8P9pxyREHfsWtVfgsfDjiZZBcjUBAaGk1BTj7N';
+    const ring = KeyRing.fromSecret(privKeyWIF, 'regtest');
+
+    const expectedSignature = 'INbVnW4e6PeRmsv2Qgu8NuopvrVjkcxob+sX8OcZG0SALh'
+      + 'WybUjzMLPdAsXI46YZGb0KQTRii+wWIQzRpG/U+S0=';
+
+    it('should sign message', async () => {
+      const sig = await nclient.execute('signmessagewithprivkey', [
+        privKeyWIF,
+        message
+      ]);
+
+      assert.equal(sig, expectedSignature);
+    });
+
+    it('should fail on invalid privkey', async () => {
+      const privKey = 'invalid priv key';
+      let err;
+
+      try {
+        await nclient.execute('signmessagewithprivkey', [
+          privKey,
+          message
+        ]);
+      } catch (e) {
+        err = e;
+      }
+
+      assert.ok(err);
+      assert.strictEqual(err.message, 'Invalid key.');
+    });
+
+    it('should fail on wrong network privkey', async () => {
+      const privKeyWIF = ring.toSecret('main');
+
+      let err;
+
+      try {
+        await nclient.execute('signmessagewithprivkey', [
+          privKeyWIF,
+          message
+        ]);
+      } catch (e) {
+        err = e;
+      }
+
+      assert.ok(err);
+      assert.strictEqual(err.message, 'Invalid key.');
+    });
+  });
+
+  describe('verifymessage', function() {
+    const message = 'This is just a test message';
+    const address = 'mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB';
+    const signature = 'INbVnW4e6PeRmsv2Qgu8NuopvrVjkcxob+sX8OcZG0SALh'
+      + 'WybUjzMLPdAsXI46YZGb0KQTRii+wWIQzRpG/U+S0=';
+
+    it('should verify correct signature', async () => {
+      const result = await nclient.execute('verifymessage', [
+        address,
+        signature,
+        message
+      ]);
+
+      assert.equal(result, true);
+    });
+
+    it('should verify invalid signature', async () => {
+      const result = await nclient.execute('verifymessage', [
+        address,
+        signature,
+        'different message.'
+      ]);
+
+      assert.equal(result, false);
+    });
+
+    it('should fail on invalid address', async () => {
+      let err;
+
+      try {
+        await nclient.execute('verifymessage', [
+          'Invalid address',
+          signature,
+          message
+        ]);
+      } catch (e) {
+        err = e;
+      }
+
+      assert.ok(err);
+      assert.strictEqual(err.message, 'Invalid address.');
+    });
+
+    it('should fail on invalid signature', async () => {
+      let err;
+
+      try {
+        await nclient.execute('verifymessage', [
+          address,
+          '.',
+          message
+        ]);
+      } catch (e) {
+        err = e;
+      }
+
+      assert.ok(err);
+      assert.strictEqual(err.message, 'Invalid signature length');
+    });
   });
 });

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -11,11 +11,13 @@ const Mnemonic = require('../lib/hd/mnemonic');
 const HDPrivateKey = require('../lib/hd/private');
 const Script = require('../lib/script/script');
 const Address = require('../lib/primitives/address');
-const network = Network.get('regtest');
 const mnemonics = require('./data/mnemonic-english.json');
 const {forValue} = require('./util/common');
+
 // Commonly used test mnemonic
 const phrase = mnemonics[0][1];
+
+const network = Network.get('regtest');
 
 const ports = {
   p2p: 49331,
@@ -41,12 +43,14 @@ const node = new FullNode({
 const {wdb} = node.require('walletdb');
 
 const nclient = new NodeClient({
+  host: '127.0.0.1',
   port: ports.node,
   apiKey: 'bar',
   timeout: 15000
 });
 
 const wclient = new WalletClient({
+  host: '127.0.0.1',
   port: ports.wallet,
   apiKey: 'bar'
 });
@@ -285,6 +289,60 @@ describe('Wallet RPC Methods', function() {
     }, {
       name: 'Error',
       message: 'Block not found.'
+    });
+  });
+
+  describe('signmessage', function() {
+    const nonWalletAddress = '2N2PyYb9yKLhFzYfdWLr6LNsdzC9keVgK6f';
+    const message = 'This is just a test message';
+
+    it('should signmessage with address', async () => {
+      const address = await wclient.execute('getnewaddress');
+
+      const signature = await wclient.execute('signmessage', [
+        address,
+        message
+      ]);
+
+      const verify = await nclient.execute('verifymessage', [
+        address,
+        signature,
+        message
+      ]);
+
+      assert.strictEqual(verify, true);
+    });
+
+    it('should fail with invalid address', async () => {
+      let err;
+
+      try {
+        await wclient.execute('signmessage', [
+          'invalid address format',
+          message
+        ]);
+      } catch (e) {
+        err = e;
+      }
+
+      assert.ok(err);
+      assert.strictEqual(err.message, 'Invalid address.');
+    });
+
+    it('should fail with non-wallet address.', async () => {
+      let err;
+
+      try {
+        await wclient.execute('signmessage', [
+          nonWalletAddress,
+          message
+        ]);
+      } catch (e) {
+        err = e;
+      }
+
+      assert.ok(err);
+      assert.strictEqual(err.message, 'Address not found.');
     });
   });
 

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -314,35 +314,27 @@ describe('Wallet RPC Methods', function() {
     });
 
     it('should fail with invalid address', async () => {
-      let err;
-
-      try {
+      await assert.rejects(async () => {
         await wclient.execute('signmessage', [
           'invalid address format',
           message
         ]);
-      } catch (e) {
-        err = e;
-      }
-
-      assert.ok(err);
-      assert.strictEqual(err.message, 'Invalid address.');
+      }, {
+        type: 'RPCError',
+        message: 'Invalid address.'
+      });
     });
 
     it('should fail with non-wallet address.', async () => {
-      let err;
-
-      try {
+      await assert.rejects(async () => {
         await wclient.execute('signmessage', [
           nonWalletAddress,
           message
         ]);
-      } catch (e) {
-        err = e;
-      }
-
-      assert.ok(err);
-      assert.strictEqual(err.message, 'Address not found.');
+      }, {
+        type: 'RPCError',
+        message: 'Address not found.'
+      });
     });
   });
 


### PR DESCRIPTION
Builds on top #464, fixes issue #460 

General updates on the `signmessagewithprivkey`, `verifymessage` and
`signmessage` :  
  These two calls are outdated and only work for old `P2PKH` addresses. It can
not be used with witness transactions or p2sh.  
  BitcoinCore thread about this: [Bitcoin Core issue][core-signmessage]  
  Trezor implemeneted variation of signmessage, details in [the issue][trezor].

There's new proposal for generic signed messages signing:
[BIP 322: Generic Signed Message Format][bip322] and [BIP 322 - PR][bip322-pr].

There's also an [discussion][core-rpcutils] about not adding new utility
RPC calls to the RPC that can be implemented as a library.


Other updates:
 - organize utils tests
 - add TODO for util tests to move to their respective repositories
   - encoding tests should go to `bufio`
   - base58 tests needs to go to bcrypto(previously bstring), after we update to bcrypto@4 (https://github.com/bcoin-org/bcrypto/commit/216f918e297dfe4db31de3bc0650f30930c5086b)
   - Validator tests need to go to `bval` and write more tests there.

---
NOTE: Bcrypto@4 changes `signRecoverable`: https://github.com/bcoin-org/bcrypto/issues/22

[core-signmessage]: https://github.com/bitcoin/bitcoin/issues/10542
[trezor]: https://github.com/trezor/trezor-mcu/issues/169
[bip322]: https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki
[bip322-pr]: https://github.com/bitcoin/bips/pull/725
[core-rpcutils]: https://github.com/bitcoin/bitcoin/issues/14671
