### PR TITLE
pkg: bump version to 2.0.0-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bcoin",
-  "version": "1.0.2",
+  "version": "2.0.0-dev",
   "description": "Bitcoin bike-shed",
   "license": "MIT",
   "repository": "git://github.com/bcoin-org/bcoin.git",


### PR DESCRIPTION
The CHANGELOG is already labeled as version `2.0.0-dev`. This distinction gets more and more important as github master branch diverges from the 1.0.2 release on npm. Support requests will go much faster since `bcoin-cli info` will return a different version if installed from npm vs github.