### PR TITLE
pool: catch peer handler errs

### DIFF
--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -1126,8 +1126,12 @@ class Pool extends EventEmitter {
       this.handleConnect(peer);
     });
 
-    peer.once('open', () => {
-      this.handleOpen(peer);
+    peer.once('open', async () => {
+      try {
+        await this.handleOpen(peer);
+      } catch (e) {
+        this.emit('error', e);
+      }
     });
 
     peer.once('close', (connected) => {


### PR DESCRIPTION
Added `try ... catch` guards around calling peer handlers.