### PR TITLE
docs: update max-inbound default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,7 +106,7 @@ database and must be passed in consistently.
 - `bip37`: Enable serving of bip37 merkleblocks (default: false).
 - `listen`: Accept incoming connections (default: true).
 - `max-outbound`: Max number of outbound connections (default: 8).
-- `max-inbound`: Max number of inbound connections (default: 30).
+- `max-inbound`: Max number of inbound connections (default: 8).
 - `seeds`: Custom list of DNS seeds (comma-separated).
 - `host`: Host to listen on (default: 0.0.0.0).
 - `port`: Port to listen on (default: 8333).


### PR DESCRIPTION
It is actually `8`, not `30`:
https://github.com/bcoin-org/bcoin/blob/0551096c0a0dae4ad8fb9f1e135b743d50a19983/lib/net/pool.js#L3531