### PR TITLE
node/http: get block header by hash/height

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -261,19 +261,15 @@ class HTTP extends Server {
       const hash = valid.uintbrhash('block');
 
       enforce(hash != null, 'Hash or height required.');
-      enforce(!this.chain.options.spv, 'Cannot get block header in SPV mode.');
 
-      const block = await this.chain.getBlock(hash);
+      const entry = await this.chain.getEntry(hash);
 
-      if (!block) {
+      if (!entry) {
         res.json(404);
         return;
       }
 
-      const header = block.toHeaders();
-      const height = await this.chain.getHeight(hash);
-
-      res.json(200, header.getJSON(this.network, null, height));
+      res.json(200, entry.toJSON());
     });
 
     // Mempool snapshot

--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -255,6 +255,27 @@ class HTTP extends Server {
       res.json(200, block.getJSON(this.network, view, height, depth));
     });
 
+    // Block Header by hash/height
+    this.get('/header/:block', async (req, res) => {
+      const valid = Validator.fromRequest(req);
+      const hash = valid.uintbrhash('block');
+
+      enforce(hash != null, 'Hash or height required.');
+      enforce(!this.chain.options.spv, 'Cannot get block header in SPV mode.');
+
+      const block = await this.chain.getBlock(hash);
+
+      if (!block) {
+        res.json(404);
+        return;
+      }
+
+      const header = block.toHeaders();
+      const height = await this.chain.getHeight(hash);
+
+      res.json(200, header.getJSON(this.network, null, height));
+    });
+
     // Mempool snapshot
     this.get('/mempool', async (req, res) => {
       enforce(this.mempool, 'No mempool available.');

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -455,10 +455,11 @@ describe('HTTP', function() {
   });
 
   // depends on the previous test to generate blocks
-  it('should fetch block header', async () => {
+  it('should fetch block header by height', async () => {
     // fetch corresponding header and block
-    const header = await nclient.get(`/header/${7}`);
-    assert.equal(header.height, 7);
+    const height = 7;
+    const header = await nclient.get(`/header/${height}`);
+    assert.equal(header.height, height);
 
     const properties = [
       'hash', 'version', 'prevBlock',
@@ -469,7 +470,7 @@ describe('HTTP', function() {
     for (const property of properties)
       assert(property in header);
 
-    const block = await nclient.getBlock(7);
+    const block = await nclient.getBlock(height);
 
     assert.equal(block.hash, header.hash);
     assert.equal(block.height, header.height);
@@ -479,6 +480,15 @@ describe('HTTP', function() {
     assert.equal(block.time, header.time);
     assert.equal(block.bits, header.bits);
     assert.equal(block.nonce, header.nonce);
+  });
+
+  it('should fetch block header by hash', async () => {
+    const info = await nclient.getInfo();
+
+    const headerByHash = await nclient.get(`/header/${info.chain.tip}`);
+    const headerByHeight = await nclient.get(`/header/${info.chain.height}`);
+
+    assert.deepEqual(headerByHash, headerByHeight);
   });
 
   it('should fetch null for block header that does not exist', async () => {

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -454,6 +454,50 @@ describe('HTTP', function() {
     assert.strictEqual(blocks.length, 10);
   });
 
+  // depends on the previous test to generate blocks
+  it('should fetch block header', async () => {
+    // fetch corresponding header and block
+    const header = await nclient.get(`/header/${7}`);
+    assert.equal(header.height, 7);
+
+    const properties = [
+      'hash', 'version', 'prevBlock',
+      'merkleRoot', 'time', 'bits',
+      'nonce', 'height', 'chainwork'
+    ];
+
+    for (const property of properties)
+      assert(property in header);
+
+    const block = await nclient.getBlock(7);
+
+    assert.equal(block.hash, header.hash);
+    assert.equal(block.height, header.height);
+    assert.equal(block.version, header.version);
+    assert.equal(block.prevBlock, header.prevBlock);
+    assert.equal(block.merkleRoot, header.merkleRoot);
+    assert.equal(block.time, header.time);
+    assert.equal(block.bits, header.bits);
+    assert.equal(block.nonce, header.nonce);
+  });
+
+  it('should fetch null for block header that does not exist', async () => {
+    // many blocks in the future
+    const header = await nclient.get(`/header/${40000}`);
+    assert.equal(header, null);
+  });
+
+  it('should have valid header chain', async () => {
+    // starting at the genesis block
+    let prevBlock = '0000000000000000000000000000000000000000000000000000000000000000';
+    for (let i = 0; i < 10; i++) {
+      const header = await nclient.get(`/header/${i}`);
+
+      assert.equal(prevBlock, header.prevBlock);
+      prevBlock = header.hash;
+    }
+  });
+
   it('should initiate rescan from socket without a bloom filter', async () => {
     // Rescan from height 5. Without a filter loaded = no response, but no error
     const response = await nclient.call('rescan', 5);

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -454,7 +454,7 @@ describe('HTTP', function() {
     assert.strictEqual(blocks.length, 10);
   });
 
-  // depends on the previous test to generate blocks
+  // Depends on the previous test to generate blocks.
   it('should fetch block header by height', async () => {
     // fetch corresponding header and block
     const height = 7;
@@ -492,13 +492,13 @@ describe('HTTP', function() {
   });
 
   it('should fetch null for block header that does not exist', async () => {
-    // many blocks in the future
+    // Many blocks in the future.
     const header = await nclient.get(`/header/${40000}`);
     assert.equal(header, null);
   });
 
   it('should have valid header chain', async () => {
-    // starting at the genesis block
+    // Starting at the genesis block.
     let prevBlock = '0000000000000000000000000000000000000000000000000000000000000000';
     for (let i = 0; i < 10; i++) {
       const header = await nclient.get(`/header/${i}`);


### PR DESCRIPTION
Add an HTTP endpoint to the Node for fetching block headers.

- `GET /header/:block`

This endpoint makes 1 less database call than fetching a block by hash or height. The `view` is not necessary for `header.getJSON`.

It also returns far less data and should always be consistent with the amount of data that it returns.

