### PR TITLE
Node RPC Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@ that have many transactions.
   which coins have been spent and are currently available.
 - `GET /` has new fields `.indexes.{addr,tx}` for the status of indexers.
 
+#### RPC
+- Remove `getinfo`.
+
 ### Network changes
 
 - Regtest params have been updated to correspond with other bitcoin

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -943,6 +943,12 @@ class RPC extends RPCBase {
       block = await this.chain.getBlock(hash);
     } else if (await this.node.hasTX(last)) {
       const tx = await this.node.getMeta(last);
+
+      if (tx && !tx.block) {
+        throw new RPCError(errs.INVALID_ADDRESS_OR_KEY,
+          'Transaction not yet in block.');
+      }
+
       if (tx)
         block = await this.chain.getBlock(tx.block);
     } else {

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -191,7 +191,6 @@ class RPC extends RPCBase {
     this.add('estimatesmartfee', this.estimateSmartFee);
     this.add('estimatesmartpriority', this.estimateSmartPriority);
 
-    this.add('getinfo', this.getInfo);
     this.add('validateaddress', this.validateAddress);
     this.add('createmultisig', this.createMultisig);
     this.add('createwitnessaddress', this.createWitnessAddress);
@@ -229,30 +228,6 @@ class RPC extends RPCBase {
   /*
    * Overall control/query calls
    */
-
-  async getInfo(args, help) {
-    if (help || args.length !== 0)
-      throw new RPCError(errs.MISC_ERROR, 'getinfo');
-
-    return {
-      version: pkg.version,
-      protocolversion: this.pool.options.version,
-      walletversion: 0,
-      balance: 0,
-      blocks: this.chain.height,
-      timeoffset: this.network.time.offset,
-      connections: this.pool.peers.size(),
-      proxy: '',
-      difficulty: toDifficulty(this.chain.tip.bits),
-      testnet: this.network !== Network.main,
-      keypoololdest: 0,
-      keypoolsize: 0,
-      unlocked_until: 0,
-      paytxfee: Amount.btc(this.network.feeRate, true),
-      relayfee: Amount.btc(this.network.minRelay, true),
-      errors: ''
-    };
-  }
 
   async help(args, help) {
     if (help || args.length > 1)

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -254,7 +254,10 @@ class RPC extends RPCBase {
     };
   }
 
-  async help(args, _help) {
+  async help(args, help) {
+    if (help || args.length > 1)
+      throw new RPCError(errs.MISC_ERROR, 'help ( "command" )');
+
     if (args.length === 0)
       return `Select a command:\n${Object.keys(this.calls).join('\n')}`;
 

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -982,18 +982,26 @@ class RPC extends RPCBase {
     if (!data)
       throw new RPCError(errs.TYPE_ERROR, 'Invalid hex string.');
 
-    const block = MerkleBlock.fromRaw(data);
+    const merkle = MerkleBlock.fromRaw(data);
 
-    if (!block.verify())
+    if (!merkle.verify())
       return [];
 
-    const entry = await this.chain.getEntry(block.hash());
+    const hash = merkle.hash();
+    const block = await this.chain.getBlock(hash);
 
-    if (!entry)
-      throw new RPCError(errs.MISC_ERROR, 'Block not found in chain.');
+    if (!block) {
+      const entry = await this.chain.getEntry(hash);
 
-    const tree = block.getTree();
+      if (!entry)
+        throw new RPCError(errs.MISC_ERROR, 'Block not found in chain.');
+    }
+
+    const tree = merkle.getTree();
     const out = [];
+
+    if (block && block.txs.length !== merkle.totalTX)
+      return out;
 
     for (const hash of tree.matches)
       out.push(util.revHex(hash));

--- a/test/node-rpc-test.js
+++ b/test/node-rpc-test.js
@@ -45,14 +45,79 @@ describe('RPC', function() {
     await node.close();
   });
 
-  it('should rpc help', async () => {
-    assert(await nclient.execute('help', []));
+  describe('help', function() {
+    it('should list all methods', async () => {
+      const response = await nclient.execute('help', []);
+      const lines = response.split('\n');
 
-    await assert.rejects(async () => {
-      await nclient.execute('help', ['getinfo']);
-    }, {
-      name: 'Error',
-      message: /^getinfo/
+      assert(response);
+      assert(lines.length);
+
+      assert.strictEqual(lines[0], 'Select a command:');
+    });
+
+    it('should contain node rpc method', async () => {
+      const response = await nclient.execute('help', []);
+      const lines = response.split('\n');
+
+      assert(response);
+      assert(lines.length);
+
+      // methods that are less likely to be depracated soon.
+      assert(lines.includes('getblockchaininfo'));
+
+      // server methods
+      assert(lines.includes('help'));
+      assert(lines.includes('stop'));
+    });
+
+    it('should not contain wallet rpc methods', async () => {
+      const response = await nclient.execute('help', []);
+      const lines = response.split('\n');
+
+      assert(response);
+      assert(lines.length);
+
+      // methods that are less likely to be depracated soon.
+      assert(!lines.includes('getwalletinfo'));
+    });
+
+    it('should get method help', async () => {
+      await assert.rejects(async () => {
+        await nclient.execute('help', ['getblockchaininfo']);
+      }, {
+        name: 'Error',
+        message: 'getblockchaininfo'
+      });
+
+      await assert.rejects(async () => {
+        await nclient.execute('help', ['help']);
+      }, {
+        name: 'Error',
+        type: 'RPCError',
+        message: 'help ( "command" )'
+      });
+    });
+
+    it('should return error on wrong command', async () => {
+      const wrongCommand = 'wrongcommand';
+
+      await assert.rejects(async () => {
+        await nclient.execute('help', [wrongCommand]);
+      }, {
+        name: 'Error',
+        message: `Method not found: ${wrongCommand}.`
+      });
+    });
+
+    it('should return help on wrong command', async () => {
+      await assert.rejects(async () => {
+        await nclient.execute('help', ['command1', 'command2']);
+      }, {
+        name: 'Error',
+        type: 'RPCError',
+        message: 'help ( "command" )'
+      });
     });
   });
 

--- a/test/node-rpc-test.js
+++ b/test/node-rpc-test.js
@@ -5,43 +5,145 @@
 
 const assert = require('bsert');
 const FullNode = require('../lib/node/fullnode');
-const {NodeClient} = require('bclient');
+const SPVNode = require('../lib/node/spvnode');
+const {NodeClient, WalletClient} = require('bclient');
+const MerkleBlock = require('../lib/primitives/merkleblock');
+const {forValue} = require('./util/common');
+
+// main timeout for the tests.
+const TIMEOUT = 5000;
 
 const ports = {
-  p2p: 49331,
-  node: 49332,
-  wallet: 49333
+  full: {
+    p2p: 49331,
+    node: 49332,
+    wallet: 49333
+  },
+  spv: {
+    p2p: 49431,
+    node: 49432,
+    wallet: 49433
+  },
+  pruned: {
+    p2p: 49531,
+    node: 49532,
+    wallet: 49533
+  },
+  fullindexed: {
+    p2p: 49631,
+    node: 49632,
+    wallet: 49633
+  }
 };
 
-const node = new FullNode({
+const nodeOptions = {
   network: 'regtest',
   apiKey: 'foo',
   walletAuth: true,
   memory: true,
   workers: true,
   workersSize: 2,
-  plugins: [require('../lib/wallet/plugin')],
-  port: ports.p2p,
-  httpPort: ports.node,
-  env: {
-    'BCOIN_WALLET_HTTP_PORT': ports.wallet.toString()
-  }});
-
-const nclient = new NodeClient({
-  port: ports.node,
-  apiKey: 'foo',
-  timeout: 15000
-});
+  publicHost: '127.0.0.1',
+  plugins: [require('../lib/wallet/plugin')]
+};
 
 describe('RPC', function() {
-  this.timeout(15000);
+  this.timeout(TIMEOUT);
+
+  const getClientOpts = (port) => {
+    return {
+      apiKey: nodeOptions.apiKey,
+      timeout: TIMEOUT,
+      port: port
+    };
+  };
+
+  const fullnodeAddr = `127.0.0.1:${ports.full.p2p}`;
+  const fullnode = new FullNode({
+    listen: true,
+    bip37: true,
+    ...nodeOptions,
+    ...getNodePorts(ports.full)
+  });
+
+  const spvnode = new SPVNode({
+    only: fullnodeAddr,
+    ...nodeOptions,
+    ...getNodePorts(ports.spv)
+  });
+
+  const prunednode = new FullNode({
+    prune: true,
+    only: fullnodeAddr,
+    ...nodeOptions,
+    ...getNodePorts(ports.pruned)
+  });
+  const fullindexed = new FullNode({
+    only: fullnodeAddr,
+    indexTX: true,
+    ...nodeOptions,
+    ...getNodePorts(ports.fullindexed)
+  });
+
+  const nclient = new NodeClient({...getClientOpts(ports.full.node)});
+  const wclient = new WalletClient({...getClientOpts(ports.full.wallet)});
+
+  const spvnclient = new NodeClient({...getClientOpts(ports.spv.node)});
+  const prunednclient = new NodeClient({...getClientOpts(ports.pruned.node)});
+  const indexednclient = new NodeClient({
+    ...getClientOpts(ports.fullindexed.node)
+  });
+
+  const MINER_WALLET = 'test';
 
   before(async () => {
-    await node.open();
+    await fullnode.open();
+    await fullnode.connect();
+
+    await prunednode.open();
+    await prunednode.connect();
+    prunednode.startSync();
+
+    await spvnode.open();
+    await spvnode.connect();
+    spvnode.startSync();
+
+    await fullindexed.open();
+    await fullindexed.connect();
+    fullindexed.startSync();
+
+    // create and select miner wallet.
+    await wclient.createWallet(MINER_WALLET);
+    await wclient.execute('selectwallet', [MINER_WALLET]);
+
+    // setup miner wallet
+    const address = await wclient.execute('getnewaddress');
+    const {wdb} = fullnode.require('walletdb');
+
+    // generate coins to our miner.
+    await nclient.execute('generatetoaddress', [101, address]);
+
+    // wait for wallet to connect blocks.
+    await forValue(wdb, 'height', 101);
+    await forValue(fullindexed.txindex, 'height', 101);
+    await forValue(prunednode.chain, 'height', 101);
+    await forValue(spvnode.chain, 'height', 101);
   });
 
   after(async () => {
-    await node.close();
+    fullindexed.stopSync();
+    spvnode.stopSync();
+    prunednode.stopSync();
+
+    await spvnode.disconnect();
+    await prunednode.disconnect();
+    await fullindexed.disconnect();
+    await fullnode.disconnect();
+
+    await fullnode.close();
+    await prunednode.close();
+    await spvnode.close();
+    await fullindexed.close();
   });
 
   describe('help', function() {
@@ -119,4 +221,296 @@ describe('RPC', function() {
       });
     });
   });
+
+  describe('gettxoutproof/verifytxoutproof', function() {
+    const TEST_WALLET = 'wallet-gettxoutproof';
+
+    const blockhashes = [];
+    const txids = [];
+
+    let mempoolTXID;
+
+    before(async () => {
+      // create wallet for testing.
+      await wclient.createWallet(TEST_WALLET);
+      await wclient.execute('selectwallet', [TEST_WALLET]);
+      const testAddr = await wclient.execute('getnewaddress');
+
+      // back to miner
+      await wclient.execute('selectwallet', [MINER_WALLET]);
+      const minerAddr = await wclient.execute('getnewaddress');
+
+      { // block 0 - This block will have 2 txs (including coinbase)
+        const txid = await wclient.execute('sendtoaddress', [testAddr, 1]);
+        const [bh] = await nclient.execute('generatetoaddress', [1, minerAddr]);
+
+        // this txid will be spent in block 2.
+        txids.push([txid]);
+        blockhashes.push(bh);
+      }
+
+      { // block 1 - Spend utxo from block 1 in this block. (2txs)
+        await wclient.execute('selectwallet', [TEST_WALLET]);
+
+        const txid = await wclient.execute('sendtoaddress', [minerAddr, 1, '', '', true]);
+        const [bh] = await nclient.execute('generatetoaddress', [1, minerAddr]);
+
+        txids.push([txid]);
+        blockhashes.push(bh);
+
+        const unspent = await wclient.execute('listunspent');
+        assert.strictEqual(unspent.length, 0);
+
+        await wclient.execute('selectwallet', [MINER_WALLET]);
+      }
+
+      { // block 2 - This block will have 4 txs (including coinbase)
+        const blocktxs = [];
+        for (let i = 0; i < 3; i++) {
+          const txid = await wclient.execute('sendtoaddress', [testAddr, 1]);
+          blocktxs.push(txid);
+        }
+
+        const [bh] = await nclient.execute('generatetoaddress', [1, minerAddr]);
+
+        txids.push(blocktxs);
+        blockhashes.push(bh);
+      }
+
+      { // block 3 - This block will have 7 txs (including coinbase)
+        const blocktxs = [];
+        for (let i = 0; i < 6; i++) {
+          const txid = await wclient.execute('sendtoaddress', [testAddr, 1]);
+          blocktxs.push(txid);
+        }
+
+        const [bh] = await nclient.execute('generatetoaddress', [1, minerAddr]);
+
+        txids.push(blocktxs);
+        blockhashes.push(bh);
+      }
+
+      { // mempool tx
+        mempoolTXID = await wclient.execute('sendtoaddress', [testAddr, 1]);
+        await forValue(fullnode.mempool.map, 'size', 1);
+        await forValue(fullnode.mempool.map, 'size', 1);
+      }
+
+      const bh = blockhashes[blockhashes.length - 1];
+      const {height} = await nclient.execute('getblock', [bh]);
+
+      await forValue(fullnode.chain, 'height', height);
+      await forValue(fullindexed.txindex, 'height', height);
+      await forValue(prunednode.chain, 'height', height);
+      await forValue(spvnode.chain, 'height', height);
+    });
+
+    it('should fail in spv mode', async () => {
+      await assert.rejects(async () => {
+        await spvnclient.execute('gettxoutproof', [[mempoolTXID]]);
+      }, {
+        name: 'Error',
+        type: 'RPCError',
+        message: /SPV/,
+        code: -1 >>> 0
+      });
+    });
+
+    it('should fail in pruned mode', async () => {
+      await assert.rejects(async () => {
+        await prunednclient.execute('gettxoutproof', [[mempoolTXID]]);
+      }, {
+        name: 'Error',
+        type: 'RPCError',
+        message: /pruned/,
+        code: -1 >>> 0
+      });
+    });
+
+    it('should fail with wrong params', async () => {
+      const hash = '00'.repeat(32);
+
+      const error0array = 'Param #0 must be a array.';
+      const error0hex = 'Param #0 must be a hex string.';
+      const error1hex = 'Param #1 must be a hex string.';
+
+      const tests = [
+        {args: [[]], message: 'Invalid TXIDs.', code: -8},
+        // help
+        {args: [], message: /^gettxoutproof/, code: -1},
+        {args: ['test'], message: error0array, code: -3},
+        {args: [['test']], message: error0hex, code: -3},
+        {args: [['00ff']], message: error0hex, code: -3},
+        {args: [[hash, '00ff']], message: error1hex, code: -3},
+        {args: [[hash], '0f00'], message: error1hex, code: -3},
+        {args: [[hash, hash]], message: /duplicate/i, code: -8}
+      ];
+
+      for (const test of tests) {
+        // @see https://github.com/bcoin-org/bcurl/pull/16
+        const code = test.code >>> 0;
+
+        await assert.rejects(async () => {
+          await nclient.execute('gettxoutproof', test.args);
+        }, {
+          type: 'RPCError',
+          message: test.message,
+          code: code
+        });
+      }
+    });
+
+    it('should fail with wrong block', async () => {
+      const hash = '00'.repeat(32);
+
+      await assert.rejects(async () => {
+        await nclient.execute('gettxoutproof', [[hash], hash]);
+      }, {
+        type: 'RPCError',
+        message: 'Block not found.',
+        code: -1 >>> 0
+      });
+    });
+
+    it('should fail for mempool tx', async () => {
+      await assert.rejects(async () => {
+        await nclient.execute('gettxoutproof', [[mempoolTXID]]);
+      }, {
+        type: 'RPCError',
+        message: 'Transaction not yet in block.',
+        code: -5 >>> 0
+      });
+    });
+
+    it('should fail for spent coin w/o blockhash and txindex', async () => {
+      // block 0 has spent txid
+      const txid = txids[0][0];
+
+      await assert.rejects(async () => {
+        await nclient.execute('gettxoutproof', [[txid]]);
+      }, {
+        type: 'RPCError',
+        message: 'Block not found.',
+        code: -1 >>> 0
+      });
+    });
+
+    it('should fail getting proof from two blocks', async () => {
+      // different blocks
+      const list = [
+        txids[2][0],
+        txids[3][0]
+      ];
+
+      await assert.rejects(async () => {
+        await nclient.execute('gettxoutproof', [list]);
+      }, {
+        type: 'RPCError',
+        message: 'Block does not contain all txids.',
+        code: -25 >>> 0
+      });
+    });
+
+    it('should fail getting proof from wrong block', async () => {
+      // txid in one block, blockhash of another.
+      const txid = txids[2][0];
+      const blockhash = blockhashes[3];
+
+      await assert.rejects(async () => {
+        await nclient.execute('gettxoutproof', [[txid], blockhash]);
+      }, {
+        type: 'RPCError',
+        message: 'Block does not contain all txids.',
+        code: -25 >>> 0
+      });
+    });
+
+    it('should verify in spv mode and pruned mode', async () => {
+      const txid = txids[2][0];
+      const proof = await nclient.execute('gettxoutproof', [[txid]]);
+
+      for (const client of [spvnclient, prunednclient]) {
+        const verify = await client.execute('verifytxoutproof', [proof]);
+
+        assert(verify);
+        assert.strict(verify.length, 1);
+        assert.strict(verify[0], txid);
+      }
+    });
+
+    it('should create proof for spent coin with txindex', async () => {
+      const txid = txids[0][0];
+      const res = await indexednclient.execute('gettxoutproof', [[txid]]);
+      const verify = await nclient.execute('verifytxoutproof', [res]);
+
+      assert(verify);
+      assert.strictEqual(verify.length, 1);
+      assert.strictEqual(verify[0], txid);
+    });
+
+    it('should create proof for one tx w/o blockhash', async () => {
+      const check = [
+        txids[2][0],
+        txids[2][1],
+        txids[3][0],
+        txids[3][1]
+      ];
+
+      for (const txid of check) {
+        const proof = await nclient.execute('gettxoutproof', [[txid]]);
+        const verify = await nclient.execute('verifytxoutproof', [proof]);
+
+        assert(verify);
+        assert.strictEqual(verify.length, 1);
+        assert.strictEqual(verify[0], txid);
+      }
+    });
+
+    it('should create proof one tx w/o blockhash (merkle)', async () => {
+      const txid = txids[2][2];
+
+      const proof = await nclient.execute('gettxoutproof', [[txid]]);
+      const verify = await nclient.execute('verifytxoutproof', [proof]);
+
+      assert(verify);
+      assert.strictEqual(verify.length, 1);
+      assert.strictEqual(verify[0], txid);
+
+      const mblock = MerkleBlock.fromRaw(proof, 'hex');
+      const mblockJSON = mblock.toJSON();
+      const tree = mblock.getTree();
+
+      assert.strictEqual(mblockJSON.hash, blockhashes[2]);
+      assert.strictEqual(mblockJSON.prevBlock, blockhashes[1]);
+      assert.strictEqual(mblockJSON.totalTX, txids[2].length + 1);
+      assert.bufferEqual(mblock.merkleRoot, tree.root);
+      assert.strictEqual(tree.matches.length, 1);
+    });
+
+    it('should create proof of multiple txs in a block', async () => {
+      const blockhash = blockhashes[3];
+      const list = [
+        txids[3][0],
+        txids[3][5]
+      ];
+
+      const proof = await nclient.execute('gettxoutproof', [list, blockhash]);
+      const verify = await nclient.execute('verifytxoutproof', [proof]);
+
+      assert(verify);
+      assert.strictEqual(verify.length, 2);
+      assert.ok(verify.includes(list[0]));
+      assert.ok(verify.includes(list[1]));
+    });
+  });
 });
+
+function getNodePorts(ports) {
+  return {
+    port: ports.p2p,
+    httpPort: ports.node,
+    env: {
+      'BCOIN_WALLET_HTTP_PORT': ports.wallet.toString()
+    }
+  };
+};

--- a/test/node-rpc-test.js
+++ b/test/node-rpc-test.js
@@ -178,10 +178,10 @@ describe('RPC', function() {
       assert(response);
       assert(lines.length);
 
-      // methods that are less likely to be depracated soon.
+      // Methods that are less likely to be depracated soon.
       assert(lines.includes('getblockchaininfo'));
 
-      // server methods
+      // Server methods
       assert(lines.includes('help'));
       assert(lines.includes('stop'));
     });
@@ -193,7 +193,7 @@ describe('RPC', function() {
       assert(response);
       assert(lines.length);
 
-      // methods that are less likely to be depracated soon.
+      // Methods that are less likely to be depracated soon.
       assert(!lines.includes('getwalletinfo'));
     });
 
@@ -238,34 +238,33 @@ describe('RPC', function() {
 
   describe('getblockchaininfo', function() {
     const check = (info, expected) => {
-      assert.ok(info);
+      assert(info);
       assert.strictEqual(info.chain, nodeOptions.network);
       assert.strictEqual(info.blocks, expected.height);
       assert.strictEqual(info.headers, expected.height);
 
       assert.strictEqual(info.pruneheight, expected.prunedheight);
-      assert.ok(typeof info.difficulty === 'number');
-      assert.ok(info.difficulty > 0);
-      assert.ok(typeof info.mediantime === 'number');
-      assert.ok(info.mediantime > 0);
+      assert(typeof info.difficulty === 'number');
+      assert(info.difficulty > 0);
+      assert(typeof info.mediantime === 'number');
+      assert(info.mediantime > 0);
       assert.strictEqual(info.verificationprogress, 1);
-      // is hex
-      assert.ok(isHex(info.chainwork));
+      assert(isHex(info.chainwork));
       assert.strictEqual(info.pruned, expected.pruned);
 
-      // check the format.
-      assert.ok(Array.isArray(info.softforks));
+      // Check the format.
+      assert(Array.isArray(info.softforks));
       for (const fork of info.softforks) {
-        assert.ok(typeof fork.id === 'string');
-        assert.ok(typeof fork.version === 'number');
-        assert.ok(typeof fork.reject === 'object');
+        assert(typeof fork.id === 'string');
+        assert(typeof fork.version === 'number');
+        assert(typeof fork.reject === 'object');
 
         const keys = Object.keys(fork.reject);
         assert.strictEqual(keys.length, 1);
-        assert.ok(typeof fork.reject.status === 'boolean');
+        assert(typeof fork.reject.status === 'boolean');
       }
 
-      assert.ok(typeof info.bip9_softforks === 'object');
+      assert(typeof info.bip9_softforks === 'object');
 
       const states = new Set([
         'defined',
@@ -278,9 +277,9 @@ describe('RPC', function() {
       for (const [name, fork] of Object.entries(info.bip9_softforks)) {
         assert.strictEqual(typeof name, 'string');
         assert.strictEqual(typeof fork, 'object');
-        assert.ok(states.has(fork.status));
+        assert(states.has(fork.status));
         assert.strictEqual(typeof fork.bit, 'number');
-        assert.ok(fork.bit >= 0 && fork.bit <= 28);
+        assert(fork.bit >= 0 && fork.bit <= 28);
         assert.strictEqual(typeof fork.startTime, 'number');
         assert.strictEqual(typeof fork.timeout, 'number');
       }
@@ -290,7 +289,7 @@ describe('RPC', function() {
       const info = await nclient.execute('getblockchaininfo');
       const height = fullnode.chain.height;
 
-      await check(info, {
+      check(info, {
         height: height,
         prunedheight: null,
         pruned: false
@@ -322,22 +321,22 @@ describe('RPC', function() {
 
   describe('getnetworkinfo', function () {
     const check = (info, expected) => {
-      assert.ok(info);
+      assert(info);
       assert.strictEqual(typeof info.version, 'string');
       assert.strictEqual(typeof info.subversion, 'string');
       assert.strictEqual(typeof info.protocolversion, 'number');
       assert.strictEqual(typeof info.version, 'string');
-      assert.ok(isHex(info.localservices));
+      assert(isHex(info.localservices));
       assert.strictEqual(info.localservices, expected.localservices);
       assert.strictEqual(info.localrelay, expected.localrelay);
       assert.strictEqual(info.timeoffset, 0);
       assert.strictEqual(info.networkactive, true);
       assert.strictEqual(info.connections, expected.connections);
-      assert.ok(Array.isArray(info.networks));
+      assert(Array.isArray(info.networks));
       assert.strictEqual(info.networks.length, 0);
       assert.strictEqual(typeof info.relayfee, 'number');
       assert.strictEqual(info.incrementalfee, 0);
-      assert.ok(Array.isArray(info.localaddresses));
+      assert(Array.isArray(info.localaddresses));
       assert.strictEqual(info.localaddresses.length, expected.localaddrlen);
 
       for (const addr of info.localaddresses) {
@@ -358,7 +357,7 @@ describe('RPC', function() {
         localrelay: true,
         connections: 3,
 
-        // this node is listening.
+        // This node is listening.
         localaddrlen: 1
       });
     });
@@ -397,7 +396,7 @@ describe('RPC', function() {
     let mempoolTXID;
 
     before(async () => {
-      // create wallet for testing.
+      // Create wallet for testing.
       await wclient.createWallet(TEST_WALLET);
       await wclient.execute('selectwallet', [TEST_WALLET]);
       const testAddr = await wclient.execute('getnewaddress');
@@ -410,7 +409,7 @@ describe('RPC', function() {
         const txid = await wclient.execute('sendtoaddress', [testAddr, 1]);
         const [bh] = await nclient.execute('generatetoaddress', [1, minerAddr]);
 
-        // this txid will be spent in block 2.
+        // This txid will be spent in block 2.
         txids.push([txid]);
         blockhashes.push(bh);
       }
@@ -575,7 +574,7 @@ describe('RPC', function() {
     });
 
     it('should fail for spent coin w/o blockhash and txindex', async () => {
-      // block 0 has spent txid
+      // Block 0 has spent txid
       const txid = txids[0][0];
 
       await assert.rejects(async () => {
@@ -588,7 +587,7 @@ describe('RPC', function() {
     });
 
     it('should fail getting proof from two blocks', async () => {
-      // different blocks
+      // Transactions from different blocks
       const list = [
         txids[2][0],
         txids[3][0]
@@ -604,7 +603,7 @@ describe('RPC', function() {
     });
 
     it('should fail getting proof from wrong block', async () => {
-      // txid in one block, blockhash of another.
+      // TXID in one block, blockhash of another.
       const txid = txids[2][0];
       const blockhash = blockhashes[3];
 
@@ -691,8 +690,8 @@ describe('RPC', function() {
 
       assert(verify);
       assert.strictEqual(verify.length, 2);
-      assert.ok(verify.includes(list[0]));
-      assert.ok(verify.includes(list[1]));
+      assert(verify.includes(list[0]));
+      assert(verify.includes(list[1]));
     });
 
     it('should fail with tweaked proof (1 tx)', async () => {
@@ -708,7 +707,7 @@ describe('RPC', function() {
 
       assert.deepStrictEqual(verify, list);
 
-      // pretend block only has 1 tx.
+      // We pretend block only has 1 tx.
       const mblock = MerkleBlock.fromRaw(proof, 'hex');
 
       mblock.totalTX = 1;
@@ -717,13 +716,13 @@ describe('RPC', function() {
 
       const tweaked = mblock.toRaw().toString('hex');
 
-      // should fail in fullnode or in pruned mode (if there's block available).
+      // Should fail in fullnode or in pruned mode (if there's block available).
       for (const client of [nclient, prunednclient]) {
         const verify = await client.execute('verifytxoutproof', [tweaked]);
         assert.deepStrictEqual(verify, []);
       }
 
-      { // spv node or pruned node (passed pruning height) can't verify tx length.
+      { // SPV node or pruned node (passed pruning height) can't verify tx length.
         const verify = await spvnclient.execute('verifytxoutproof', [tweaked]);
 
         assert(verify);
@@ -744,7 +743,7 @@ describe('RPC', function() {
 
       assert.deepStrictEqual(verify, list);
 
-      // pretend block only has 1 tx.
+      // We pretend block only has 1 tx.
       const mblock = MerkleBlock.fromRaw(proof, 'hex');
 
       // left internal node.
@@ -756,17 +755,17 @@ describe('RPC', function() {
 
       mblock.totalTX = 2;
       mblock.hashes = [left, right];
-      mblock.flags = Buffer.from([0x03]); // we are interested in left/first tx.
+      mblock.flags = Buffer.from([0x03]); // We are interested in left/first tx.
 
       const tweaked = mblock.toRaw().toString('hex');
 
-      // should fail in fullnode or in pruned mode (if there's block available).
+      // Should fail in fullnode or in pruned mode (if there's block available).
       for (const client of [nclient, prunednclient]) {
         const verify = await client.execute('verifytxoutproof', [tweaked]);
         assert.deepStrictEqual(verify, []);
       }
 
-      // spv node does not have blocks.
+      // SPV node does not have blocks.
       {
         const verify = await spvnclient.execute('verifytxoutproof', [tweaked]);
         const expected = [revHex(left)];
@@ -778,7 +777,5 @@ describe('RPC', function() {
 });
 
 function isHex(string) {
-  const hexCheck = /^([0-9a-f]{2})*$/i;
-
-  return hexCheck.test(string);
+  return /^([0-9a-f]{2})*$/i.test(string);
 }

--- a/test/node-rpc-test.js
+++ b/test/node-rpc-test.js
@@ -5,7 +5,6 @@
 
 const assert = require('bsert');
 const FullNode = require('../lib/node/fullnode');
-const pkg = require('../lib/pkg');
 const {NodeClient} = require('bclient');
 
 const ports = {
@@ -118,49 +117,6 @@ describe('RPC', function() {
         type: 'RPCError',
         message: 'help ( "command" )'
       });
-    });
-  });
-
-  describe('getinfo', function() {
-    it('should return info', async () => {
-      const chain = node.require('chain');
-      const info = await nclient.execute('getinfo', []);
-
-      assert.strictEqual(info.version, pkg.version);
-      assert.strictEqual(info.blocks, chain.height);
-      assert.strictEqual(info.testnet, true);
-
-      // defaults, wallet is no longer in node.
-      assert.strictEqual(info.walletversion, 0);
-      assert.strictEqual(info.balance, 0);
-      assert.strictEqual(info.keypoololdest, 0);
-      assert.strictEqual(info.keypoolsize, 0);
-      assert.strictEqual(info.unlocked_until, 0);
-    });
-
-    it('should return correct time offset', async () => {
-      {
-        const info = await nclient.execute('getinfo', []);
-
-        assert.strictEqual(info.timeoffset, 0);
-      }
-
-      {
-        const now = node.network.now();
-        await nclient.execute('setmocktime', [now + 1000]);
-
-        const info = await nclient.execute('getinfo', []);
-        assert.strictEqual(info.timeoffset, 1000);
-      }
-
-      {
-        // recover
-        const now = node.network.now();
-        await nclient.execute('setmocktime', [now - 1000]);
-
-        const info = await nclient.execute('getinfo', []);
-        assert.strictEqual(info.timeoffset, 0);
-      }
     });
   });
 });


### PR DESCRIPTION
RPC tests:
- Fix `help help`
- `help` tests
-  remove `getinfo`.
- test for `getblockchaininfo`.
- test for `getnetworkinfo`.
- Change `verifytxoutproof` to check totalTX count if possible. (performance degrades)
  - If performance is an issue we could index this information separately or with headers(entry).
- Add tests for `gettxoutproof` and `verifytxoutproof`.