### PR TITLE
blockstore: skip location for memory store

### DIFF
--- a/docs/examples/connect-to-the-p2p-network.js
+++ b/docs/examples/connect-to-the-p2p-network.js
@@ -10,8 +10,13 @@ const logger = new Logger({
 });
 
 // Create a blockchain and store it in memory.
+const blocks = bcoin.blockstore.create({
+  memory: true
+});
+
 const chain = new bcoin.Chain({
   memory: true,
+  blocks: blocks,
   network: 'main',
   logger: logger
 });
@@ -31,6 +36,7 @@ const pool = new bcoin.Pool({
 
 (async function() {
   await logger.open();
+  await blocks.open();
   await chain.open();
 
   await pool.open();
@@ -65,8 +71,13 @@ const pool = new bcoin.Pool({
 // Start up a testnet sync in-memory
 // while we're at it (because we can).
 
+const tblocks = bcoin.blockstore.create({
+  memory: true
+});
+
 const tchain = new bcoin.Chain({
   memory: true,
+  blocks: tblocks,
   network: 'testnet',
   logger: logger
 });
@@ -86,6 +97,7 @@ const tpool = new bcoin.Pool({
 });
 
 (async function() {
+  await tblocks.open();
   await tchain.open();
 
   await tpool.open();

--- a/docs/examples/create-a-blockchain-and-mempool.js
+++ b/docs/examples/create-a-blockchain-and-mempool.js
@@ -8,8 +8,17 @@ bcoin.set('regtest');
 
 // Start up a blockchain, mempool, and miner using in-memory
 // databases (stored in a red-black tree instead of on-disk).
-const chain = new bcoin.Chain({ network: 'regtest', memory: true });
-const mempool = new bcoin.Mempool({ chain: chain });
+const blocks = bcoin.blockstore.create({
+  memory: true
+});
+const chain = new bcoin.Chain({
+  network: 'regtest',
+  memory: true,
+  blocks: blocks
+});
+const mempool = new bcoin.Mempool({
+  chain: chain
+});
 const miner = new bcoin.Miner({
   chain: chain,
   mempool: mempool,
@@ -20,6 +29,7 @@ const miner = new bcoin.Miner({
 
 (async () => {
   // Open the chain
+  await blocks.open();
   await chain.open();
 
   // Open the miner (initialize the databases, etc).

--- a/docs/examples/get-tx-from-chain.js
+++ b/docs/examples/get-tx-from-chain.js
@@ -6,13 +6,17 @@ const fs = require('bfile');
 // Create chain for testnet, stored in memory by default.
 // To store the chain on disk at the `prefix` location,
 // set `memory: false`.
+const blocks = bcoin.blockstore.create({
+  memory: true,
+  prefix: '/tmp/bcoin-testnet-example'
+});
+
 const chain = new bcoin.Chain({
   network: 'testnet',
   indexTX: true,
   indexAddress: true,
-  db: 'leveldb',
-  prefix: '/tmp/bcoin-testnet-example',
-  memory: true
+  memory: true,
+  blocks: blocks
 });
 
 // Create a network pool of peers with a limit of 8 peers.
@@ -26,6 +30,7 @@ const pool = new bcoin.Pool({
   if (!chain.options.memory)
     await fs.mkdirp(chain.options.prefix);
 
+  await blocks.open();
   await chain.open();
 
   // Connect the blockchain to the network

--- a/docs/examples/spv-sync-wallet.js
+++ b/docs/examples/spv-sync-wallet.js
@@ -18,7 +18,8 @@ const walletdb = new bcoin.wallet.WalletDB({ memory: true });
 
 // Full node will provide tx data to SPV node
 const full = {};
-full.chain = new bcoin.Chain();
+full.blocks = bcoin.blockstore.create({ memory: true });
+full.chain = new bcoin.Chain({ blocks: full.blocks });
 full.pool = new bcoin.Pool({
   chain: full.chain,
   port: 44444,
@@ -32,6 +33,7 @@ full.pool = new bcoin.Pool({
   await chain.open();
   await pool.connect();
 
+  await full.blocks.open();
   await full.pool.open();
   await full.chain.open();
   await full.pool.connect();

--- a/lib/blockstore/index.js
+++ b/lib/blockstore/index.js
@@ -17,17 +17,16 @@ const FileBlockStore = require('./file');
  */
 
 exports.create = (options) => {
-  const location = join(options.prefix, 'blocks');
-
   if (options.memory) {
     return new LevelBlockStore({
       network: options.network,
       logger: options.logger,
-      location: location,
       cacheSize: options.cacheSize,
       memory: options.memory
     });
   }
+
+  const location = join(options.prefix, 'blocks');
 
   return new FileBlockStore({
     network: options.network,


### PR DESCRIPTION
While here, fix docs examples which were failing due to improperly configured `blockstore`.

Also a minor nit: `new bcoin.Chain()` instantiates a new `Chain` without a `blockstore`, since `options` is `null`. This is because we only validate `options` if they are given, but if given we require a `blockstore` (except in spv). We could add another check if `options` is `null`. Thoughts?