### PR TITLE
bwallet-cli: add sign parameter

### DIFF
--- a/bin/bwallet-cli
+++ b/bin/bwallet-cli
@@ -322,7 +322,8 @@ class CLI {
       outputs: [output],
       smart: this.config.bool('smart'),
       rate: this.config.ufixed('rate', 8),
-      subtractFee: this.config.bool('subtract-fee')
+      subtractFee: this.config.bool('subtract-fee'),
+      sign: this.config.bool('sign')
     };
 
     const tx = await this.wallet.createTX(options);


### PR DESCRIPTION
I'm not sure how this worked before, or if it was affected by https://github.com/bcoin-org/bcoin/pull/444

Consider this process:
- Create a watch-only multisig wallet, import xpubs, get receive address, receive coins.
- Create TX with https://bcoin.io/api-docs/#create-a-transaction

Currently throws: `Error: Cannot sign from a watch-only wallet.`

After merge `mktx` can be called with `--sign=false` which will bypass `wallet.sign()` and return a TX template.

Finally:

- Sign TX with https://bcoin.io/api-docs/#sign-transaction

I'm working on the examples right now for api-docs, and it will be added shortly to https://github.com/bcoin-org/bcoin-org.github.io/pull/161