### PR TITLE
Add merkle block data type and methods

### DIFF
--- a/lib/blockstore/abstract.js
+++ b/lib/blockstore/abstract.js
@@ -61,6 +61,16 @@ class AbstractBlockStore {
   }
 
   /**
+   * This method stores merkle blocks including
+   * all the relevant transactions.
+   * @returns {Promise}
+   */
+
+  async writeMerkle(hash, data) {
+    throw new Error('Abstract method.');
+  }
+
+  /**
    * This method stores block undo coin data.
    * @returns {Promise}
    */
@@ -75,6 +85,15 @@ class AbstractBlockStore {
    */
 
   async write(hash, data) {
+    throw new Error('Abstract method.');
+  }
+
+  /**
+   * This method reads merkle block data.
+   * @returns {Promise}
+   */
+
+  async readMerkle(hash) {
     throw new Error('Abstract method.');
   }
 
@@ -98,6 +117,15 @@ class AbstractBlockStore {
   }
 
   /**
+   * This will free resources for storing the merkle block data.
+   * @returns {Promise}
+   */
+
+  async pruneMerkle(hash) {
+    throw new Error('Abstract method.');
+  }
+
+  /**
    * This will free resources for storing the block undo coin data.
    * @returns {Promise}
    */
@@ -112,6 +140,16 @@ class AbstractBlockStore {
    */
 
   async prune(hash) {
+    throw new Error('Abstract method.');
+  }
+
+  /**
+   * This will check if merkle block data has been stored
+   * and is available.
+   * @returns {Promise}
+   */
+
+  async hasMerkle(hash) {
     throw new Error('Abstract method.');
   }
 

--- a/lib/blockstore/abstract.js
+++ b/lib/blockstore/abstract.js
@@ -80,6 +80,15 @@ class AbstractBlockStore {
   }
 
   /**
+   * This method stores serialized block filter data in files.
+   * @returns {Promise}
+   */
+
+  async writeFilter(hash, data) {
+    throw new Error('Abstract method.');
+  }
+
+  /**
    * This method stores block data.
    * @returns {Promise}
    */
@@ -94,6 +103,24 @@ class AbstractBlockStore {
    */
 
   async readMerkle(hash) {
+    throw new Error('Abstract method.');
+  }
+
+  /**
+   * This method will retrieve serialized block filter data.
+   * @returns {Promise}
+   */
+
+  async readFilter(hash) {
+    throw new Error('Abstract method.');
+  }
+
+  /**
+   * This method will retrieve block filter header only.
+   * @returns {Promise}
+   */
+
+  async readFilterHeader(hash) {
     throw new Error('Abstract method.');
   }
 
@@ -135,6 +162,15 @@ class AbstractBlockStore {
   }
 
   /**
+   * This will free resources for storing the serialized block filter data.
+   * @returns {Promise}
+   */
+
+  async pruneFilter(hash) {
+    throw new Error('Abstract method.');
+  }
+
+  /**
    * This will free resources for storing the block data.
    * @returns {Promise}
    */
@@ -160,6 +196,16 @@ class AbstractBlockStore {
    */
 
   async hasUndo(hash) {
+    throw new Error('Abstract method.');
+  }
+
+  /**
+   * This will check if a block filter has been stored
+   * and is available.
+   * @returns {Promise}
+   */
+
+  async hasFilter(hash) {
     throw new Error('Abstract method.');
   }
 

--- a/lib/blockstore/common.js
+++ b/lib/blockstore/common.js
@@ -18,7 +18,8 @@
 exports.types = {
   BLOCK: 1,
   UNDO: 2,
-  FILTER: 3
+  FILTER: 3,
+  MERKLE: 4
 };
 
 /**
@@ -29,5 +30,6 @@ exports.types = {
 exports.prefixes = {
   1: 'blk',
   2: 'blu',
-  3: 'blf'
+  3: 'blf',
+  4: 'blm'
 };

--- a/lib/blockstore/file.js
+++ b/lib/blockstore/file.js
@@ -500,7 +500,7 @@ class FileBlockStore extends AbstractBlockStore {
    * @returns {Promise}
    */
 
-  async readHeader(hash) {
+  async readFilterHeader(hash) {
     return this._read(types.FILTER, hash, 0, 32);
   }
 
@@ -657,6 +657,17 @@ class FileBlockStore extends AbstractBlockStore {
 
   async hasUndo(hash) {
     return await this.db.has(layout.b.encode(types.UNDO, hash));
+  }
+
+  /**
+   * This will check if a block filter has been stored
+   * and is available.
+   * @param {Buffer} hash - The block hash
+   * @returns {Promise}
+   */
+
+  async hasFilter(hash) {
+    return await this.db.has(layout.b.encode(types.FILTER, hash));
   }
 
   /**

--- a/lib/blockstore/file.js
+++ b/lib/blockstore/file.js
@@ -128,7 +128,7 @@ class FileBlockStore extends AbstractBlockStore {
         try {
           length = reader.readU32();
 
-          if (type === types.BLOCK) {
+          if (type === types.BLOCK || type === types.MERKLE) {
             position = reader.offset;
             hash = hash256.digest(reader.readBytes(80, true));
             reader.seek(length - 80);
@@ -178,6 +178,7 @@ class FileBlockStore extends AbstractBlockStore {
 
   async index() {
     await this._index(types.BLOCK);
+    await this._index(types.MERKLE);
     await this._index(types.UNDO);
   }
 
@@ -308,6 +309,17 @@ class FileBlockStore extends AbstractBlockStore {
   }
 
   /**
+   * This method stores merkle block data in files.
+   * @param {Buffer} hash - The block hash
+   * @param {Buffer} data - The block data
+   * @returns {Promise}
+   */
+
+  async writeMerkle(hash, data) {
+    return this._write(types.MERKLE, hash, data);
+  }
+
+  /**
    * This method stores block undo coin data in files.
    * @param {Buffer} hash - The block hash
    * @param {Buffer} data - The block data
@@ -367,7 +379,7 @@ class FileBlockStore extends AbstractBlockStore {
     // Hash for a block is not stored with
     // the magic prefix as it's read from the header
     // of the block data.
-    if (type !== types.BLOCK)
+    if (type !== types.BLOCK && type !== types.MERKLE)
       mlength += 32;
 
     const blength = data.length;
@@ -378,7 +390,7 @@ class FileBlockStore extends AbstractBlockStore {
     bwm.writeU32(this.network.magic);
     bwm.writeU32(blength);
 
-    if (type !== types.BLOCK)
+    if (type !== types.BLOCK && type !== types.MERKLE)
       bwm.writeHash(hash);
 
     const magic = bwm.render();
@@ -436,6 +448,16 @@ class FileBlockStore extends AbstractBlockStore {
     this.writing[type] = false;
 
     return true;
+  }
+
+  /**
+   * This method will retrieve merkle block data.
+   * @param {Buffer} hash - The block hash
+   * @returns {Promise}
+   */
+
+  async readMerkle(hash) {
+    return this._read(types.MERKLE, hash);
   }
 
   /**
@@ -534,6 +556,16 @@ class FileBlockStore extends AbstractBlockStore {
   }
 
   /**
+   * This will free resources for storing merkle block data.
+   * @param {Buffer} hash - The block hash
+   * @returns {Promise}
+   */
+
+  async pruneMerkle(hash) {
+    return this._prune(types.MERKLE, hash);
+  }
+
+  /**
    * This will free resources for storing the block undo coin data.
    * @param {Buffer} hash - The block hash
    * @returns {Promise}
@@ -603,6 +635,17 @@ class FileBlockStore extends AbstractBlockStore {
       await fs.unlink(this.filepath(type, blockrecord.file));
 
     return true;
+  }
+
+  /**
+   * This will check if merkle block data has been stored
+   * and is available.
+   * @param {Buffer} hash - The block hash
+   * @returns {Promise}
+   */
+
+  async hasMerkle(hash) {
+    return await this.db.has(layout.b.encode(types.MERKLE, hash));
   }
 
   /**

--- a/lib/blockstore/level.js
+++ b/lib/blockstore/level.js
@@ -71,6 +71,17 @@ class LevelBlockStore extends AbstractBlockStore {
   }
 
   /**
+   * This method stores merkle block data in LevelDB.
+   * @param {Buffer} hash - The block hash
+   * @param {Buffer} data - The block data
+   * @returns {Promise}
+   */
+
+  async writeMerkle(hash, data) {
+    return this.db.put(layout.b.encode(types.MERKLE, hash), data);
+  }
+
+  /**
    * This method stores block undo coin data in LevelDB.
    * @param {Buffer} hash - The block hash
    * @param {Buffer} data - The block data
@@ -90,6 +101,16 @@ class LevelBlockStore extends AbstractBlockStore {
 
   async write(hash, data) {
     return this.db.put(layout.b.encode(types.BLOCK, hash), data);
+  }
+
+  /**
+   * This method will retrieve merkle block data.
+   * @param {Buffer} hash - The block hash
+   * @returns {Promise}
+   */
+
+  async readMerkle(hash) {
+    return this.db.get(layout.b.encode(types.MERKLE, hash));
   }
 
   /**
@@ -127,6 +148,23 @@ class LevelBlockStore extends AbstractBlockStore {
   }
 
   /**
+   * This will free resources for storing merkle block data.
+   * The block data may not be immediately removed from disk, and will
+   * be reclaimed during LevelDB compaction.
+   * @param {Buffer} hash - The block hash
+   * @returns {Promise}
+   */
+
+  async pruneMerkle(hash) {
+    if (!await this.hasMerkle(hash))
+      return false;
+
+    await this.db.del(layout.b.encode(types.MERKLE, hash));
+
+    return true;
+  }
+
+  /**
    * This will free resources for storing the block undo coin data.
    * The block data may not be immediately removed from disk, and will
    * be reclaimed during LevelDB compaction.
@@ -158,6 +196,17 @@ class LevelBlockStore extends AbstractBlockStore {
     await this.db.del(layout.b.encode(types.BLOCK, hash));
 
     return true;
+  }
+
+  /**
+   * This will check if a merkle block data has been stored
+   * and is available.
+   * @param {Buffer} hash - The block hash
+   * @returns {Promise}
+   */
+
+  async hasMerkle(hash) {
+    return this.db.has(layout.b.encode(types.MERKLE, hash));
   }
 
   /**

--- a/lib/blockstore/level.js
+++ b/lib/blockstore/level.js
@@ -104,6 +104,17 @@ class LevelBlockStore extends AbstractBlockStore {
   }
 
   /**
+   * This method stores serialized block filter data in LevelDB.
+   * @param {Buffer} hash - The block hash
+   * @param {Buffer} data - The serialized block filter data.
+   * @returns {Promise}
+   */
+
+  async writeFilter(hash, data) {
+    return this.db.put(layout.b.encode(types.FILTER, hash), data);
+  }
+
+  /**
    * This method will retrieve merkle block data.
    * @param {Buffer} hash - The block hash
    * @returns {Promise}
@@ -121,6 +132,31 @@ class LevelBlockStore extends AbstractBlockStore {
 
   async readUndo(hash) {
     return this.db.get(layout.b.encode(types.UNDO, hash));
+  }
+
+  /**
+   * This method will retrieve serialized block filter data.
+   * @param {Buffer} hash - The block hash
+   * @returns {Promise}
+   */
+
+  async readFilter(hash) {
+    return this.db.get(layout.b.encode(types.FILTER, hash));
+  }
+
+  /**
+   * This method will retrieve block filter header only.
+   * @param {Buffer} hash - The block hash
+   * @returns {Promise}
+   */
+
+  async readFilterHeader(hash) {
+    const data = await this.db.get(layout.b.encode(types.FILTER, hash));
+
+    if (!data)
+      return null;
+
+    return data.slice(0, 32);
   }
 
   /**
@@ -182,6 +218,21 @@ class LevelBlockStore extends AbstractBlockStore {
   }
 
   /**
+   * This will free resources for storing the serialized block filter data.
+   * @param {Buffer} hash - The block hash
+   * @returns {Promise}
+   */
+
+  async pruneFilter(hash) {
+    if (!await this.hasFilter(hash))
+      return false;
+
+    await this.db.del(layout.b.encode(types.FILTER, hash));
+
+    return true;
+  }
+
+  /**
    * This will free resources for storing the block data. The block
    * data may not be immediately removed from disk, and will be reclaimed
    * during LevelDB compaction.
@@ -218,6 +269,17 @@ class LevelBlockStore extends AbstractBlockStore {
 
   async hasUndo(hash) {
     return this.db.has(layout.b.encode(types.UNDO, hash));
+  }
+
+  /**
+   * This will check if a block filter has been stored
+   * and is available.
+   * @param {Buffer} hash - The block hash
+   * @returns {Promise}
+   */
+
+  async hasFilter(hash) {
+    return this.db.has(layout.b.encode(types.FILTER, hash));
   }
 
   /**

--- a/lib/indexer/filterindexer.js
+++ b/lib/indexer/filterindexer.js
@@ -103,7 +103,7 @@ class FilterIndexer extends Indexer {
   async getFilterHeader(hash) {
     assert(hash);
 
-    return this.blocks.readHeader(hash);
+    return this.blocks.readFilterHeader(hash);
   }
 }
 

--- a/test/blockstore-test.js
+++ b/test/blockstore-test.js
@@ -80,7 +80,7 @@ describe('BlockStore', function() {
       assert.equal(store.logger.info(), 'blockstore');
     });
 
-    it('has unimplemented base methods', async () => {
+    describe('unimplemented base methods', function() {
       const groups = {
         base: ['open', 'close', 'ensure'],
         block: ['write', 'read', 'prune', 'has'],
@@ -94,16 +94,15 @@ describe('BlockStore', function() {
 
       for (const methods of Object.values(groups)) {
         for (const method of methods) {
-          assert(store[method]);
-
-          let err = null;
-          try {
-            await store[method]();
-          } catch (e) {
-            err = e;
-          }
-          assert(err, `Expected unimplemented method ${method}.`);
-          assert.equal(err.message, 'Abstract method.');
+          it(`${method}`, async () => {
+            assert(store[method]);
+            assert.rejects(async () => {
+              await store[method]();
+            }, {
+              name: 'Error',
+              message: 'Abstract method.'
+            });
+          });
         }
       }
     });

--- a/test/blockstore-test.js
+++ b/test/blockstore-test.js
@@ -81,24 +81,30 @@ describe('BlockStore', function() {
     });
 
     it('has unimplemented base methods', async () => {
-      const methods = ['open', 'close', 'write', 'writeUndo',
-                       'writeMerkle', 'read', 'readUndo', 'readMerkle',
-                       'prune', 'pruneUndo', 'pruneMerkle',
-                       'has', 'hasUndo', 'hasMerkle', 'ensure'];
+      const groups = {
+        base: ['open', 'close', 'ensure'],
+        block: ['write', 'read', 'prune', 'has'],
+        undo: ['writeUndo', 'readUndo', 'pruneUndo', 'hasUndo'],
+        filter: ['writeFilter', 'readFilter', 'readFilterHeader',
+                 'pruneFilter', 'hasFilter'],
+        merkle: ['writeMerkle', 'readMerkle', 'pruneMerkle', 'hasMerkle']
+      };
 
       const store = new AbstractBlockStore();
 
-      for (const method of methods) {
-        assert(store[method]);
+      for (const methods of Object.values(groups)) {
+        for (const method of methods) {
+          assert(store[method]);
 
-        let err = null;
-        try {
-          await store[method]();
-        } catch (e) {
-          err = e;
+          let err = null;
+          try {
+            await store[method]();
+          } catch (e) {
+            err = e;
+          }
+          assert(err, `Expected unimplemented method ${method}.`);
+          assert.equal(err.message, 'Abstract method.');
         }
-        assert(err, `Expected unimplemented method ${method}.`);
-        assert.equal(err.message, 'Abstract method.');
       }
     });
   });

--- a/test/blockstore-test.js
+++ b/test/blockstore-test.js
@@ -31,6 +31,10 @@ const undos = [
   common.readBlock('block928849')
 ];
 
+const merkles = [
+  common.readMerkle('merkle300025-extended')
+];
+
 const {
   AbstractBlockStore,
   FileBlockStore,
@@ -78,8 +82,9 @@ describe('BlockStore', function() {
 
     it('has unimplemented base methods', async () => {
       const methods = ['open', 'close', 'write', 'writeUndo',
-                       'read', 'readUndo', 'prune', 'pruneUndo',
-                       'has', 'hasUndo', 'ensure'];
+                       'writeMerkle', 'read', 'readUndo', 'readMerkle',
+                       'prune', 'pruneUndo', 'pruneMerkle',
+                       'has', 'hasUndo', 'hasMerkle', 'ensure'];
 
       const store = new AbstractBlockStore();
 
@@ -411,6 +416,11 @@ describe('BlockStore', function() {
         assert.equal(filepath, `${location()}blu99999.dat`);
       });
 
+      it('will give merkle type', () => {
+        const filepath = store.filepath(types.MERKLE, 99999);
+        assert.equal(filepath, `${location()}blm99999.dat`);
+      });
+
       it('will fail for unknown prefix', () => {
         let err = null;
         try {
@@ -671,6 +681,17 @@ describe('BlockStore', function() {
       assert.bufferEqual(block1, block2);
     });
 
+    it('will write and read merkle block', async () => {
+      const block1 = random.randomBytes(128);
+      const hash = random.randomBytes(32);
+
+      await store.writeMerkle(hash, block1);
+
+      const block2 = await store.readMerkle(hash);
+
+      assert.bufferEqual(block1, block2);
+    });
+
     it('will read a block w/ offset and length', async () => {
       const block1 = random.randomBytes(128);
       const hash = random.randomBytes(32);
@@ -770,6 +791,33 @@ describe('BlockStore', function() {
       for (let i = 0; i < 16; i++) {
         const expect = blocks[i];
         const block = await store.readUndo(expect.hash);
+        assert.bufferEqual(block, expect.block);
+      }
+    });
+
+    it('will allocate new files with merkle blocks', async () => {
+      const blocks = [];
+
+      for (let i = 0; i < 16; i++) {
+        const block = random.randomBytes(128);
+        const hash = random.randomBytes(32);
+        blocks.push({hash, block});
+        await store.writeMerkle(hash, block);
+        const block2 = await store.readMerkle(hash);
+        assert.bufferEqual(block2, block);
+      }
+
+      const first = await fs.stat(store.filepath(types.MERKLE, 0));
+      const second = await fs.stat(store.filepath(types.MERKLE, 1));
+      const third = await fs.stat(store.filepath(types.MERKLE, 2));
+
+      const magic = (8 * 16);
+      const len = first.size + second.size + third.size - magic;
+      assert.equal(len, 128 * 16);
+
+      for (let i = 0; i < 16; i++) {
+        const expect = blocks[i];
+        const block = await store.readMerkle(expect.hash);
         assert.bufferEqual(block, expect.block);
       }
     });
@@ -1145,6 +1193,37 @@ describe('BlockStore', function() {
         assert.bufferEqual(block, expect.block);
       }
     });
+
+    it('will import merkle blocks from files', async () => {
+      const blocks = [];
+
+      for (let i = 0; i < merkles.length; i++) {
+        const [block] = merkles[i].getBlock();
+        const hash = block.hash();
+        const raw = merkles[i].getRaw();
+
+        blocks.push({hash, block: raw});
+        await store.writeMerkle(hash, raw);
+      }
+
+      await store.close();
+
+      await rimraf(resolve(location, './index'));
+
+      store = new FileBlockStore({
+        location: location,
+        maxFileLength: 1024
+      });
+
+      await store.open();
+
+      for (let i = 0; i < blocks.length; i++) {
+        const expect = blocks[i];
+        const block = await store.readMerkle(expect.hash);
+        assert.equal(block.length, expect.block.length);
+        assert.bufferEqual(block, expect.block);
+      }
+    });
   });
 
   describe('LevelBlockStore', function() {
@@ -1188,6 +1267,17 @@ describe('BlockStore', function() {
       await store.writeUndo(hash, block1);
 
       const block2 = await store.readUndo(hash);
+
+      assert.bufferEqual(block1, block2);
+    });
+
+    it('will write and read merkle block', async () => {
+      const block1 = random.randomBytes(128);
+      const hash = random.randomBytes(32);
+
+      await store.writeMerkle(hash, block1);
+
+      const block2 = await store.readMerkle(hash);
 
       assert.bufferEqual(block1, block2);
     });


### PR DESCRIPTION
This adds the ability to persist merkle blocks to disk for cases when the transactions have not yet been sent to the wallet. This is in the case of chain reorganizations, the wallet running as a separate process, and in other cases where blocks may be downloaded but not yet added to the chain.