### PR TITLE
DO NOT MERGE: bcurl fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,8 @@
       }
     },
     "bcurl": {
-      "version": "git+https://github.com/tynes/bcurl.git#62ca0b903fd7ebd074f599bac7fddc67802e7a00",
-      "from": "git+https://github.com/tynes/bcurl.git#fix-join",
+      "version": "github:tynes/bcurl#d5157b0be5db0546f5e812792918775d1dd8bb29",
+      "from": "github:tynes/bcurl#fix-join",
       "requires": {
         "brq": "~0.1.7",
         "bsert": "~0.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,9 +24,8 @@
       }
     },
     "bcurl": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/bcurl/-/bcurl-0.1.6.tgz",
-      "integrity": "sha512-noeDhfqFiUcNOUuZKErkXcbZfxBjn6duTfYPEfA4hAYXGr7gwVxkAWvIerxl3ZLLyn8jzh7Oi0nHlrLm1ST9Fw==",
+      "version": "git+https://github.com/tynes/bcurl.git#62ca0b903fd7ebd074f599bac7fddc67802e7a00",
+      "from": "git+https://github.com/tynes/bcurl.git#fix-join",
       "requires": {
         "brq": "~0.1.7",
         "bsert": "~0.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
     },
     "bcurl": {
       "version": "github:tynes/bcurl#d5157b0be5db0546f5e812792918775d1dd8bb29",
-      "from": "github:tynes/bcurl#fix-join",
+      "from": "github:tynes/bcurl#d5157b0be5db0546f5e812792918775d1dd8bb29",
       "requires": {
         "brq": "~0.1.7",
         "bsert": "~0.0.10",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "bcfg": "~0.1.6",
     "bcrypto": "~3.1.11",
-    "bcurl": "^0.1.6",
+    "bcurl": "https://github.com/tynes/bcurl.git#fix-join",
     "bdb": "~1.1.7",
     "bdns": "~0.1.5",
     "bevent": "~0.1.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "bcfg": "~0.1.6",
     "bcrypto": "~3.1.11",
-    "bcurl": "tynes/bcurl#fix-join",
+    "bcurl": "tynes/bcurl#d5157b0be5db0546f5e812792918775d1dd8bb29",
     "bdb": "~1.1.7",
     "bdns": "~0.1.5",
     "bevent": "~0.1.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "bcfg": "~0.1.6",
     "bcrypto": "~3.1.11",
-    "bcurl": "https://github.com/tynes/bcurl.git#fix-join",
+    "bcurl": "tynes/bcurl#fix-join",
     "bdb": "~1.1.7",
     "bdns": "~0.1.5",
     "bevent": "~0.1.5",


### PR DESCRIPTION
DO NOT MERGE

This PR is meant to show that https://github.com/bcoin-org/bcurl/pull/17 works and can be merged into `bcurl`.