### PR TITLE
Client block header

### DIFF
--- a/bin/bcoin-cli
+++ b/bin/bcoin-cli
@@ -95,6 +95,22 @@ class CLI {
     this.log(block);
   }
 
+  async getBlockHeader() {
+    let hash = this.config.str(0, '');
+
+    if (hash.length !== 64)
+      hash = parseInt(hash, 10);
+
+    const header = await this.client.getBlockHeader(hash);
+
+    if (!header) {
+      this.log('Header not found.');
+      return;
+    }
+
+    this.log(header);
+  }
+
   async getFilter() {
     let hash = this.config.str(0, '');
 
@@ -204,6 +220,9 @@ class CLI {
       case 'block':
         await this.getBlock();
         break;
+      case 'header':
+        await this.getBlockHeader();
+        break;
       case 'filter':
         await this.getFilter();
         break;
@@ -222,6 +241,7 @@ class CLI {
         this.log('  $ tx [hash/address]: View transactions.');
         this.log('  $ coin [hash+index/address]: View coins.');
         this.log('  $ block [hash/height]: View block.');
+        this.log('  $ header [hash/height]: View block header.');
         this.log('  $ filter [hash/height]: View filter');
         this.log('  $ reset [height/hash]: Reset chain to desired block.');
         this.log('  $ rpc [command] [args]: Execute RPC command.' +

--- a/lib/client/node.js
+++ b/lib/client/node.js
@@ -147,6 +147,17 @@ class NodeClient extends Client {
   }
 
   /**
+   * Retrieve a block header.
+   * @param {Hash|Number} block
+   * @returns {Promise}
+   */
+
+  getBlockHeader(block) {
+    assert(typeof block === 'string' || typeof block === 'number');
+    return this.get(`/header/${block}`);
+  }
+
+  /**
    * Retreive a filter from the filter indexer.
    * @param {Hash|Number} filter
    * @returns {Promise}

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -5,6 +5,7 @@
 
 const {BloomFilter} = require('bfilter');
 const assert = require('bsert');
+const {NodeClient, WalletClient} = require('../lib/client');
 const consensus = require('../lib/protocol/consensus');
 const Address = require('../lib/primitives/address');
 const Script = require('../lib/script/script');
@@ -35,9 +36,8 @@ const node = new FullNode({
   httpPort: ports.node,
   env: {
     'BCOIN_WALLET_HTTP_PORT': ports.wallet.toString()
-  }});
-
-const {NodeClient, WalletClient} = require('../lib/client');
+  }
+});
 
 const nclient = new NodeClient({
   port: ports.node,
@@ -458,7 +458,7 @@ describe('HTTP', function() {
   it('should fetch block header by height', async () => {
     // fetch corresponding header and block
     const height = 7;
-    const header = await nclient.get(`/header/${height}`);
+    const header = await nclient.getBlockHeader(height);
     assert.equal(header.height, height);
 
     const properties = [
@@ -485,15 +485,15 @@ describe('HTTP', function() {
   it('should fetch block header by hash', async () => {
     const info = await nclient.getInfo();
 
-    const headerByHash = await nclient.get(`/header/${info.chain.tip}`);
-    const headerByHeight = await nclient.get(`/header/${info.chain.height}`);
+    const headerByHash = await nclient.getBlockHeader(info.chain.tip);
+    const headerByHeight = await nclient.getBlockHeader(info.chain.height);
 
     assert.deepEqual(headerByHash, headerByHeight);
   });
 
   it('should fetch null for block header that does not exist', async () => {
     // Many blocks in the future.
-    const header = await nclient.get(`/header/${40000}`);
+    const header = await nclient.getBlockHeader(40000);
     assert.equal(header, null);
   });
 
@@ -501,7 +501,7 @@ describe('HTTP', function() {
     // Starting at the genesis block.
     let prevBlock = '0000000000000000000000000000000000000000000000000000000000000000';
     for (let i = 0; i < 10; i++) {
-      const header = await nclient.get(`/header/${i}`);
+      const header = await nclient.getBlockHeader(i);
 
       assert.equal(prevBlock, header.prevBlock);
       prevBlock = header.hash;


### PR DESCRIPTION
- Adds `getBlockHeader` method to the `NodeClient`
- Adds `header` method to `bcoin-cli`
- Updates tests to use `getBlockHeader` over `get('/header')`

Port of https://github.com/bcoin-org/bclient/pull/21/
