### PR TITLE
bcoin: expose utils/message

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -13,6 +13,7 @@
 exports.binary = require('./binary');
 exports.fixed = require('./fixed');
 exports.util = require('./util');
+exports.message = require('./message');
 
 const {inspect: {custom}} = require('util');
 exports.inspectSymbol = custom || 'inspect';


### PR DESCRIPTION
Sorry, I should've caught this while reviewing #802.
I'd like to use the message signing utilities in https://github.com/pinheadmz/bid, where I had to re-write / copypaste them until #802 merged. 