### PR TITLE
Add abandon tx to CLI and client

### DIFF
--- a/bin/bwallet-cli
+++ b/bin/bwallet-cli
@@ -352,7 +352,7 @@ class CLI {
 
     await this.wallet.abandon(hash);
 
-    this.log('Abandoned!');
+    this.log('Abandoned tx: ' + hash);
   }
 
   async viewTX() {

--- a/bin/bwallet-cli
+++ b/bin/bwallet-cli
@@ -347,6 +347,14 @@ class CLI {
     this.log('Zapped!');
   }
 
+  async abandonTX() {
+    const hash = this.config.str(0);
+
+    await this.wallet.abandon(hash);
+
+    this.log('Abandoned!');
+  }
+
   async viewTX() {
     const raw = this.config.str([0, 'tx']);
     const tx = await this.wallet.fill(raw);
@@ -556,6 +564,9 @@ class CLI {
       case 'zap':
         await this.zapWallet();
         break;
+      case 'abandon':
+        await this.abandonTX();
+        break;
       case 'tx':
         await this.getDetails();
         break;
@@ -615,6 +626,7 @@ class CLI {
         this.log('  $ mktx [address] [value]: Create transaction.');
         this.log('  $ sign [tx-hex]: Sign transaction.');
         this.log('  $ zap [age?]: Zap pending wallet TXs.');
+        this.log('  $ abandon [hash]: Abandon a transaction.');
         this.log('  $ tx [hash]: View transaction details.');
         this.log('  $ blocks: List wallet blocks.');
         this.log('  $ block [height]: View wallet block.');

--- a/lib/client/wallet.js
+++ b/lib/client/wallet.js
@@ -326,6 +326,16 @@ class WalletClient extends Client {
   }
 
   /**
+   * @param {Number} id - Wallet id.
+   * @param {Number} hash - Tx hash.
+   * @returns {Promise}
+   */
+
+  abandon(id, hash) {
+    return this.del(`/wallet/${id}/tx/${hash}`);
+  }
+
+  /**
    * Create a transaction, fill.
    * @param {Object} options
    * @returns {Promise}
@@ -759,6 +769,19 @@ class Wallet extends EventEmitter {
 
   zap(account, age) {
     return this.client.zap(this.id, account, age);
+  }
+
+  /**
+   * Used to remove a pending transaction from the wallet.
+   * That is likely the case if it has a policy or low fee
+   * that prevents it from proper network propagation.
+   * @param {Number} id - Wallet id.
+   * @param {Number} hash - Tx hash.
+   * @returns {Promise}
+   */
+
+  abandon(hash) {
+    return this.client.abandon(this.id, hash);
   }
 
   /**

--- a/lib/client/wallet.js
+++ b/lib/client/wallet.js
@@ -64,6 +64,8 @@ class WalletClient extends Client {
 
   /**
    * Dispatch event.
+   * @param {Number} id
+   * @param {String} event
    * @private
    */
 
@@ -114,6 +116,8 @@ class WalletClient extends Client {
 
   /**
    * Create a wallet object.
+   * @param {Number} id
+   * @param {String} token
    */
 
   wallet(id, token) {
@@ -122,6 +126,7 @@ class WalletClient extends Client {
 
   /**
    * Join a wallet.
+   * @param {String} token
    */
 
   all(token) {
@@ -138,6 +143,8 @@ class WalletClient extends Client {
 
   /**
    * Join a wallet.
+   * @param {Number} id
+   * @param {String} token
    */
 
   join(id, token) {
@@ -146,6 +153,7 @@ class WalletClient extends Client {
 
   /**
    * Leave a wallet.
+   * @param {Number} id
    */
 
   leave(id) {
@@ -192,6 +200,7 @@ class WalletClient extends Client {
 
   /**
    * Create a wallet.
+   * @param {Number} id
    * @param {Object} options
    * @returns {Promise}
    */
@@ -202,6 +211,7 @@ class WalletClient extends Client {
 
   /**
    * Get wallet transaction history.
+   * @param {Number} id
    * @param {String} account
    * @returns {Promise}
    */
@@ -212,6 +222,7 @@ class WalletClient extends Client {
 
   /**
    * Get wallet coins.
+   * @param {Number} id
    * @param {String} account
    * @returns {Promise}
    */
@@ -222,6 +233,7 @@ class WalletClient extends Client {
 
   /**
    * Get all unconfirmed transactions.
+   * @param {Number} id
    * @param {String} account
    * @returns {Promise}
    */
@@ -232,6 +244,7 @@ class WalletClient extends Client {
 
   /**
    * Calculate wallet balance.
+   * @param {Number} id
    * @param {String} account
    * @returns {Promise}
    */
@@ -242,6 +255,7 @@ class WalletClient extends Client {
 
   /**
    * Get last N wallet transactions.
+   * @param {Number} id
    * @param {String} account
    * @param {Number} limit - Max number of transactions.
    * @returns {Promise}
@@ -253,6 +267,7 @@ class WalletClient extends Client {
 
   /**
    * Get wallet transactions by timestamp range.
+   * @param {Number} id
    * @param {String} account
    * @param {Object} options
    * @param {Number} options.start - Start time.
@@ -275,6 +290,7 @@ class WalletClient extends Client {
   /**
    * Get transaction (only possible if the transaction
    * is available in the wallet history).
+   * @param {Number} id
    * @param {Hash} hash
    * @returns {Promise}
    */
@@ -285,7 +301,7 @@ class WalletClient extends Client {
 
   /**
    * Get wallet blocks.
-   * @param {Number} height
+   * @param {Number} id
    * @returns {Promise}
    */
 
@@ -295,6 +311,7 @@ class WalletClient extends Client {
 
   /**
    * Get wallet block.
+   * @param {Number} id
    * @param {Number} height
    * @returns {Promise}
    */
@@ -306,6 +323,7 @@ class WalletClient extends Client {
   /**
    * Get unspent coin (only possible if the transaction
    * is available in the wallet history).
+   * @param {Number} id
    * @param {Hash} hash
    * @param {Number} index
    * @returns {Promise}
@@ -316,7 +334,8 @@ class WalletClient extends Client {
   }
 
   /**
-   * @param {Number} now - Current time.
+   * @param {Number} id
+   * @param {String} account
    * @param {Number} age - Age delta.
    * @returns {Promise}
    */
@@ -326,8 +345,8 @@ class WalletClient extends Client {
   }
 
   /**
-   * @param {Number} id - Wallet id.
-   * @param {Number} hash - Tx hash.
+   * @param {Number} id
+   * @param {Hash} hash
    * @returns {Promise}
    */
 
@@ -337,6 +356,7 @@ class WalletClient extends Client {
 
   /**
    * Create a transaction, fill.
+   * @param {Number} id
    * @param {Object} options
    * @returns {Promise}
    */
@@ -347,6 +367,7 @@ class WalletClient extends Client {
 
   /**
    * Create a transaction, fill, sign, and broadcast.
+   * @param {Number} id
    * @param {Object} options
    * @param {String} options.address
    * @param {Amount} options.value
@@ -359,6 +380,7 @@ class WalletClient extends Client {
 
   /**
    * Sign a transaction.
+   * @param {Number} id
    * @param {Object} options
    * @returns {Promise}
    */
@@ -369,6 +391,7 @@ class WalletClient extends Client {
 
   /**
    * Get the raw wallet JSON.
+   * @param {Number} id
    * @returns {Promise}
    */
 
@@ -378,6 +401,7 @@ class WalletClient extends Client {
 
   /**
    * Get wallet accounts.
+   * @param {Number} id
    * @returns {Promise} - Returns Array.
    */
 
@@ -387,6 +411,7 @@ class WalletClient extends Client {
 
   /**
    * Get wallet master key.
+   * @param {Number} id
    * @returns {Promise}
    */
 
@@ -396,6 +421,7 @@ class WalletClient extends Client {
 
   /**
    * Get wallet account.
+   * @param {Number} id
    * @param {String} account
    * @returns {Promise}
    */
@@ -406,6 +432,7 @@ class WalletClient extends Client {
 
   /**
    * Create account.
+   * @param {Number} id
    * @param {String} name
    * @param {Object} options
    * @returns {Promise}
@@ -417,6 +444,7 @@ class WalletClient extends Client {
 
   /**
    * Create address.
+   * @param {Number} id
    * @param {Object} options
    * @returns {Promise}
    */
@@ -427,6 +455,7 @@ class WalletClient extends Client {
 
   /**
    * Create change address.
+   * @param {Number} id
    * @param {Object} options
    * @returns {Promise}
    */
@@ -437,7 +466,8 @@ class WalletClient extends Client {
 
   /**
    * Create nested address.
-   * @param {Object} options
+   * @param {Number} id
+   * @param {String} account
    * @returns {Promise}
    */
 
@@ -447,6 +477,7 @@ class WalletClient extends Client {
 
   /**
    * Change or set master key`s passphrase.
+   * @param {Number} id
    * @param {String|Buffer} passphrase
    * @param {(String|Buffer)?} old
    * @returns {Promise}
@@ -458,6 +489,7 @@ class WalletClient extends Client {
 
   /**
    * Generate a new token.
+   * @param {Number} id
    * @param {(String|Buffer)?} passphrase
    * @returns {Promise}
    */
@@ -470,7 +502,8 @@ class WalletClient extends Client {
 
   /**
    * Import private key.
-   * @param {Number|String} account
+   * @param {Number} id
+   * @param {String} account
    * @param {String} key
    * @returns {Promise}
    */
@@ -485,8 +518,9 @@ class WalletClient extends Client {
 
   /**
    * Import public key.
+   * @param {Number} id
    * @param {Number|String} account
-   * @param {String} key
+   * @param {String} publicKey
    * @returns {Promise}
    */
 
@@ -499,7 +533,8 @@ class WalletClient extends Client {
 
   /**
    * Import address.
-   * @param {Number|String} account
+   * @param {Number} id
+   * @param {String} account
    * @param {String} address
    * @returns {Promise}
    */
@@ -521,6 +556,7 @@ class WalletClient extends Client {
 
   /**
    * Unlock a coin.
+   * @param {Number} id
    * @param {String} hash
    * @param {Number} index
    * @returns {Promise}
@@ -532,6 +568,7 @@ class WalletClient extends Client {
 
   /**
    * Get locked coins.
+   * @param {Number} id
    * @returns {Promise}
    */
 
@@ -541,6 +578,7 @@ class WalletClient extends Client {
 
   /**
    * Lock wallet.
+   * @param {Number} id
    * @returns {Promise}
    */
 
@@ -550,6 +588,7 @@ class WalletClient extends Client {
 
   /**
    * Unlock wallet.
+   * @param {Number} id
    * @param {String} passphrase
    * @param {Number} timeout
    * @returns {Promise}
@@ -561,6 +600,7 @@ class WalletClient extends Client {
 
   /**
    * Get wallet key.
+   * @param {Number} id
    * @param {String} address
    * @returns {Promise}
    */
@@ -571,6 +611,7 @@ class WalletClient extends Client {
 
   /**
    * Get wallet key WIF dump.
+   * @param {Number} id
    * @param {String} address
    * @param {String?} passphrase
    * @returns {Promise}
@@ -582,6 +623,7 @@ class WalletClient extends Client {
 
   /**
    * Add a public account key to the wallet for multisig.
+   * @param {Number} id
    * @param {String} account
    * @param {String} key - Account (bip44) key (base58).
    * @returns {Promise}
@@ -593,8 +635,9 @@ class WalletClient extends Client {
 
   /**
    * Remove a public account key to the wallet for multisig.
+   * @param {Number} id
    * @param {String} account
-   * @param {String} key - Account (bip44) key (base58).
+   * @param {String} accountKey - Account (bip44) key (base58).
    * @returns {Promise}
    */
 
@@ -604,6 +647,7 @@ class WalletClient extends Client {
 
   /**
    * Resend wallet transactions.
+   * @param {Number} id
    * @returns {Promise}
    */
 
@@ -762,7 +806,7 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * @param {Number} now - Current time.
+   * @param {String} account
    * @param {Number} age - Age delta.
    * @returns {Promise}
    */
@@ -775,8 +819,7 @@ class Wallet extends EventEmitter {
    * Used to remove a pending transaction from the wallet.
    * That is likely the case if it has a policy or low fee
    * that prevents it from proper network propagation.
-   * @param {Number} id - Wallet id.
-   * @param {Number} hash - Tx hash.
+   * @param {Hash} hash
    * @returns {Promise}
    */
 
@@ -866,7 +909,7 @@ class Wallet extends EventEmitter {
 
   /**
    * Create address.
-   * @param {Object} options
+   * @param {String} account
    * @returns {Promise}
    */
 
@@ -876,7 +919,7 @@ class Wallet extends EventEmitter {
 
   /**
    * Create change address.
-   * @param {Object} options
+   * @param {String} account
    * @returns {Promise}
    */
 
@@ -886,7 +929,7 @@ class Wallet extends EventEmitter {
 
   /**
    * Create nested address.
-   * @param {Object} options
+   * @param {String} account
    * @returns {Promise}
    */
 
@@ -925,7 +968,8 @@ class Wallet extends EventEmitter {
   /**
    * Import private key.
    * @param {Number|String} account
-   * @param {String} key
+   * @param {String} privateKey
+   * @param {String} passphrase
    * @returns {Promise}
    */
 
@@ -936,7 +980,7 @@ class Wallet extends EventEmitter {
   /**
    * Import public key.
    * @param {Number|String} account
-   * @param {String} key
+   * @param {String} publicKey
    * @returns {Promise}
    */
 
@@ -1030,7 +1074,7 @@ class Wallet extends EventEmitter {
   /**
    * Add a public account key to the wallet for multisig.
    * @param {String} account
-   * @param {String} key - Account (bip44) key (base58).
+   * @param {String} accountKey - Account (bip44) key (base58).
    * @returns {Promise}
    */
 
@@ -1041,7 +1085,7 @@ class Wallet extends EventEmitter {
   /**
    * Remove a public account key to the wallet for multisig.
    * @param {String} account
-   * @param {String} key - Account (bip44) key (base58).
+   * @param {String} accountKey - Account (bip44) key (base58).
    * @returns {Promise}
    */
 


### PR DESCRIPTION
Useful to release coins to be spent that are used in a transaction that is problematic to broadcast because of policy conflicts.