### PR TITLE
Mempool HTTP Details

### DIFF
--- a/lib/client/node.js
+++ b/lib/client/node.js
@@ -46,11 +46,12 @@ class NodeClient extends Client {
 
   /**
    * Get a mempool snapshot.
+   * @param {Boolean} details
    * @returns {Promise}
    */
 
-  getMempool() {
-    return this.get('/mempool');
+  getMempool(details) {
+    return this.get('/mempool', {details});
   }
 
   /**

--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -297,11 +297,22 @@ class HTTP extends Server {
     this.get('/mempool', async (req, res) => {
       enforce(this.mempool, 'No mempool available.');
 
-      const hashes = this.mempool.getSnapshot();
+      const valid = Validator.fromRequest(req);
+      const details = valid.bool('details', false);
+
       const result = [];
 
-      for (const hash of hashes)
-        result.push(util.revHex(hash));
+      if (details) {
+        const txs = this.mempool.getHistory();
+
+        for (const tx of txs)
+          result.push(tx.toJSON());
+      } else {
+        const hashes = this.mempool.getSnapshot();
+
+        for (const hash of hashes)
+          result.push(hash.toString('hex'));
+      }
 
       res.json(200, result);
     });


### PR DESCRIPTION
While running a full node, I wanted a better look into the details of the transactions in the mempool. This PR adds a new query parameter to the `GET /mempool` Node HTTP endpoint called `details`.

If `details` is set to `true`, it will return a list of `TX` JSON instead of a list of hashes.

This differs from the RPC method `getrawmempool` with the verbose option, as that does not return the full `TX` JSON. For `getrawmempool`, this function is called for each TX in the mempool instead: https://github.com/bcoin-org/bcoin/blob/99638ac1090402b6efe3364e0de3be3be903626d/lib/node/rpc.js#L2776