### PR TITLE
Do not queue too many blocks between wallet and node

### DIFF
--- a/lib/wallet/nodeclient.js
+++ b/lib/wallet/nodeclient.js
@@ -36,18 +36,18 @@ class NodeClient extends AsyncEmitter {
    */
 
   init() {
-    this.node.on('connect', (entry, block) => {
+    this.node.chain.on('connect', async (entry, block) => {
       if (!this.opened)
         return;
 
-      this.emit('block connect', entry, block.txs);
+      await this.emitAsync('block connect', entry, block.txs);
     });
 
-    this.node.on('disconnect', (entry, block) => {
+    this.node.chain.on('disconnect', async (entry, block) => {
       if (!this.opened)
         return;
 
-      this.emit('block disconnect', entry);
+      await this.emitAsync('block disconnect', entry);
     });
 
     this.node.on('tx', (tx) => {


### PR DESCRIPTION
It's possible that the queue of blocks between node and wallet can grow too large and lead to a variety of memory issues.