### PR TITLE
bcoin-cli: expose estimateFee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ take multiple hours (e.g. 8 hours) depending on hardware and the
 index. Please take the potential downtime in re-indexing into account
 before upgrading.
 
+
+### Client API changes
+
+- Client module `/lib/client` was created from the external dependency `bclient`.
+- `NodeClient` method `estimateFee` now returns JSON instead of a number.
+- Added `fee` command to `bcoin-cli`.
+- Added `getBlockHeader` to `NodeClient` and corresponding `header` command to CLI.
+- Added `getFilter` to `NodeClient` and corresponding `filter` command to CLI.
+
 ### Wallet API changes
 
 #### HTTP

--- a/bin/bcoin-cli
+++ b/bin/bcoin-cli
@@ -131,14 +131,14 @@ class CLI {
   async estimateFee() {
     const blocks = this.config.uint(0, 1);
 
-    const fee = await this.client.estimateFee(blocks);
+    const json = await this.client.estimateFee(blocks);
 
-    if (!fee) {
+    if (!json) {
       this.log('Fee not found.');
       return;
     }
 
-    this.log(Amount.btc(fee.rate));
+    this.log(Amount.btc(json.rate));
   }
 
   async getCoin() {

--- a/bin/bcoin-cli
+++ b/bin/bcoin-cli
@@ -4,6 +4,7 @@
 
 const Config = require('bcfg');
 const NodeClient = require('../lib/client/node');
+const Amount = require('../lib/btc/amount');
 
 const ports = {
   main: 8332,
@@ -132,7 +133,12 @@ class CLI {
 
     const fee = await this.client.estimateFee(blocks);
 
-    this.log(fee);
+    if (!fee) {
+      this.log('Fee not found.');
+      return;
+    }
+
+    this.log(Amount.btc(fee.rate));
   }
 
   async getCoin() {

--- a/bin/bcoin-cli
+++ b/bin/bcoin-cli
@@ -259,8 +259,8 @@ class CLI {
         this.log('  $ coin [hash+index/address]: View coins.');
         this.log('  $ block [hash/height]: View block.');
         this.log('  $ header [hash/height]: View block header.');
-        this.log('  $ filter [hash/height]: View filter');
-        this.log('  $ fee [target]: Estimate smart fee');
+        this.log('  $ filter [hash/height]: View filter.');
+        this.log('  $ fee [target]: Estimate smart fee.');
         this.log('  $ reset [height/hash]: Reset chain to desired block.');
         this.log('  $ rpc [command] [args]: Execute RPC command.' +
           ' (`bcoin-cli rpc help` for more)');

--- a/bin/bcoin-cli
+++ b/bin/bcoin-cli
@@ -127,6 +127,14 @@ class CLI {
     this.log(filter);
   }
 
+  async estimateFee() {
+    const blocks = this.config.uint(0, 1);
+
+    const fee = await this.client.estimateFee(blocks);
+
+    this.log(fee);
+  }
+
   async getCoin() {
     const hash = this.config.str(0, '');
     const index = this.config.uint(1);
@@ -226,6 +234,9 @@ class CLI {
       case 'filter':
         await this.getFilter();
         break;
+      case 'fee':
+        await this.estimateFee();
+        break;
       case 'reset':
         await this.reset();
         break;
@@ -243,6 +254,7 @@ class CLI {
         this.log('  $ block [hash/height]: View block.');
         this.log('  $ header [hash/height]: View block header.');
         this.log('  $ filter [hash/height]: View filter');
+        this.log('  $ fee [target]: Estimate smart fee');
         this.log('  $ reset [height/hash]: Reset chain to desired block.');
         this.log('  $ rpc [command] [args]: Execute RPC command.' +
           ' (`bcoin-cli rpc help` for more)');

--- a/bin/bcoin-cli
+++ b/bin/bcoin-cli
@@ -138,6 +138,11 @@ class CLI {
       return;
     }
 
+    if (!Number.isInteger(json.rate)) {
+      this.log('Fee is not an integer.');
+      return;
+    }
+
     this.log(Amount.btc(json.rate));
   }
 

--- a/lib/client/node.js
+++ b/lib/client/node.js
@@ -291,7 +291,7 @@ class NodeClient extends Client {
 
   estimateFee(blocks) {
     assert(blocks == null || typeof blocks === 'number');
-    return this.call('estimate fee', blocks);
+    return this.get(`/fee?blocks=${blocks}`);
   }
 
   /**

--- a/lib/client/node.js
+++ b/lib/client/node.js
@@ -291,7 +291,10 @@ class NodeClient extends Client {
 
   estimateFee(blocks) {
     assert(blocks == null || typeof blocks === 'number');
-    return this.get(`/fee?blocks=${blocks}`);
+    let query = '/fee';
+    if (blocks != null)
+      query += `?blocks=${blocks}`;
+    return this.get(query);
   }
 
   /**

--- a/lib/client/node.js
+++ b/lib/client/node.js
@@ -284,7 +284,7 @@ class NodeClient extends Client {
   }
 
   /**
-   * Esimate smart fee.
+   * Estimate smart fee.
    * @param {Number?} blocks
    * @returns {Promise}
    */

--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -325,7 +325,7 @@ class HTTP extends Server {
     // Estimate fee
     this.get('/fee', async (req, res) => {
       const valid = Validator.fromRequest(req);
-      const blocks = valid.u32('blocks');
+      const blocks = valid.u32('blocks', 1);
 
       if (!this.fees) {
         res.json(200, { rate: this.network.feeRate });

--- a/lib/wallet/nodeclient.js
+++ b/lib/wallet/nodeclient.js
@@ -175,16 +175,16 @@ class NodeClient extends AsyncEmitter {
   }
 
   /**
-   * Esimate smart fee.
+   * Estimate smart fee.
    * @param {Number?} blocks
    * @returns {Promise}
    */
 
   async estimateFee(blocks) {
     if (!this.node.fees)
-      return this.network.feeRate;
+      return {rate: this.network.feeRate};
 
-    const fee =  this.node.fees.estimateFee(blocks);
+    const fee = this.node.fees.estimateFee(blocks);
     return {rate: fee};
   }
 

--- a/lib/wallet/nodeclient.js
+++ b/lib/wallet/nodeclient.js
@@ -184,7 +184,8 @@ class NodeClient extends AsyncEmitter {
     if (!this.node.fees)
       return this.network.feeRate;
 
-    return this.node.fees.estimateFee(blocks);
+    const fee =  this.node.fees.estimateFee(blocks);
+    return {rate: fee};
   }
 
   /**

--- a/lib/wallet/nullclient.js
+++ b/lib/wallet/nullclient.js
@@ -137,7 +137,7 @@ class NullClient extends EventEmitter {
    */
 
   async estimateFee(blocks) {
-    return this.network.feeRate;
+    return {rate: this.network.feeRate};
   }
 
   /**

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -503,15 +503,15 @@ class WalletDB extends EventEmitter {
     if (this.feeRate > 0)
       return this.feeRate;
 
-    const rate = await this.client.estimateFee(blocks);
+    const json = await this.client.estimateFee(blocks);
 
-    if (rate < this.network.feeRate)
+    if (!json || json.rate < this.network.feeRate)
       return this.network.feeRate;
 
-    if (rate > this.network.maxFeeRate)
+    if (json.rate > this.network.maxFeeRate)
       return this.network.maxFeeRate;
 
-    return rate;
+    return json.rate;
   }
 
   /**

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -505,7 +505,13 @@ class WalletDB extends EventEmitter {
 
     const json = await this.client.estimateFee(blocks);
 
-    if (!json || json.rate < this.network.feeRate)
+    if (!json)
+      throw new Error('Fee not found.');
+
+    if (!Number.isInteger(json.rate))
+      throw new Error('Fee is not an integer.');
+
+    if (json.rate < this.network.feeRate)
       return this.network.feeRate;
 
     if (json.rate > this.network.maxFeeRate)


### PR DESCRIPTION
While I was updating the api-docs this morning I noticed that the request `/fee` was listed but had no description or examples. While this endpoint does exist in the HTTP API, it was never exposed in the CLI.

In addition, `NodeClient` was written to use a socket call to get the fee estimate. This is fine, but would also require an extra step for client (`open()` which would include `auth()`, before a socket call is possible). I'm not sure the history here, but it should be okay to just `GET` the fee like any other HTTP API request.