### PR TITLE
scripts: fuzz: pass hash as buffer not string

### DIFF
--- a/scripts/fuzz.js
+++ b/scripts/fuzz.js
@@ -68,7 +68,7 @@ function randomKey() {
 }
 
 function randomOutpoint() {
-  const hash = random.randomBytes(32).toString('hex');
+  const hash = random.randomBytes(32);
   return new Outpoint(hash, rand(0, 0xffffffff));
 }
 


### PR DESCRIPTION
One more lingering regression leftover from the great "hashes as buffers instead of strings" refactor from #533 

