### PR TITLE
wallet-rpc: dump wallet backup with correct network

### DIFF
--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -327,7 +327,7 @@ class RPC extends RPCBase {
       if (!ring)
         continue;
 
-      const addr = ring.getAddress('string');
+      const addr = ring.getAddress('string', this.network);
 
       let fmt = '%s %s label= addr=%s';
 


### PR DESCRIPTION
Another mysterious change since the last time I ran through every command in the API docs.

command: `bwallet-cli --network=regtest rpc dumpwallet $path`

Notice how the dump is being generated by a regtest wallet, and the private keys in WIF format have regtest prefixes, but the base58 addresses are all mainnet.

Current:
```
# Wallet Dump created by Bcoin 2.0.0-dev
# * Created on 2019-10-22T18:26:58Z
# * Best block at time of backup was 845 (72365e9f4b4ed638bb1600116a67e3fa59b6ad6be2a449b675db607a984da4f8).
# * File: /Users/matthewzipkin/Desktop/dump1

cNUUoZYmUGoJyodrNaohzfu6LmKy7pBk6yqubJcTeL5WPWw97DQ1 2019-10-22T18:26:58Z label= addr=1Z79Rwb6Zw9JoNqt45ewZf5D51GSTwkjY
cNH7YBw6haTB3yWkAndoPhwXRLNibXjWAYpqRQdvqPKLeW7JAj6h 2019-10-22T18:26:58Z change=1 addr=12D7WDNd7Ari9qacWsZvVUYCebBFk1zuhF
cNmBeL4kpjLtNZcvjSezftq4ks6ajzZRi1z2AGpuBGy6XjxzytiQ 2019-10-22T18:26:58Z label= addr=1314fEWLTyVo51nBeWd6vrDQ6HnXLFBRxA
...
```

After merge:
```
# Wallet Dump created by Bcoin 2.0.0-dev
# * Created on 2019-10-22T18:29:15Z
# * Best block at time of backup was 845 (72365e9f4b4ed638bb1600116a67e3fa59b6ad6be2a449b675db607a984da4f8).
# * File: /Users/matthewzipkin/Desktop/dump1

cNUUoZYmUGoJyodrNaohzfu6LmKy7pBk6yqubJcTeL5WPWw97DQ1 2019-10-22T18:29:15Z label= addr=mg54SV2ZubNQ5urTbd42mUsQ54byPvSg5j
cNH7YBw6haTB3yWkAndoPhwXRLNibXjWAYpqRQdvqPKLeW7JAj6h 2019-10-22T18:29:15Z change=1 addr=mgj4oGTbvCHxvx4EESYJKPkXWamxh2R6ef
cNmBeL4kpjLtNZcvjSezftq4ks6ajzZRi1z2AGpuBGy6XjxzytiQ 2019-10-22T18:29:15Z label= addr=mhX1xHbKGzw3r8FoN5bUkmRixHPEDNywxh
...
```