### PR TITLE
walletDB: bind to socket events on connect not constructor

### DIFF
--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -104,7 +104,6 @@ class WalletDB extends EventEmitter {
     }
 
     this.filter = BloomFilter.fromRate(items, 0.001, flag);
-    this._bind();
   }
 
   /**
@@ -297,6 +296,7 @@ class WalletDB extends EventEmitter {
    */
 
   async connect() {
+    this._bind();
     return this.client.open();
   }
 

--- a/test/wallet-standalone-test.js
+++ b/test/wallet-standalone-test.js
@@ -6,141 +6,59 @@
 const assert = require('bsert');
 const FullNode = require('../lib/node/fullnode');
 const Node = require('../lib/wallet/node');
-const NetAddress = require('../lib/net/netaddress');
 
 const ports = {
-  high: {
-    p2p: 49330,
-    node: 49331
-  },
-  low: {
-    p2p: 49332,
-    node: 49333
-  }
+  p2p: 49331,
+  node: 49332
 };
 
-// This full node will have a longer chain
-const high = new FullNode({
+const fullNode = new FullNode({
   network: 'regtest',
-  listen: true,
-  port: ports.high.p2p,
-  httpPort: ports.high.node,
-  memory: true,
-  maxOutbound: 1
+  port: ports.p2p,
+  httpPort: ports.node,
+  memory: true
 });
 
-// This full node will have a shorter chain
-const low = new FullNode({
-  network: 'regtest',
-  listen: true,
-  port: ports.low.p2p,
-  httpPort: ports.low.node,
-  memory: true,
-  maxOutbound: 1
-});
-
-// Wallet server starts off connected to the "high" node
 const walletNode = new Node({
   network: 'regtest',
   memory: true,
-  nodePort: ports.high.node
+  nodePort: ports.node
 });
 
-describe('Standalone wallet server test', function() {
-  before( async() => {
-    await high.open();
-    await low.open();
-    await high.connect();
-    await low.connect();
-    high.startSync();
-    low.startSync();
-    await walletNode.open();
+const wdb = walletNode.wdb;
+
+describe('Standalone wallet node test', function() {
+  before(async () => {
+    await fullNode.open();
   });
 
-  after( async() => {
-    await walletNode.close();
-    await high.close();
-    await low.close();
+  after(async () => {
+    if (walletNode.opened)
+      await walletNode.close();
+    await fullNode.close();
   });
 
-  let wallet;
+  it('should bind hooks on connect', async() => {
+    let hooked = false;
+    wdb.rescanBlock = () => {
+      hooked = true;
+    };
 
-  it('should connect high and low nodes', async() => {
-    const host = NetAddress.fromHostname(
-      `127.0.0.1:${ports.low.p2p}`,
-      'regtest'
-    );
-    const peer = high.pool.createOutbound(host);
-    high.pool.peers.add(peer);
-  });
-
-  it('should mine 10 blocks to wallet from high node', async() => {
-    wallet = await walletNode.wdb.get(0);
-    let addr = await wallet.receiveAddress();
-    addr = addr.toString('regtest');
-
-    for (let i = 0; i < 10; i++) {
-      const block = await high.miner.mineBlock(null, addr);
-      await high.chain.add(block);
-    }
-
-    await walletNode.wdb.scan(0);
-
-    const balance = await wallet.getBalance();
-    assert.strictEqual(balance.confirmed, 50 * 10 * 1e8);
-    assert.strictEqual(balance.unconfirmed, 50 * 10 * 1e8);
-
-    assert.strictEqual(walletNode.wdb.height, high.chain.height);
-  });
-
-  it('should disconnect high and low nodes', async() => {
-    high.pool.peers.head().destroy();
-  });
-
-  it('should mine 10 more blocks to wallet from high node', async() => {
-    const wallet = await walletNode.wdb.get(0);
-    let addr = await wallet.receiveAddress();
-    addr = addr.toString('regtest');
-
-    for (let i = 0; i < 10; i++) {
-      const block = await high.miner.mineBlock(null, addr);
-      await high.chain.add(block);
-    }
-
-    await walletNode.wdb.scan(0);
-
-    const balance = await wallet.getBalance();
-    assert.strictEqual(balance.confirmed, 50 * 20 * 1e8);
-    assert.strictEqual(balance.unconfirmed, 50 * 20 * 1e8);
-
-    assert.strictEqual(walletNode.wdb.height, high.chain.height);
-  });
-
-  it('should switch wallet from high node to low node', async() => {
-    await walletNode.close();
-    walletNode.client.port = ports.low.node;
-    walletNode.wdb.client.port = ports.low.node;
+    // Initial connect
+    assert(!hooked);
     await walletNode.open();
 
-    const balance = await wallet.getBalance();
+    // Wait for the socket call and check
+    await new Promise(r => setTimeout(r, 100));
+    assert(hooked);
 
-    // At this point the wallet is showing incorrect confirmed balance
-    // relative to the shorter-chain node
-    assert.strictEqual(balance.confirmed, 50 * 20 * 1e8);
-    assert.strictEqual(balance.unconfirmed, 50 * 20 * 1e8);
+    // Reset
+    await walletNode.close();
+    hooked = false;
 
-    assert.strictEqual(walletNode.wdb.height - 10, low.chain.height);
-  });
-
-  it('should rescan wallet from low node', async() => {
-    await walletNode.wdb.scan(0);
-
-    const balance = await wallet.getBalance();
-
-    // The confirmed balance has dropped to the height of the full node's chain
-    assert.strictEqual(balance.confirmed, 50 * 10 * 1e8);
-    assert.strictEqual(balance.unconfirmed, 50 * 20 * 1e8);
-
-    assert.strictEqual(walletNode.wdb.height, low.chain.height);
+    // ...and reconnect
+    await walletNode.open();
+    await new Promise(r => setTimeout(r, 100));
+    assert(hooked);
   });
 });

--- a/test/wallet-standalone-test.js
+++ b/test/wallet-standalone-test.js
@@ -1,0 +1,146 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const FullNode = require('../lib/node/fullnode');
+const Node = require('../lib/wallet/node');
+const NetAddress = require('../lib/net/netaddress');
+
+const ports = {
+  high: {
+    p2p: 49330,
+    node: 49331
+  },
+  low: {
+    p2p: 49332,
+    node: 49333
+  }
+};
+
+// This full node will have a longer chain
+const high = new FullNode({
+  network: 'regtest',
+  listen: true,
+  port: ports.high.p2p,
+  httpPort: ports.high.node,
+  memory: true,
+  maxOutbound: 1
+});
+
+// This full node will have a shorter chain
+const low = new FullNode({
+  network: 'regtest',
+  listen: true,
+  port: ports.low.p2p,
+  httpPort: ports.low.node,
+  memory: true,
+  maxOutbound: 1
+});
+
+// Wallet server starts off connected to the "high" node
+const walletNode = new Node({
+  network: 'regtest',
+  memory: true,
+  nodePort: ports.high.node
+});
+
+describe('Standalone wallet server test', function() {
+  before( async() => {
+    await high.open();
+    await low.open();
+    await high.connect();
+    await low.connect();
+    high.startSync();
+    low.startSync();
+    await walletNode.open();
+  });
+
+  after( async() => {
+    await walletNode.close();
+    await high.close();
+    await low.close();
+  });
+
+  let wallet;
+
+  it('should connect high and low nodes', async() => {
+    const host = NetAddress.fromHostname(
+      `127.0.0.1:${ports.low.p2p}`,
+      'regtest'
+    );
+    const peer = high.pool.createOutbound(host);
+    high.pool.peers.add(peer);
+  });
+
+  it('should mine 10 blocks to wallet from high node', async() => {
+    wallet = await walletNode.wdb.get(0);
+    let addr = await wallet.receiveAddress();
+    addr = addr.toString('regtest');
+
+    for (let i = 0; i < 10; i++) {
+      const block = await high.miner.mineBlock(null, addr);
+      await high.chain.add(block);
+    }
+
+    await walletNode.wdb.scan(0);
+
+    const balance = await wallet.getBalance();
+    assert.strictEqual(balance.confirmed, 50 * 10 * 1e8);
+    assert.strictEqual(balance.unconfirmed, 50 * 10 * 1e8);
+
+    assert.strictEqual(walletNode.wdb.height, high.chain.height);
+  });
+
+  it('should disconnect high and low nodes', async() => {
+    high.pool.peers.head().destroy();
+  });
+
+  it('should mine 10 more blocks to wallet from high node', async() => {
+    const wallet = await walletNode.wdb.get(0);
+    let addr = await wallet.receiveAddress();
+    addr = addr.toString('regtest');
+
+    for (let i = 0; i < 10; i++) {
+      const block = await high.miner.mineBlock(null, addr);
+      await high.chain.add(block);
+    }
+
+    await walletNode.wdb.scan(0);
+
+    const balance = await wallet.getBalance();
+    assert.strictEqual(balance.confirmed, 50 * 20 * 1e8);
+    assert.strictEqual(balance.unconfirmed, 50 * 20 * 1e8);
+
+    assert.strictEqual(walletNode.wdb.height, high.chain.height);
+  });
+
+  it('should switch wallet from high node to low node', async() => {
+    await walletNode.close();
+    walletNode.client.port = ports.low.node;
+    walletNode.wdb.client.port = ports.low.node;
+    await walletNode.open();
+
+    const balance = await wallet.getBalance();
+
+    // At this point the wallet is showing incorrect confirmed balance
+    // relative to the shorter-chain node
+    assert.strictEqual(balance.confirmed, 50 * 20 * 1e8);
+    assert.strictEqual(balance.unconfirmed, 50 * 20 * 1e8);
+
+    assert.strictEqual(walletNode.wdb.height - 10, low.chain.height);
+  });
+
+  it('should rescan wallet from low node', async() => {
+    await walletNode.wdb.scan(0);
+
+    const balance = await wallet.getBalance();
+
+    // The confirmed balance has dropped to the height of the full node's chain
+    assert.strictEqual(balance.confirmed, 50 * 10 * 1e8);
+    assert.strictEqual(balance.unconfirmed, 50 * 20 * 1e8);
+
+    assert.strictEqual(walletNode.wdb.height, low.chain.height);
+  });
+});


### PR DESCRIPTION
Moves _bind() to inside connect() so that events and hooks are bound to a client just before the socket is opened.

_bind() used to be called by walletDB.constructor(), meaning events were only bound once on object instantiation, and they would not be triggered by new connections after closing and reopening.

I encountered this bug while trying to help a user on slack with unexpected behavior. This user moved their walletDB from one node to another node, which hadn't finished syncing yet, and the balances were unexpected. That user's particular issue was unrelated to this PR! But in trying to test their use case, I stumbled upon this.

A brief gist of the bug can be seen here: https://gist.github.com/pinheadmz/c017efaa571268e3987b0e75d4ae187b

That script was developed out into the test included in this PR. The error:
```
[error] (node) Call not found: block rescan.
```
is what I'm trying to fix. If you run the test without the patch you'll get that error. There might be a cleaner way of testing this without opening sockets, I'm open to suggestions? I also don't think we have any standalone-wallet-server integration tests yet though so maybe it's a good idea to start with this script.
