### PR TITLE
jsdocs: no default value for wallet.zap()

### DIFF
--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1950,7 +1950,7 @@ class Wallet extends EventEmitter {
   /**
    * Zap stale TXs from wallet.
    * @param {(Number|String)?} acct
-   * @param {Number} age - Age threshold (unix time, default=72 hours).
+   * @param {Number} age - Age threshold (unix time).
    * @returns {Promise}
    */
 


### PR DESCRIPTION
A user on slack got this error because they assumed the default value for `zap()` was 72 hours:

```
AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value: assert((age >>> 0) === age)
at TXDB.zap (/usr/app/node_modules/bcoin/lib/wallet/txdb.js:2007:5)
at Wallet._zap (/usr/app/node_modules/bcoin/lib/wallet/wallet.js:1905:22)
```