### PR TITLE
Improve tx size estimation

### DIFF
--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1090,11 +1090,11 @@ class MTX extends TX {
 
   /**
    * Estimate maximum possible size.
-   * @param {Function?} estimate - Input script size estimator.
+   * @param {Function?} getAccount - Returns account receiving an input.
    * @returns {Number}
    */
 
-  async estimateSize(estimate) {
+  async estimateSize(getAccount) {
     const scale = consensus.WITNESS_SCALE_FACTOR;
 
     let total = 0;
@@ -1156,7 +1156,7 @@ class MTX extends TX {
       }
 
       // Bare multisig
-      const [m] = prev.getMultisig();
+      let [m] = prev.getMultisig();
       if (m !== -1) {
         let size = 0;
         // Bare Multisig
@@ -1191,33 +1191,83 @@ class MTX extends TX {
         continue;
       }
 
-      // Call out to the custom estimator.
-      // Provided by wallet with knowledge of redeem script size.
-      if (estimate) {
-        const size = await estimate(prev);
-        if (size !== -1) {
-          total += size;
-          continue;
+      // Assume 2-of-3 multisig for all scripthash payments,
+      // unless specific details can be provided by getAccount()
+      m = 2;
+      let n = 3;
+      let type = 1;
+      let witness = false;
+      if (getAccount) {
+        const account = await getAccount(prev.getAddress());
+        if (account) {
+          m = account.m;
+          n = account.n;
+          witness = account.witness;
+          type = account.type; // 0 = PUBKEYHASH, 1 = MULTISIG
         }
       }
 
-      // P2SH (2-of-3 multisig)
+      // P2SH
       if (prev.isScripthash()) {
         let size = 0;
-        // OP_0
-        size += 1;
-        // varint-len [signature] x 2
-        size += (1 + 73) * 2;
-        // redeem script (OP_PUSHDATA1, varint length)
-        size += 1 + 1;
-        // redeem script (OP_2, varint-len + pubKey x3, OP_3, OP_CHECKMULTISIG)
-        size += 1 + ((1 + 33) * 3) + 1 + 1;
-        size += encoding.sizeVarint(size);
-        total += size;
-        continue;
+
+        if (!witness) {
+          // MULTISIG
+          // OP_0
+          size += 1;
+          // varint-len [signature]
+          size += (1 + 73) * m;
+          // script (OP_PUSHDATA1, varint length)
+          size += 1 + 1;
+          // script (OP_2, varint-len + pubKey, OP_3, OP_CHECKMULTISIG)
+          size += 1 + ((1 + 33) * n) + 1 + 1;
+          size += encoding.sizeVarint(size);
+          total += size;
+          continue;
+        } else {
+          // "Nested Bullshit"
+          witnessMarker = 2;
+          switch (type) {
+            case 0:
+              // PUBKEYHASH
+              // scriptSig (varint-len OP_0 varint-len <20-byte pubKeyHash>)
+              total += 23;
+
+              // witness
+              // varint-items-len
+              size += 1;
+              // varint-len [signature]
+              size += 1 + 73;
+              // varint-len [key]
+              size += 1 + 33;
+              size = (size + scale - 1) / scale | 0;
+              total += size;
+              continue;
+            case 1:
+              // MULTISIG
+              // scriptSig (varint-len OP_0 varint-len <32-byte scriptHash>)
+              total += 35;
+
+              // witness
+              // varint-items-len
+              size += 1;
+              // OP_0
+              size += 1;
+              // varint-len [signature]
+              size += (1 + 73) * m;
+              // redeem script varint-len
+              size += 1;
+              // redeem script (m, <pubKeys x m>, n, OP_CHECKMULTISIG)
+              size += 1 + ((1 + 33) * n) + 1 + 1;
+              // vsize
+              size = (size + scale - 1) / scale | 0;
+              total += size;
+              continue;
+          }
+        }
       }
 
-      // P2WSH (2-of-3 multisig)
+      // P2WSH
       if (prev.isWitnessScripthash()) {
         witnessMarker = 2;
 
@@ -1230,12 +1280,12 @@ class MTX extends TX {
         size += 1;
         // OP_0
         size += 1;
-        // varint-len [signature] x 2
-        size += (1 + 73) * 2;
+        // varint-len [signature]
+        size += (1 + 73) * m;
         // redeem script varint-len
         size += 1;
-        // redeem script (OP_2, varint-len + pubKey x3, OP_3, OP_CHECKMULTISIG)
-        size += 1 + ((1 + 33) * 3) + 1 + 1;
+        // redeem script (m, <pubKeys x m>, n, OP_CHECKMULTISIG)
+        size += 1 + ((1 + 33) * n) + 1 + 1;
         // vsize
         size = (size + scale - 1) / scale | 0;
         total += size;
@@ -1634,7 +1684,7 @@ class CoinSelector {
     this.inputs = new BufferMap();
 
     // Needed for size estimation.
-    this.estimate = null;
+    this.getAccount = null;
 
     this.injectInputs();
 
@@ -1724,9 +1774,9 @@ class CoinSelector {
       }
     }
 
-    if (options.estimate) {
-      assert(typeof options.estimate === 'function');
-      this.estimate = options.estimate;
+    if (options.getAccount) {
+      assert(typeof options.getAccount === 'function');
+      this.getAccount = options.getAccount;
     }
 
     if (options.inputs) {
@@ -1974,7 +2024,7 @@ class CoinSelector {
     // Keep recalculating the fee and funding
     // until we reach some sort of equilibrium.
     do {
-      const size = await this.tx.estimateSize(this.estimate);
+      const size = await this.tx.estimateSize(this.getAccount);
 
       this.fee = this.getFee(size);
 

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1099,16 +1099,26 @@ class MTX extends TX {
 
     let total = 0;
 
-    // Calculate the size, minus the input scripts.
+    // Version
     total += 4;
+
+    // Witness marker and flag (BIP144)
+    let witnessMarker = 0;
+
+    // Number of inputs
     total += encoding.sizeVarint(this.inputs.length);
+
+    // One outpoint (hash/index) per input
     total += this.inputs.length * 40;
 
+    // Number of outputs.
     total += encoding.sizeVarint(this.outputs.length);
 
+    // Outputs are already final, get actual size
     for (const output of this.outputs)
       total += output.getSize();
 
+    // Timelock
     total += 4;
 
     // Add size for signatures and public keys
@@ -1145,6 +1155,7 @@ class MTX extends TX {
         continue;
       }
 
+      // Bare multisig
       const [m] = prev.getMultisig();
       if (m !== -1) {
         let size = 0;
@@ -1161,6 +1172,12 @@ class MTX extends TX {
 
       // P2WPKH
       if (prev.isWitnessPubkeyhash()) {
+        witnessMarker = 2;
+
+        // legacy script size (0x00)
+        total += 1;
+
+        // witness
         let size = 0;
         // varint-items-len
         size += 1;
@@ -1175,6 +1192,7 @@ class MTX extends TX {
       }
 
       // Call out to the custom estimator.
+      // Provided by wallet with knowledge of redeem script size.
       if (estimate) {
         const size = await estimate(prev);
         if (size !== -1) {
@@ -1183,22 +1201,41 @@ class MTX extends TX {
         }
       }
 
-      // P2SH
+      // P2SH (2-of-3 multisig)
       if (prev.isScripthash()) {
-        // varint size
-        total += 1;
-        // 2-of-3 multisig input
-        total += 149;
+        let size = 0;
+        // OP_0
+        size += 1;
+        // varint-len [signature] x 2
+        size += (1 + 73) * 2;
+        // redeem script (OP_PUSHDATA1, varint length)
+        size += 1 + 1;
+        // redeem script (OP_2, varint-len + pubKey x3, OP_3, OP_CHECKMULTISIG)
+        size += 1 + ((1 + 33) * 3) + 1 + 1;
+        size += encoding.sizeVarint(size);
+        total += size;
         continue;
       }
 
-      // P2WSH
+      // P2WSH (2-of-3 multisig)
       if (prev.isWitnessScripthash()) {
+        witnessMarker = 2;
+
+        // legacy script size (0x00)
+        total += 1;
+
+        // witness
         let size = 0;
         // varint-items-len
         size += 1;
-        // 2-of-3 multisig input
-        size += 149;
+        // OP_0
+        size += 1;
+        // varint-len [signature] x 2
+        size += (1 + 73) * 2;
+        // redeem script varint-len
+        size += 1;
+        // redeem script (OP_2, varint-len + pubKey x3, OP_3, OP_CHECKMULTISIG)
+        size += 1 + ((1 + 33) * 3) + 1 + 1;
         // vsize
         size = (size + scale - 1) / scale | 0;
         total += size;
@@ -1209,7 +1246,7 @@ class MTX extends TX {
       total += 110;
     }
 
-    return total;
+    return total + witnessMarker;
   }
 
   /**

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -28,7 +28,6 @@ const Account = require('./account');
 const MasterKey = require('./masterkey');
 const policy = require('../protocol/policy');
 const consensus = require('../protocol/consensus');
-const {encoding} = bio;
 const {Mnemonic} = HD;
 const {inspectSymbol} = require('../utils');
 
@@ -1131,7 +1130,7 @@ class Wallet extends EventEmitter {
       height: this.wdb.state.height,
       rate: rate,
       maxFee: options.maxFee,
-      estimate: prev => this.estimateSize(prev)
+      getAccount: this.getAccountByAddress.bind(this)
     });
 
     assert(mtx.getFee() <= MTX.Selector.MAX_FEE, 'TX exceeds MAX_FEE.');
@@ -1151,84 +1150,6 @@ class Wallet extends EventEmitter {
       return null;
 
     return this.getAccount(path.account);
-  }
-
-  /**
-   * Input size estimator for max possible tx size.
-   * @param {Script} prev
-   * @returns {Number}
-   */
-
-  async estimateSize(prev) {
-    const scale = consensus.WITNESS_SCALE_FACTOR;
-    const address = prev.getAddress();
-
-    if (!address)
-      return -1;
-
-    const account = await this.getAccountByAddress(address);
-
-    if (!account)
-      return -1;
-
-    let size = 0;
-
-    if (prev.isScripthash()) {
-      // Nested bullshit.
-      if (account.witness) {
-        switch (account.type) {
-          case Account.types.PUBKEYHASH:
-            size += 23; // redeem script
-            size *= 4; // vsize
-            break;
-          case Account.types.MULTISIG:
-            size += 35; // redeem script
-            size *= 4; // vsize
-            break;
-        }
-      }
-    }
-
-    switch (account.type) {
-      case Account.types.PUBKEYHASH:
-        // P2PKH
-        // OP_PUSHDATA0 [signature]
-        size += 1 + 73;
-        // OP_PUSHDATA0 [key]
-        size += 1 + 33;
-        break;
-      case Account.types.MULTISIG:
-        // P2SH Multisig
-        // OP_0
-        size += 1;
-        // OP_PUSHDATA0 [signature] ...
-        size += (1 + 73) * account.m;
-        // OP_PUSHDATA2 [redeem]
-        size += 3;
-        // m value
-        size += 1;
-        // OP_PUSHDATA0 [key] ...
-        size += (1 + 33) * account.n;
-        // n value
-        size += 1;
-        // OP_CHECKMULTISIG
-        size += 1;
-        break;
-    }
-
-    if (account.witness) {
-      // Varint witness items length.
-      size += 1;
-      // Calculate vsize if
-      // we're a witness program.
-      size = (size + scale - 1) / scale | 0;
-    } else {
-      // Byte for varint
-      // size of input script.
-      size += encoding.sizeVarint(size);
-    }
-
-    return size;
   }
 
   /**

--- a/test/mtx-test.js
+++ b/test/mtx-test.js
@@ -1,0 +1,251 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const MTX = require('../lib/primitives/mtx');
+const KeyRing = require('../lib/primitives/keyring');
+const Address = require('../lib/primitives/address');
+const Script = require('../lib/script/script');
+const Coin = require('../lib/primitives/coin');
+
+describe('MTX', function() {
+  describe('Estimate Size', function() {
+    for (let ins = 1; ins <= 10; ins++) {
+      it(`P2PK ${ins}-in 1-out`, async () => {
+        const ring = KeyRing.generate();
+        const script = Script.fromPubkey(ring.publicKey);
+
+        const mtx = new MTX();
+
+        for (let i = 1; i <= ins; i++) {
+          const coin = new Coin({
+            version: 1,
+            height: 1,
+            value: 10000,
+            script: script,
+            coinbase: false,
+            hash: Buffer.alloc(32),
+            index: 0
+          });
+          mtx.addCoin(coin);
+        }
+
+        mtx.addOutput({
+          address: new Address(),
+          value: 9000
+        });
+        const estSize = await mtx.estimateSize();
+
+        mtx.sign(ring);
+        const tx = mtx.toTX();
+        assert(tx.verify(mtx.view));
+        const actualSize = tx.getVirtualSize();
+
+        assert(estSize >= actualSize);
+      });
+
+      it(`P2PKH ${ins}-in 1-out`, async () => {
+        const ring = KeyRing.generate();
+        const script = Script.fromPubkeyhash(ring.getKeyHash());
+
+        const mtx = new MTX();
+
+        for (let i = 1; i <= ins; i++) {
+          const coin = new Coin({
+            version: 1,
+            height: 1,
+            value: 10000,
+            script: script,
+            coinbase: false,
+            hash: Buffer.alloc(32),
+            index: 0
+          });
+
+          mtx.addCoin(coin);
+        }
+
+        mtx.addOutput({
+          address: new Address(),
+          value: 9000
+        });
+        const estSize = await mtx.estimateSize();
+
+        mtx.sign(ring);
+        const tx = mtx.toTX();
+        assert(tx.verify(mtx.view));
+        const actualSize = tx.getVirtualSize();
+
+        assert(estSize >= actualSize);
+      });
+
+      it(`Bare 2-of-3 Multisig ${ins}-in 1-out`, async () => {
+        const ring1 = KeyRing.generate();
+        const ring2 = KeyRing.generate();
+        const ring3 = KeyRing.generate();
+        const script = Script.fromMultisig(2, 3,
+          [
+            ring1.publicKey,
+            ring2.publicKey,
+            ring3.publicKey
+          ]);
+
+        const mtx = new MTX();
+
+        for (let i = 1; i <= ins; i++) {
+          const coin = new Coin({
+            version: 1,
+            height: 1,
+            value: 10000,
+            script: script,
+            coinbase: false,
+            hash: Buffer.alloc(32),
+            index: 0
+          });
+
+          mtx.addCoin(coin);
+        }
+
+        mtx.addOutput({
+          address: new Address(),
+          value: 9000
+        });
+        const estSize = await mtx.estimateSize();
+
+        ring1.script = script;
+        ring2.script = script;
+        mtx.sign([ring1, ring2]);
+        const tx = mtx.toTX();
+        assert(tx.verify(mtx.view));
+        const actualSize = tx.getVirtualSize();
+
+        assert(estSize >= actualSize);
+      });
+
+      it(`P2WPKH ${ins}-in 1-out`, async () => {
+        const ring = KeyRing.generate();
+        ring.witness = true;
+        const script = ring.getProgram();
+
+        const mtx = new MTX();
+
+        for (let i = 1; i <= ins; i++) {
+          const coin = new Coin({
+            version: 1,
+            height: 1,
+            value: 10000,
+            script: script,
+            coinbase: false,
+            hash: Buffer.alloc(32),
+            index: 0
+          });
+
+          mtx.addCoin(coin);
+        }
+
+        mtx.addOutput({
+          address: new Address(),
+          value: 9000
+        });
+        const estSize = await mtx.estimateSize();
+
+        mtx.sign(ring);
+        const tx = mtx.toTX();
+        assert(tx.verify(mtx.view));
+        const actualSize = tx.getVirtualSize();
+
+        assert(estSize >= actualSize);
+      });
+
+      it(`P2SH 2-of-3 Multisig ${ins}-in 1-out`, async () => {
+        const ring1 = KeyRing.generate();
+        const ring2 = KeyRing.generate();
+        const ring3 = KeyRing.generate();
+        const script = Script.fromMultisig(2, 3,
+          [
+            ring1.publicKey,
+            ring2.publicKey,
+            ring3.publicKey
+          ]);
+
+        const mtx = new MTX();
+
+        for (let i = 1; i <= ins; i++) {
+          const coin = new Coin({
+            version: 1,
+            height: 1,
+            value: 10000,
+            script: Script.fromScripthash(script.hash160()),
+            coinbase: false,
+            hash: Buffer.alloc(32),
+            index: 0
+          });
+
+          mtx.addCoin(coin);
+        }
+
+        mtx.addOutput({
+          address: new Address(),
+          value: 9000
+        });
+        const estSize = await mtx.estimateSize();
+
+        ring1.script = script;
+        ring2.script = script;
+        mtx.sign([ring1, ring2]);
+        const tx = mtx.toTX();
+        assert(tx.verify(mtx.view));
+        const actualSize = tx.getVirtualSize();
+
+        assert(estSize >= actualSize);
+      });
+
+      it(`P2WSH 2-of-3 Multisig ${ins}-in 1-out`, async () => {
+        const ring1 = KeyRing.generate();
+        const ring2 = KeyRing.generate();
+        const ring3 = KeyRing.generate();
+        ring1.witness = true;
+        ring2.witness = true;
+        ring3.witness = true;
+        const script = Script.fromMultisig(2, 3,
+          [
+            ring1.publicKey,
+            ring2.publicKey,
+            ring3.publicKey
+          ]);
+
+        const mtx = new MTX();
+
+        for (let i = 1; i <= ins; i++) {
+          const coin = new Coin({
+            version: 1,
+            height: 1,
+            value: 10000,
+            script: Script.fromProgram(0, script.sha256()),
+            coinbase: false,
+            hash: Buffer.alloc(32),
+            index: 0
+          });
+
+          mtx.addCoin(coin);
+        }
+
+        mtx.addOutput({
+          address: new Address(),
+          value: 9000
+        });
+        const estSize = await mtx.estimateSize();
+
+        ring1.script = script;
+        ring2.script = script;
+        mtx.sign([ring1, ring2]);
+        const tx = mtx.toTX();
+        assert(tx.verify(mtx.view));
+        const actualSize = tx.getVirtualSize();
+
+        assert(estSize >= actualSize);
+      });
+    }
+  });
+});

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -19,6 +19,7 @@ const Outpoint = require('../lib/primitives/outpoint');
 const Script = require('../lib/script/script');
 const HD = require('../lib/hd');
 const Wallet = require('../lib/wallet/wallet');
+const Account = require('../lib/wallet/account');
 const nodejsUtil = require('util');
 
 const KEY1 = 'xprv9s21ZrQH143K3Aj6xQBymM31Zb4BVc7wxqfUhMZrzewdDVCt'
@@ -1750,6 +1751,267 @@ describe('Wallet', function() {
 
     assert(err);
     assert.equal(err.message, 'At least one output required.');
+  });
+
+  describe('Estimate Size', function() {
+    let wallet;
+    before(async () => {
+      wallet = await wdb.create();
+    });
+
+    for (let ins = 1; ins <= 10; ins++) {
+      it(`P2SH 4-of-6 Multisig ${ins}-in 1-out`, async () => {
+        const ring1 = KeyRing.generate();
+        const ring2 = KeyRing.generate();
+        const ring3 = KeyRing.generate();
+        const ring4 = KeyRing.generate();
+        const ring5 = KeyRing.generate();
+        const ring6 = KeyRing.generate();
+        const script = Script.fromMultisig(4, 6,
+          [
+            ring1.publicKey,
+            ring2.publicKey,
+            ring3.publicKey,
+            ring4.publicKey,
+            ring5.publicKey,
+            ring6.publicKey
+          ]);
+
+        const mtx = new MTX();
+
+        for (let i = 1; i <= ins; i++) {
+          const coin = new Coin({
+            version: 1,
+            height: 1,
+            value: 10000,
+            script: Script.fromScripthash(script.hash160()),
+            coinbase: false,
+            hash: Buffer.alloc(32),
+            index: 0
+          });
+
+          mtx.addCoin(coin);
+        }
+
+        mtx.addOutput({
+          address: new Address(),
+          value: 9000
+        });
+
+        // Dummy account details for size estimator
+        wallet.getAccountByAddress = async (addr) => {
+          return {
+            witness: false,
+            type: Account.types.MULTISIG,
+            m: 4,
+            n: 6
+          };
+        };
+        const getAccount = wallet.getAccountByAddress.bind(wallet);
+        const estSize = await mtx.estimateSize(getAccount);
+
+        ring1.script = script;
+        ring2.script = script;
+        ring3.script = script;
+        ring4.script = script;
+        mtx.sign([ring1, ring2, ring3, ring4]);
+        const tx = mtx.toTX();
+        assert(tx.verify(mtx.view));
+        const actualSize = tx.getVirtualSize();
+
+        assert(estSize >= actualSize);
+      });
+
+      it(`P2WSH 4-of-6 Multisig ${ins}-in 1-out`, async () => {
+        const ring1 = KeyRing.generate();
+        const ring2 = KeyRing.generate();
+        const ring3 = KeyRing.generate();
+        const ring4 = KeyRing.generate();
+        const ring5 = KeyRing.generate();
+        const ring6 = KeyRing.generate();
+        ring1.witness = true;
+        ring2.witness = true;
+        ring3.witness = true;
+        ring4.witness = true;
+        ring5.witness = true;
+        ring6.witness = true;
+        const script = Script.fromMultisig(4, 6,
+          [
+            ring1.publicKey,
+            ring2.publicKey,
+            ring3.publicKey,
+            ring4.publicKey,
+            ring5.publicKey,
+            ring6.publicKey
+          ]);
+
+        const mtx = new MTX();
+
+        for (let i = 1; i <= ins; i++) {
+          const coin = new Coin({
+            version: 1,
+            height: 1,
+            value: 10000,
+            script: Script.fromProgram(0, script.sha256()),
+            coinbase: false,
+            hash: Buffer.alloc(32),
+            index: 0
+          });
+
+          mtx.addCoin(coin);
+        }
+
+        mtx.addOutput({
+          address: new Address(),
+          value: 9000
+        });
+
+        // Dummy account details for size estimator
+        wallet.getAccountByAddress = async (addr) => {
+          return {
+            witness: true,
+            type: Account.types.MULTISIG,
+            m: 4,
+            n: 6
+          };
+        };
+        const getAccount = wallet.getAccountByAddress.bind(wallet);
+        const estSize = await mtx.estimateSize(getAccount);
+
+        ring1.script = script;
+        ring2.script = script;
+        ring3.script = script;
+        ring4.script = script;
+        mtx.sign([ring1, ring2, ring3, ring4]);
+        const tx = mtx.toTX();
+        assert(tx.verify(mtx.view));
+        const actualSize = tx.getVirtualSize();
+
+        assert(estSize >= actualSize);
+      });
+
+      it(`P2WPKH-in-P2SH ${ins}-in 1-out`, async () => {
+        const ring = KeyRing.generate();
+        ring.witness = true;
+        ring.nested = true;
+        const script = ring.getNestedHash();
+
+        const mtx = new MTX();
+
+        for (let i = 1; i <= ins; i++) {
+          const coin = new Coin({
+            version: 1,
+            height: 1,
+            value: 10000,
+            script: Script.fromScripthash(script),
+            coinbase: false,
+            hash: Buffer.alloc(32),
+            index: 0
+          });
+
+          mtx.addCoin(coin);
+        }
+
+        mtx.addOutput({
+          address: new Address(),
+          value: 9000
+        });
+
+        // Dummy account details for size estimator
+        wallet.getAccountByAddress = async (addr) => {
+          return {
+            witness: true,
+            type: Account.types.PUBKEYHASH,
+            m: 1,
+            n: 1
+          };
+        };
+        const getAccount = wallet.getAccountByAddress.bind(wallet);
+        const estSize = await mtx.estimateSize(getAccount);
+
+        mtx.sign(ring);
+        const tx = mtx.toTX();
+        assert(tx.verify(mtx.view));
+        const actualSize = tx.getVirtualSize();
+
+        assert(estSize >= actualSize);
+      });
+
+      it(`4-of-6 P2WSH-in-P2SH ${ins}-in 1-out`, async () => {
+        const ring1 = KeyRing.generate();
+        const ring2 = KeyRing.generate();
+        const ring3 = KeyRing.generate();
+        const ring4 = KeyRing.generate();
+        const ring5 = KeyRing.generate();
+        const ring6 = KeyRing.generate();
+        ring1.witness = true;
+        ring1.nested = true;
+        ring2.witness = true;
+        ring2.nested = true;
+        ring3.witness = true;
+        ring3.nested = true;
+        ring4.witness = true;
+        ring4.nested = true;
+        ring5.witness = true;
+        ring5.nested = true;
+        ring6.witness = true;
+        ring6.nested = true;
+
+        const script = Script.fromMultisig(4, 6,
+          [
+            ring1.publicKey,
+            ring2.publicKey,
+            ring3.publicKey,
+            ring4.publicKey,
+            ring5.publicKey,
+            ring6.publicKey
+          ]);
+        ring1.script = script;
+        ring2.script = script;
+        ring3.script = script;
+        ring4.script = script;
+
+        const mtx = new MTX();
+
+        for (let i = 1; i <= ins; i++) {
+          const coin = new Coin({
+            version: 1,
+            height: 1,
+            value: 10000,
+            script: Script.fromScripthash(ring1.getNestedHash()),
+            coinbase: false,
+            hash: Buffer.alloc(32),
+            index: 0
+          });
+
+          mtx.addCoin(coin);
+        }
+
+        mtx.addOutput({
+          address: new Address(),
+          value: 9000
+        });
+
+        // Dummy account details for size estimator
+        wallet.getAccountByAddress = async (addr) => {
+          return {
+            witness: true,
+            type: Account.types.MULTISIG,
+            m: 4,
+            n: 6
+          };
+        };
+        const getAccount = wallet.getAccountByAddress.bind(wallet);
+        const estSize = await mtx.estimateSize(getAccount);
+
+        mtx.sign([ring1, ring2, ring3, ring4]);
+        const tx = mtx.toTX();
+        assert(tx.verify(mtx.view));
+        const actualSize = tx.getVirtualSize();
+
+        assert(estSize >= actualSize);
+      });
+    }
   });
 
   it('should cleanup', async () => {


### PR DESCRIPTION
Closes #666 

This is a WIP, looking for feedback in tests and the approach of passing `getAccountByAddress()` to `mtx`.

### Size Estimation

When we are funding a tx, we need to estimate what the size of the final tx will be so we can apply the `rate` correctly, set the fee and therefore the change output value. There are challenges to getting this estimate exactly right:

- Signatures can vary in length. (70-72 bytes)

- The number of pubKeys and signatures invovled in a multisig policy may not be known

### The Bug

Currently the size estimation for SegWit transactions is neglecting a few bytes. Notably:

- The two bytes `0x0001` witness marker and flag ([BIP144](https://github.com/bitcoin/bips/blob/master/bip-0144.mediawiki#serialization))

- The legacy `scriptSig` still contains a `0x00` byte, indicating a 0-length `scriptSig` because all the good stuff is in the witness now. ([BIP141](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#witness-program))

This bug affected non-nested witness transactions that paid `minRelay` fees, because the tx size estimate would be _low_, resulting in an insufficient fee. Such transactions would not be included in blocks. The estimates would end up lower and lower depending on the number of witness inputs. For testing scripts that needed to confirm txs with multiple witness inputs, [fees had to be multiplied a great deal](https://github.com/bcoin-org/bcoin/blob/e4d6cdbc2a69a104f2f7e59d42e22454e01c15bd/docs/Examples/generate-blocks-and-txs.js#L18).

### Method

To fix, I started off just adding the neglected bytes to the estimate count, but I realized that there are TWO `estimateSize()` functions in bcoin. The main one is in `mtx`, and the second is in `wallet`. The entire `wallet.estimateSize()` function is passed as a parameter to `mtx.estimateSize()` the reason being that `wallet` has access to all the `Account` details including `witness`, `type`, `m`, and `n`, which are required to accurately estimate a redeem script and witness length.

Instead of trying to apply the simple fix to both functions, I merged the two, removing `wallet.estimateSize()` entirely, and instead pass `wallet.getAccountByAddress()` to `mtx.estimateSize()`. This allows `mtx` to access the data it needs to predict a tx size.

### Testing

Ugh. Testing anything involved with signature length kinda sucks and the tests will necessarily be non-deterministic. I wrote the tests to create up to 10-input transactions for each tx type:

- P2PK
- P2PKH
- Bare Multisig
- P2WPKH
- P2SH Multisig (2-of-3 by default, 4-of-6 when account details are passed in)
- P2WSH Multisig (2-of-3 by default, 4-of-6 when account details are passed in)
- P2WPKH-in-P2SH
- P2WSH-Multisig-in-P2SH

All I can do is check that the estimates are always greater or equal to the actual tx size after signing. Without the patches applied, the witness transactions always fail. 

I also have the test currently outputting the difference in actual vs estimated size: https://gist.github.com/pinheadmz/327e1b356c2e0f05ace7f66fd49b5a36

As the input size goes up, the accuracy of the estimate drops, with the potential to overestimate a tx size by ~65 vbytes for 10-inputs.