### PR TITLE
Create txdb credit for known key paths when confirming

### DIFF
--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -690,8 +690,18 @@ class TXDB {
 
       details.setOutput(i, path);
 
-      const credit = await this.getCredit(hash, i);
-      assert(credit);
+      let credit = await this.getCredit(hash, i);
+
+      if (!credit) {
+        // This credit didn't belong to us the first time we
+        // saw the transaction (before confirmation or rescan).
+        // Create new credit for database.
+        credit = Credit.fromTX(tx, i, height);
+
+        // Add coin to "unconfirmed" balance (which includes confirmed coins)
+        state.coin(path, 1);
+        state.unconfirmed(path, credit.coin.value);
+      }
 
       // Credits spent in the mempool add an
       // undo coin for ease. If this credit is

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -620,6 +620,7 @@ class TXDB {
     const height = block.height;
     const details = new Details(wtx, block);
     const state = new BalanceDelta();
+    let own = false;
 
     wtx.setBlock(block);
 
@@ -663,6 +664,7 @@ class TXDB {
 
         const path = await this.getPath(coin);
         assert(path);
+        own = true;
 
         details.setInput(i, path, coin);
 
@@ -697,6 +699,10 @@ class TXDB {
         // saw the transaction (before confirmation or rescan).
         // Create new credit for database.
         credit = Credit.fromTX(tx, i, height);
+
+        // If this tx spent any of our own coins, we "own" this output,
+        // meaning if it becomes unconfirmed, we can still confidently spend it.
+        credit.own = own;
 
         // Add coin to "unconfirmed" balance (which includes confirmed coins)
         state.coin(path, 1);


### PR DESCRIPTION
Closes #821 

Although issue #821 and similar issues can be abated by using a larger BIP44 `lookahead` value and adjusting the timing of bloom filter updates (patch in progress) there still exists an edge case in `txdb` which can be problematic even after these issues are solved. This PR tests a more acute version of this edge case like so:

- A transaction (`tx1`) is broadcast with outputs to these two addresses:
  1. An address from Alice's wallet `A`
  2. An address derived from some externally derived key `B`.
- `tx1` confirms, and Alice's wallet balance correctly reflects only the coin sent to key `A`
- Alice imports the private key `B` into the same wallet, and rescans.

Outcome: Alice's wallet shows `tx1` as UNCONFIRMED, with unexpected values for both confirmed and unconfirmed balance. Specifically, it will show the value of coin 1 as unconfirmed, and the confirmed balance will be zero.

### Why?

Because there is a sort of bad assumption in `txdb.confirm()`:

https://github.com/bcoin-org/bcoin/blob/75722469f3a3963bb2163bbc4edc763e6bdcf55f/lib/wallet/txdb.js#L686-L694

When `txdb` confirms a transaction, it assumes every output with a recognized path should already have a corresponding `Credit` in the database. When this assumption fails, the assertion is thrown (and caught) which prevents the `confirm()` method from completing, for any coin in the transaction. Because the rescan process starts with a rollback, the original coin `A` is stuck in an unconfirmed state.

This patch creates a new `Credit` (instead of throwing an error) and quickly handles its "unconfirmed" state before proceeding with the rest of the transaction confirmation.