### PR TITLE
security.md: add mark@purse.io key

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,8 @@ Versions of bcoin that are currently supported with security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.0.0+   | :white_check_mark: |
+| 2.0.0-dev | :white_check_mark: |
+| 1.0.0+    | :white_check_mark: |
 | < 1.0.0-beta   | :x:         |
 
 ## Reporting a Vulnerability
@@ -15,10 +16,11 @@ To report security issues send an email to braydon@purse.io (not for support).
 
 The following keys may be used to communicate sensitive information to developers:
 
-| Name | Fingerprint |
-|------|-------------|
-| Braydon Fuller | 5B7D C58D 90FE C1E9 90A3  10BA F24F 232D 108B 3AD4 |
+| Name | Fingerprint | Email |
+|------|-------------| ----- |
+| Braydon Fuller | 5B7D C58D 90FE C1E9 90A3  10BA F24F 232D 108B 3AD4 | braydon@purse.io
+| Mark Tyneway   | F525 BDE2 7C71 B684 7B1C  73AB C543 71E9 6096 D987 | mark@purse.io
 
 You can import a key by running the following command with that individual’s fingerprint:
 
-`gpg --recv-keys "<fingerprint>"` Ensure that you put quotes around fingerprints containing spaces.
+`$ gpg --recv-keys "<fingerprint>"` Ensure that you put quotes around fingerprints containing spaces.


### PR DESCRIPTION
Updates the SECURITY.md to include my commit signing key. It is available on key servers and can be synced locally using the gpg --recv-keys command.

Also include version 2.0.0-dev in the versions table. I don't think we should bikeshed about whether or not to include the version's table too much, if we have too many versions and it becomes a problem, then we could deal with it then. My concern is backporting stuff to 1.0.0+, when I feel like the 2.0.0 release should be an upgrade for everybody.

Edit: Closed https://github.com/bcoin-org/bcoin/pull/848 because I pulled in more commits than I wanted when I was rebasing to force push to trigger another run of the CI. Had to do it this way because I don't have merge access, which is required to trigger builds on the CI. The tests passed fine this time, but there is a non-deterministic test. Details can be found in #848