### PR TITLE
wallet: double lock when funding

### DIFF
--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1091,11 +1091,13 @@ class Wallet extends EventEmitter {
    */
 
   async fund(mtx, options, force) {
-    const unlock = await this.fundLock.lock(force);
+    const unlock1 = await this.fundLock.lock(force);
+    const unlock2 = await this.writeLock.lock();
     try {
       return await this._fund(mtx, options);
     } finally {
-      unlock();
+      unlock2();
+      unlock1();
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/bcoin-org/bcoin/issues/906

Copied from the issue discussion...

---

So I think I see how a race condition could exist here, and actually it looks like it could happen with `createTX` accidentally using _spent_ coins, the same way in this case `createTX` is accidentally using _locked_ coins. The reason I think is because there is no shared lock in the wallet around the two functions that read and write coins in `txdb`.

When you create a TX (with `smart: false`) , `wallet.fund()` calls `txdb.getCoins()` and then filters them with `txdb.filterUnlocked()` -- with a "fund" lock:

https://github.com/bcoin-org/bcoin/blob/3623d04a9fc0ea1ad223597b2be941c07d16e0e9/lib/wallet/wallet.js#L1093-L1100

If at that same moment, a transaction is broadcast or received by the wallet, the walletDB will call `txdb.insert()` -- with a "write" lock:

https://github.com/bcoin-org/bcoin/blob/3623d04a9fc0ea1ad223597b2be941c07d16e0e9/lib/wallet/wallet.js#L1889-L1896

Inside `txdb.insert()` a bunch of stuff happens but especially these two things:

1. coins are marked as spent and removed from the credits bucket in the DB

2. coins are removed from the "locked coins" list

#### So...

Just looking at the above, I actually kinda wonder why we haven't seen a bug where `wallet.fund()` tries to use coins that, at that same moment, are being marked as spent by `txdb.insert()`. Maybe LevelDB is preventing that from happening concurrently. In which case it might make sense that we see this behavior around locked coins instead (which is just a `BufferSet` in memory, no special handling or wrappers).

I wonder if @nodar-chkuaselidze has any insight here... could be the solution is to add an extra lock to `fund()`:

```diff
diff --git a/lib/wallet/wallet.js b/lib/wallet/wallet.js
index c4a4c197..bfbaeed9 100644
--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1091,11 +1091,13 @@ class Wallet extends EventEmitter {
    */
 
   async fund(mtx, options, force) {
-    const unlock = await this.fundLock.lock(force);
+    const unlock1 = await this.fundLock.lock(force);
+    const unlock2 = await this.writeLock.lock();
     try {
       return await this._fund(mtx, options);
     } finally {
-      unlock();
+      unlock2();
+      unlock1();
     }
   }
 ```