### PR TITLE
net: deprecate p2p message reject

### DIFF
--- a/lib/net/packets.js
+++ b/lib/net/packets.js
@@ -26,7 +26,6 @@ const MerkleBlock = require('../primitives/merkleblock');
 const TX = require('../primitives/tx');
 const {encoding} = bio;
 const DUMMY = Buffer.alloc(0);
-const {inspectSymbol} = require('../utils');
 
 /**
  * Packet types.
@@ -50,7 +49,6 @@ exports.types = {
   SENDHEADERS: 12,
   BLOCK: 13,
   TX: 14,
-  REJECT: 15,
   MEMPOOL: 16,
   FILTERLOAD: 17,
   FILTERADD: 18,
@@ -89,7 +87,6 @@ exports.typesByVal = [
   'SENDHEADERS',
   'BLOCK',
   'TX',
-  'REJECT',
   'MEMPOOL',
   'FILTERLOAD',
   'FILTERADD',
@@ -1472,322 +1469,6 @@ class TXPacket extends Packet {
 }
 
 /**
- * Reject Packet
- * @extends Packet
- * @property {(Number|String)?} code - Code
- * (see {@link RejectPacket.codes}).
- * @property {String?} msg - Message.
- * @property {String?} reason - Reason.
- * @property {(Hash|Buffer)?} data - Transaction or block hash.
- */
-
-class RejectPacket extends Packet {
-  /**
-   * Create reject packet.
-   * @constructor
-   */
-
-  constructor(options) {
-    super();
-
-    this.cmd = 'reject';
-    this.type = exports.types.REJECT;
-
-    this.message = '';
-    this.code = RejectPacket.codes.INVALID;
-    this.reason = '';
-    this.hash = null;
-
-    if (options)
-      this.fromOptions(options);
-  }
-
-  /**
-   * Inject properties from options object.
-   * @private
-   * @param {Object} options
-   */
-
-  fromOptions(options) {
-    let code = options.code;
-
-    if (options.message)
-      this.message = options.message;
-
-    if (code != null) {
-      if (typeof code === 'string')
-        code = RejectPacket.codes[code.toUpperCase()];
-
-      if (code >= RejectPacket.codes.INTERNAL)
-        code = RejectPacket.codes.INVALID;
-
-      this.code = code;
-    }
-
-    if (options.reason)
-      this.reason = options.reason;
-
-    if (options.hash)
-      this.hash = options.hash;
-
-    return this;
-  }
-
-  /**
-   * Instantiate reject packet from options.
-   * @param {Object} options
-   * @returns {RejectPacket}
-   */
-
-  static fromOptions(options) {
-    return new this().fromOptions(options);
-  }
-
-  /**
-   * Get uint256le hash if present.
-   * @returns {Hash}
-   */
-
-  rhash() {
-    return this.hash ? util.revHex(this.hash) : null;
-  }
-
-  /**
-   * Get symbolic code.
-   * @returns {String}
-   */
-
-  getCode() {
-    const code = RejectPacket.codesByVal[this.code];
-
-    if (!code)
-      return this.code.toString(10);
-
-    return code.toLowerCase();
-  }
-
-  /**
-   * Get serialization size.
-   * @returns {Number}
-   */
-
-  getSize() {
-    let size = 0;
-
-    size += encoding.sizeVarString(this.message, 'ascii');
-    size += 1;
-    size += encoding.sizeVarString(this.reason, 'ascii');
-
-    if (this.hash)
-      size += 32;
-
-    return size;
-  }
-
-  /**
-   * Serialize reject packet to writer.
-   * @param {BufferWriter} bw
-   */
-
-  toWriter(bw) {
-    assert(this.message.length <= 12);
-    assert(this.reason.length <= 111);
-
-    bw.writeVarString(this.message, 'ascii');
-    bw.writeU8(this.code);
-    bw.writeVarString(this.reason, 'ascii');
-
-    if (this.hash)
-      bw.writeHash(this.hash);
-
-    return bw;
-  }
-
-  /**
-   * Serialize reject packet.
-   * @returns {Buffer}
-   */
-
-  toRaw() {
-    const size = this.getSize();
-    return this.toWriter(bio.write(size)).render();
-  }
-
-  /**
-   * Inject properties from buffer reader.
-   * @private
-   * @param {BufferReader} br
-   */
-
-  fromReader(br) {
-    this.message = br.readVarString('ascii', 12);
-    this.code = br.readU8();
-    this.reason = br.readVarString('ascii', 111);
-
-    switch (this.message) {
-      case 'block':
-      case 'tx':
-        this.hash = br.readHash();
-        break;
-      default:
-        this.hash = null;
-        break;
-    }
-
-    return this;
-  }
-
-  /**
-   * Inject properties from serialized data.
-   * @private
-   * @param {Buffer} data
-   */
-
-  fromRaw(data) {
-    return this.fromReader(bio.read(data));
-  }
-
-  /**
-   * Instantiate reject packet from buffer reader.
-   * @param {BufferReader} br
-   * @returns {RejectPacket}
-   */
-
-  static fromReader(br) {
-    return new this().fromReader(br);
-  }
-
-  /**
-   * Instantiate reject packet from serialized data.
-   * @param {Buffer} data
-   * @param {String?} enc
-   * @returns {RejectPacket}
-   */
-
-  static fromRaw(data, enc) {
-    if (typeof data === 'string')
-      data = Buffer.from(data, enc);
-    return new this().fromRaw(data, enc);
-  }
-
-  /**
-   * Inject properties from reason message and object.
-   * @private
-   * @param {Number|String} code
-   * @param {String} reason
-   * @param {String?} msg
-   * @param {Hash?} hash
-   */
-
-  fromReason(code, reason, msg, hash) {
-    if (typeof code === 'string')
-      code = RejectPacket.codes[code.toUpperCase()];
-
-    if (!code)
-      code = RejectPacket.codes.INVALID;
-
-    if (code >= RejectPacket.codes.INTERNAL)
-      code = RejectPacket.codes.INVALID;
-
-    this.message = '';
-    this.code = code;
-    this.reason = reason;
-
-    if (msg) {
-      assert(hash);
-      this.message = msg;
-      this.hash = hash;
-    }
-
-    return this;
-  }
-
-  /**
-   * Instantiate reject packet from reason message.
-   * @param {Number} code
-   * @param {String} reason
-   * @param {String?} msg
-   * @param {Hash?} hash
-   * @returns {RejectPacket}
-   */
-
-  static fromReason(code, reason, msg, hash) {
-    return new this().fromReason(code, reason, msg, hash);
-  }
-
-  /**
-   * Instantiate reject packet from verify error.
-   * @param {VerifyError} err
-   * @param {(TX|Block)?} obj
-   * @returns {RejectPacket}
-   */
-
-  static fromError(err, obj) {
-    return this.fromReason(err.code, err.reason, obj);
-  }
-
-  /**
-   * Inspect reject packet.
-   * @returns {String}
-   */
-
-  [inspectSymbol]() {
-    const code = RejectPacket.codesByVal[this.code] || this.code;
-    const hash = this.hash ? util.revHex(this.hash) : null;
-    return '<Reject:'
-      + ` msg=${this.message}`
-      + ` code=${code}`
-      + ` reason=${this.reason}`
-      + ` hash=${hash}`
-      + '>';
-  }
-}
-
-/**
- * Reject codes. Note that `internal` and higher
- * are not meant for use on the p2p network.
- * @enum {Number}
- * @default
- */
-
-RejectPacket.codes = {
-  MALFORMED: 0x01,
-  INVALID: 0x10,
-  OBSOLETE: 0x11,
-  DUPLICATE: 0x12,
-  NONSTANDARD: 0x40,
-  DUST: 0x41,
-  INSUFFICIENTFEE: 0x42,
-  CHECKPOINT: 0x43,
-  // Internal codes (NOT FOR USE ON NETWORK)
-  INTERNAL: 0x100,
-  HIGHFEE: 0x101,
-  ALREADYKNOWN: 0x102,
-  CONFLICT: 0x103
-};
-
-/**
- * Reject codes by value.
- * @const {Object}
- */
-
-RejectPacket.codesByVal = {
-  0x01: 'MALFORMED',
-  0x10: 'INVALID',
-  0x11: 'OBSOLETE',
-  0x12: 'DUPLICATE',
-  0x40: 'NONSTANDARD',
-  0x41: 'DUST',
-  0x42: 'INSUFFICIENTFEE',
-  0x43: 'CHECKPOINT',
-  // Internal codes (NOT FOR USE ON NETWORK)
-  0x100: 'INTERNAL',
-  0x101: 'HIGHFEE',
-  0x102: 'ALREADYKNOWN',
-  0x103: 'CONFLICT'
-};
-
-/**
  * Mempool Packet
  * @extends Packet
  */
@@ -2748,8 +2429,6 @@ exports.fromRaw = function fromRaw(cmd, data) {
       return BlockPacket.fromRaw(data);
     case 'tx':
       return TXPacket.fromRaw(data);
-    case 'reject':
-      return RejectPacket.fromRaw(data);
     case 'mempool':
       return MempoolPacket.fromRaw(data);
     case 'filterload':
@@ -2795,7 +2474,6 @@ exports.HeadersPacket = HeadersPacket;
 exports.SendHeadersPacket = SendHeadersPacket;
 exports.BlockPacket = BlockPacket;
 exports.TXPacket = TXPacket;
-exports.RejectPacket = RejectPacket;
 exports.MempoolPacket = MempoolPacket;
 exports.FilterLoadPacket = FilterLoadPacket;
 exports.FilterAddPacket = FilterAddPacket;

--- a/lib/net/peer.js
+++ b/lib/net/peer.js
@@ -203,7 +203,6 @@ class Peer extends EventEmitter {
         return;
 
       this.error(err);
-      this.sendReject('malformed', 'error parsing message');
       this.increaseBan(10);
     });
   }
@@ -1752,32 +1751,6 @@ class Peer extends EventEmitter {
   }
 
   /**
-   * Send `reject` to peer.
-   * @param {Number} code
-   * @param {String} reason
-   * @param {String} msg
-   * @param {Hash} hash
-   */
-
-  sendReject(code, reason, msg, hash) {
-    const reject = packets.RejectPacket.fromReason(code, reason, msg, hash);
-
-    if (msg) {
-      this.logger.debug('Rejecting %s %h (%s): code=%s reason=%s.',
-        msg, hash, this.hostname(), code, reason);
-    } else {
-      this.logger.debug('Rejecting packet from %s: code=%s reason=%s.',
-        this.hostname(), code, reason);
-    }
-
-    this.logger.debug(
-      'Sending reject packet to peer (%s).',
-      this.hostname());
-
-    this.send(reject);
-  }
-
-  /**
    * Send a `sendcmpct` packet.
    * @param {Number} mode
    */
@@ -1826,18 +1799,6 @@ class Peer extends EventEmitter {
 
   ban() {
     this.emit('ban');
-  }
-
-  /**
-   * Send a `reject` packet to peer.
-   * @param {String} msg
-   * @param {VerifyError} err
-   * @returns {Boolean}
-   */
-
-  reject(msg, err) {
-    this.sendReject(err.code, err.reason, msg, err.hash);
-    return this.increaseBan(err.score);
   }
 
   /**

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -1195,9 +1195,6 @@ class Pool extends EventEmitter {
       case packetTypes.TX:
         await this.handleTX(peer, packet);
         break;
-      case packetTypes.REJECT:
-        await this.handleReject(peer, packet);
-        break;
       case packetTypes.MEMPOOL:
         await this.handleMempool(peer, packet);
         break;
@@ -2173,7 +2170,7 @@ class Pool extends EventEmitter {
       entry = await this.chain.add(block, flags, peer.id);
     } catch (err) {
       if (err.type === 'VerifyError') {
-        peer.reject('block', err);
+        peer.increaseBan(err.score);
         this.logger.warning(err);
         return;
       }
@@ -2323,7 +2320,7 @@ class Pool extends EventEmitter {
       peer.hostname());
 
     // Punish the original peer who sent this.
-    peer.reject(msg, err);
+    peer.increaseBan(err.score);
   }
 
   /**
@@ -2436,7 +2433,7 @@ class Pool extends EventEmitter {
       missing = await this.mempool.addTX(tx, peer.id);
     } catch (err) {
       if (err.type === 'VerifyError') {
-        peer.reject('tx', err);
+        peer.increaseBan(err.score);
         this.logger.info(err);
         return;
       }
@@ -2450,34 +2447,6 @@ class Pool extends EventEmitter {
 
       this.ensureTX(peer, missing);
     }
-  }
-
-  /**
-   * Handle peer reject event.
-   * @method
-   * @private
-   * @param {Peer} peer
-   * @param {RejectPacket} packet
-   */
-
-  async handleReject(peer, packet) {
-    this.logger.warning(
-      'Received reject (%s): msg=%s code=%s reason=%s hash=%h.',
-      peer.hostname(),
-      packet.message,
-      packet.getCode(),
-      packet.reason,
-      packet.hash);
-
-    if (!packet.hash)
-      return;
-
-    const entry = this.invMap.get(packet.hash);
-
-    if (!entry)
-      return;
-
-    entry.handleReject(peer);
   }
 
   /**
@@ -4228,20 +4197,6 @@ class BroadcastItem extends EventEmitter {
 
       this.jobs.length = 0;
     }, 1000);
-  }
-
-  /**
-   * Handle a reject from a peer.
-   * @param {Peer} peer
-   */
-
-  handleReject(peer) {
-    this.emit('reject', peer);
-
-    for (const job of this.jobs)
-      job.resolve(false);
-
-    this.jobs.length = 0;
   }
 
   /**

--- a/test/net-test.js
+++ b/test/net-test.js
@@ -507,45 +507,6 @@ describe('Net', function() {
       check(pkt, true, true);
     });
 
-    it('reject', () => {
-      const check = (pkt) => {
-        assert.equal(pkt.cmd, 'reject');
-        assert.equal(pkt.type, packets.types.REJECT);
-
-        assert.equal(pkt.code, 1);
-        assert.equal(pkt.reason, 'test-reason');
-        assert.equal(pkt.message, 'block');
-
-        assert.equal(pkt.getCode(), 'malformed');
-
-        assert.bufferEqual(pkt.hash, Buffer.alloc(32, 0x01));
-      };
-
-      let pkt = new packets.RejectPacket({
-        message: 'block',
-        code: 1,
-        reason: 'test-reason',
-        hash: Buffer.alloc(32, 0x01)
-      });
-
-      check(pkt);
-
-      pkt = packets.RejectPacket.fromRaw(pkt.toRaw());
-      check(pkt);
-
-      pkt = packets.RejectPacket.fromReason(
-        'malformed',
-        'test-reason',
-        'block',
-        Buffer.alloc(32, 0x01)
-      );
-
-      check(pkt);
-
-      pkt = packets.RejectPacket.fromRaw(pkt.toRaw());
-      check(pkt);
-    });
-
     it('mempool (BIP35)', () => {
       const check = (pkt) => {
         assert.equal(pkt.cmd, 'mempool');
@@ -2085,19 +2046,12 @@ describe('Net', function() {
           increaseBan = true;
         };
 
-        let send = false;
-        peer.send = (packet) => {
-          assert.equal(packet.type, packets.types.REJECT);
-          send = true;
-        };
-
         pool.resolveTX = () => true;
 
         const pkt = new packets.TXPacket(block.txs[10]);
 
         await pool.handleTX(peer, pkt);
         assert(increaseBan);
-        assert(send);
       });
     });
 


### PR DESCRIPTION
This PR removes the `RejectPacket` from `bcoin`, following recent changes to `bitcoind`. I am not particularly opinionated on whether or not this gets merged, but am opening it up for discussion.

One thing that needs more investigation are the internal codes for reject packets as there is no test coverage for them.

The `Pool` will now call `peer.increaseBan` instead of calling `peer.reject`, which previously wrapper `peer.increaseBan`.

Part of the rationality of removing this packet was that it is not a recommended way to debug. If we do decide to remove the `RejectPacket`, then we should also be sure that logging is sufficient.

There is a case to be made about node diversity and supporting features that are not supported by `bitcoind`, regarding @pinheadmz's suggestion to couple them with `whitebind`.

Closes https://github.com/bcoin-org/bcoin/issues/880