### PR TITLE
Add title to worker processes

### DIFF
--- a/lib/workers/worker.js
+++ b/lib/workers/worker.js
@@ -10,4 +10,6 @@
 const Master = require('./master');
 const server = new Master();
 
+process.title = 'bcoin-worker';
+
 server.listen();


### PR DESCRIPTION
This will give worker processes the title 'bcoin-worker' instead of the more generic 'node'.