### PR TITLE
node/http: get info mempool orphan count

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -113,6 +113,7 @@ class HTTP extends Server {
     this.get('/', async (req, res) => {
       const totalTX = this.mempool ? this.mempool.map.size : 0;
       const size = this.mempool ? this.mempool.getSize() : 0;
+      const orphans = this.mempool ? this.mempool.orphans.size : 0;
 
       let addr = this.pool.hosts.getLocal();
 
@@ -151,7 +152,8 @@ class HTTP extends Server {
         },
         mempool: {
           tx: totalTX,
-          size: size
+          size: size,
+          orphans: orphans
         },
         time: {
           uptime: this.node.uptime(),


### PR DESCRIPTION
Return the number of orphans in the mempool for `GET /` on the Node HTTP server. I found this to be an interesting number to watch.