### PR TITLE
hd-private: fix error message in deriveAccount()

### DIFF
--- a/lib/hd/private.js
+++ b/lib/hd/private.js
@@ -252,7 +252,7 @@ class HDPrivateKey {
 
   deriveAccount(purpose, type, account) {
     assert((purpose >>> 0) === purpose, 'Purpose must be a number.');
-    assert((type >>> 0) === type, 'Account index must be a number.');
+    assert((type >>> 0) === type, 'Coin type must be a number.');
     assert((account >>> 0) === account, 'Account index must be a number.');
     assert(this.isMaster(), 'Cannot derive account index.');
     return this


### PR DESCRIPTION
Fixes a typo in the error message of `HDPrivate.deriveAccount()`