### PR TITLE
wallet: prevent chains of unconfirmed spends exceeding policy limit

### DIFF
--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1322,6 +1322,16 @@ class TXDB {
   }
 
   /**
+   * Test whether the database has a pending transaction.
+   * @param {Hash} hash
+   * @returns {Promise} - Returns Boolean.
+   */
+
+  async hasPending(hash) {
+    return this.bucket.has(layout.p.encode(hash));
+  }
+
+  /**
    * Get all coin hashes in the database.
    * @param {Number} acct
    * @returns {Promise} - Returns {@link Hash}[].

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1341,7 +1341,8 @@ class Wallet extends EventEmitter {
     if (tx.getWeight() > policy.MAX_TX_WEIGHT)
       throw new Error('TX exceeds policy weight.');
 
-    if (await this.countPendingAncestors(tx) + 1 > policy.MEMPOOL_MAX_ANCESTORS)
+    const ancestors = await this.getPendingAncestors(tx);
+    if (ancestors.size + 1 > policy.MEMPOOL_MAX_ANCESTORS)
       throw new Error('TX exceeds maximum unconfirmed ancestors.');
 
     await this.wdb.addTX(tx);
@@ -1741,23 +1742,23 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * Count all pending ancestors.
+   * Get all pending ancestors.
    * @param {TX} tx
-   * @returns {Promise} - Returns {Number}
+   * @returns {Promise} - Returns {BufferSet} with Hash
    */
 
-   async countPendingAncestors(tx) {
-    return this._countPendingAncestors(tx, new BufferSet());
+   async getPendingAncestors(tx) {
+    return this._getPendingAncestors(tx, new BufferSet());
    }
 
   /**
-   * Count all pending ancestors.
+   * Get all pending ancestors.
    * @param {TX} tx
    * @param {Object} set
-   * @returns {Promise} - Returns {Number}
+   * @returns {Promise} - Returns {BufferSet} with Hash
    */
 
-  async _countPendingAncestors(tx, set) {
+  async _getPendingAncestors(tx, set) {
     for (const {prevout} of tx.inputs) {
       const hash = prevout.hash;
 
@@ -1770,10 +1771,10 @@ class Wallet extends EventEmitter {
       set.add(hash);
 
       const parent = await this.getTX(hash);
-      await this._countPendingAncestors(parent.tx, set);
+      await this._getPendingAncestors(parent.tx, set);
     }
 
-    return set.size;
+    return set;
   }
 
   /**

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -31,6 +31,7 @@ const consensus = require('../protocol/consensus');
 const {encoding} = bio;
 const {Mnemonic} = HD;
 const {inspectSymbol} = require('../utils');
+const {BufferSet} = require('buffer-map');
 
 /**
  * Wallet
@@ -1340,6 +1341,9 @@ class Wallet extends EventEmitter {
     if (tx.getWeight() > policy.MAX_TX_WEIGHT)
       throw new Error('TX exceeds policy weight.');
 
+    if (await this.countPendingAncestors(tx) + 1 > policy.MEMPOOL_MAX_ANCESTORS)
+      throw new Error('TX exceeds maximum unconfirmed ancestors.');
+
     await this.wdb.addTX(tx);
 
     this.logger.debug('Sending wallet tx (%s): %h', this.id, tx.hash());
@@ -1734,6 +1738,42 @@ class Wallet extends EventEmitter {
     const rings = await this.deriveInputs(mtx);
 
     return mtx.signAsync(rings, Script.hashType.ALL, this.wdb.workers);
+  }
+
+  /**
+   * Count all pending ancestors.
+   * @param {TX} tx
+   * @returns {Promise} - Returns {Number}
+   */
+
+   async countPendingAncestors(tx) {
+    return this._countPendingAncestors(tx, new BufferSet());
+   }
+
+  /**
+   * Count all pending ancestors.
+   * @param {TX} tx
+   * @param {Object} set
+   * @returns {Promise} - Returns {Number}
+   */
+
+  async _countPendingAncestors(tx, set) {
+    for (const {prevout} of tx.inputs) {
+      const hash = prevout.hash;
+
+      if (!await this.txdb.hasPending(hash))
+        continue;
+
+      if (set.has(hash))
+        continue;
+
+      set.add(hash);
+
+      const parent = await this.getTX(hash);
+      await this._countPendingAncestors(parent.tx, set);
+    }
+
+    return set.size;
   }
 
   /**

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1742,7 +1742,7 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * Get all pending ancestors.
+   * Get pending ancestors up to the policy limit
    * @param {TX} tx
    * @returns {Promise} - Returns {BufferSet} with Hash
    */
@@ -1752,7 +1752,7 @@ class Wallet extends EventEmitter {
    }
 
   /**
-   * Get all pending ancestors.
+   * Get pending ancestors up to the policy limit.
    * @param {TX} tx
    * @param {Object} set
    * @returns {Promise} - Returns {BufferSet} with Hash
@@ -1762,16 +1762,22 @@ class Wallet extends EventEmitter {
     for (const {prevout} of tx.inputs) {
       const hash = prevout.hash;
 
-      if (!await this.hasPending(hash))
+      if (set.has(hash))
         continue;
 
-      if (set.has(hash))
+      if (!await this.hasPending(hash))
         continue;
 
       set.add(hash);
 
+      if (set.size > policy.MEMPOOL_MAX_ANCESTORS)
+        break;
+
       const parent = await this.getTX(hash);
       await this._getPendingAncestors(parent.tx, set);
+
+      if (set.size > policy.MEMPOOL_MAX_ANCESTORS)
+        break;
     }
 
     return set;

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -68,6 +68,8 @@ class Wallet extends EventEmitter {
 
     this.txdb = new TXDB(this.wdb);
 
+    this.maxAncestors = policy.MEMPOOL_MAX_ANCESTORS;
+
     if (options)
       this.fromOptions(options);
   }
@@ -127,6 +129,11 @@ class Wallet extends EventEmitter {
     if (options.tokenDepth != null) {
       assert((options.tokenDepth >>> 0) === options.tokenDepth);
       this.tokenDepth = options.tokenDepth;
+    }
+
+    if (options.maxAncestors != null) {
+      assert((options.maxAncestors >>> 0) === options.maxAncestors);
+      this.maxAncestors = options.maxAncestors;
     }
 
     if (!id)
@@ -1342,7 +1349,7 @@ class Wallet extends EventEmitter {
       throw new Error('TX exceeds policy weight.');
 
     const ancestors = await this.getPendingAncestors(tx);
-    if (ancestors.size + 1 > policy.MEMPOOL_MAX_ANCESTORS)
+    if (ancestors.size + 1 > this.maxAncestors)
       throw new Error('TX exceeds maximum unconfirmed ancestors.');
 
     await this.wdb.addTX(tx);
@@ -1770,13 +1777,13 @@ class Wallet extends EventEmitter {
 
       set.add(hash);
 
-      if (set.size > policy.MEMPOOL_MAX_ANCESTORS)
+      if (set.size > this.maxAncestors)
         break;
 
       const parent = await this.getTX(hash);
       await this._getPendingAncestors(parent.tx, set);
 
-      if (set.size > policy.MEMPOOL_MAX_ANCESTORS)
+      if (set.size > this.maxAncestors)
         break;
     }
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1761,7 +1761,7 @@ class Wallet extends EventEmitter {
     for (const {prevout} of tx.inputs) {
       const hash = prevout.hash;
 
-      if (!await this.txdb.hasPending(hash))
+      if (!await this.hasPending(hash))
         continue;
 
       if (set.has(hash))
@@ -1774,6 +1774,16 @@ class Wallet extends EventEmitter {
     }
 
     return set.size;
+  }
+
+  /**
+   * Test whether the database has a pending transaction.
+   * @param {Hash} hash
+   * @returns {Promise} - Returns Boolean.
+   */
+
+  hasPending(hash) {
+    return this.txdb.hasPending(hash);
   }
 
   /**

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -249,10 +249,6 @@ describe('Wallet', function() {
     await workers.close();
   });
 
-  it('should open walletdb', () => {
-    consensus.COINBASE_MATURITY = 0;
-  });
-
   it('should generate new key and address', async () => {
     const wallet = await wdb.create();
 
@@ -1955,10 +1951,5 @@ describe('Wallet', function() {
     }, {
       message: 'TX exceeds maximum unconfirmed ancestors.'
     });
-  });
-
-  it('should cleanup', async () => {
-    consensus.COINBASE_MATURITY = 100;
-    // await wdb.close();
   });
 });

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -1924,9 +1924,9 @@ describe('Wallet', function() {
     const tx0 = mtx.toTX();
     await wallet.txdb.add(tx0, null);
 
-    let count;
-    count = await wallet.countPendingAncestors(tx0);
-    assert.strictEqual(count, 0);
+    let ancs = null;
+    ancs = await wallet.getPendingAncestors(tx0);
+    assert.strictEqual(ancs.size, 0);
 
     // Create one tx
     const tx1 = await wallet.send({
@@ -1935,8 +1935,8 @@ describe('Wallet', function() {
         value: 10000
       }]
     });
-    count = await wallet.countPendingAncestors(tx1);
-    assert.strictEqual(count, 1);
+    ancs = await wallet.getPendingAncestors(tx1);
+    assert.strictEqual(ancs.size, 1);
 
     // Create a second tx
     const tx2 = await wallet.send({
@@ -1945,8 +1945,8 @@ describe('Wallet', function() {
         value: 10000
       }]
     });
-    count = await wallet.countPendingAncestors(tx2);
-    assert.strictEqual(count, 2);
+    ancs = await wallet.getPendingAncestors(tx2);
+    assert.strictEqual(ancs.size, 2);
 
     // Confirm tx0 with dummy block
     const block100 = {
@@ -1957,8 +1957,8 @@ describe('Wallet', function() {
     const wtx0 = await wallet.txdb.getTX(tx0.hash());
     await wallet.txdb.confirm(wtx0, block100);
 
-    count = await wallet.countPendingAncestors(tx2);
-    assert.strictEqual(count, 1);
+    ancs = await wallet.getPendingAncestors(tx2);
+    assert.strictEqual(ancs.size, 1);
 
     // Confirm tx1 with dummy block
     const block101 = {
@@ -1969,8 +1969,8 @@ describe('Wallet', function() {
     const wtx1 = await wallet.txdb.getTX(tx1.hash());
     await wallet.txdb.confirm(wtx1, block101);
 
-    count = await wallet.countPendingAncestors(tx2);
-    assert.strictEqual(count, 0);
+    ancs = await wallet.getPendingAncestors(tx2);
+    assert.strictEqual(ancs.size, 0);
   });
 
   it('should not exceed MEMPOOL_MAX_ANCESTORS policy', async () => {


### PR DESCRIPTION
Recently a rogue node on Handshake generated a chain of over 10,000 transactions from a single coin, each spending the change output of its parent. Mempool relay policy limits these chains at 25, but the wallet will keep generating and trying to broadcast. Transactions were evicted from the mempool, turning it into at least one chain of orphans. The node kept rebroadcasting after receving each block, and it was a mess!

This PR prevents the wallet from exceeding the limit on unspent tx chains.