### PR TITLE
tx: add input, output, outpoint helper

### DIFF
--- a/lib/primitives/tx.js
+++ b/lib/primitives/tx.js
@@ -2052,6 +2052,40 @@ class TX {
   }
 
   /**
+   * Create outpoint from output index.
+   * @param {Number} index
+   * @returns {Outpoint}
+   */
+
+  outpoint(index) {
+    return new Outpoint(this.hash(), index);
+  }
+
+  /**
+   * Get input from index.
+   * @param {Number} index
+   * @returns {Input|null}
+   */
+
+  input(index) {
+    if (index >= this.inputs.length)
+      return null;
+    return this.inputs[index];
+  }
+
+  /**
+   * Get output from index.
+   * @param {Number} index
+   * @returns {Output|null}
+   */
+
+  output(index) {
+    if (index >= this.outputs.length)
+      return null;
+    return this.outputs[index];
+  }
+
+  /**
    * Convert the tx to an inv item.
    * @returns {InvItem}
    */


### PR DESCRIPTION
This is a port of helpers that were added to the `hsd/TX` primitive. It adds three methods to `TX`

- `input`
- `output`
- `outpoint`

Each method accepts an index and returns the appropriate object at that index.

I was used to scripting with them and then noticed that `bcoin` does not have them, I think they are helpful and make the code cleaner.