### PR TITLE
script: JSONify witness stack as array

### DIFF
--- a/lib/script/witness.js
+++ b/lib/script/witness.js
@@ -432,7 +432,12 @@ class Witness extends Stack {
    */
 
   toJSON() {
-    return this.toRaw().toString('hex');
+    const items = [];
+
+    for (const item of this.items)
+      items.push(item.toString('hex'));
+
+    return items;
   }
 
   /**
@@ -442,8 +447,14 @@ class Witness extends Stack {
    */
 
   fromJSON(json) {
-    assert(typeof json === 'string', 'Witness must be a string.');
-    return this.fromRaw(Buffer.from(json, 'hex'));
+    assert(json && Array.isArray(json), 'Witness must be an array.');
+
+    for (const str of json) {
+      const item = Buffer.from(str, 'hex');
+      this.items.push(item);
+    }
+
+    return this;
   }
 
   /**


### PR DESCRIPTION
Porting the JSON format of witness data from `hsd`.

Look how nice this looks! Here is a partially signed multisig transaction:

### Current

```
"witness": "070000483045022100804216dc296b0c0c0f1a1ed54751c60a349518f3d6a558927be0099ecd
f10a3a022013cf0e5ddaf99b0d94c00e69c875f43f034ac7fb934b4abfb75f91e2a72b966d01000
000ad53210242705b9570ec3c193ba67528ff38ee272f37b14ef33564e8d1b33812efb3ad81210
2bcb81bd3451ed30559473940b58e4272765f272dc17855e1be2b21a05945d23c2102d9f1f9f32
14b64b31ef82c16376283e438d738406338776750f86424c2ec303c21036427eda147982560d
066449070c457697cf22ff3bbe2d0ecd5ba070d52d9434a21039c6a894d0067c32997f2390c2e
cffaa0376ac34c8c0a4ebfa6d738c28814456455ae",
```

### After Merge

```
 "witness": [
    "",
    "",
    "3045022100804216dc296b0c0c0f1a1ed54751c60a349518f3d6a558927be0099ecdf10a3a022
013cf0e5ddaf99b0d94c00e69c875f43f034ac7fb934b4abfb75f91e2a72b966d01",
    "",
    "",
    "",
    "53210242705b9570ec3c193ba67528ff38ee272f37b14ef33564e8d1b33812efb3ad812102bcb8
1bd3451ed30559473940b58e4272765f272dc17855e1be2b21a05945d23c2102d9f1f9f3214b64
b31ef82c16376283e438d738406338776750f86424c2ec303c21036427eda147982560d06644
9070c457697cf22ff3bbe2d0ecd5ba070d52d9434a21039c6a894d0067c32997f2390c2ecffaa0
376ac34c8c0a4ebfa6d738c28814456455ae"
  ],
```