### PR TITLE
mempool: remove block even if mempool is empty

### DIFF
--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -244,11 +244,6 @@ class Mempool extends EventEmitter {
    */
 
   async _removeBlock(block, txs) {
-    if (this.map.size === 0) {
-      this.tip = block.prevBlock;
-      return;
-    }
-
     let total = 0;
 
     for (let i = 1; i < txs.length; i++) {


### PR DESCRIPTION
Closes https://github.com/bcoin-org/bcoin/issues/915

Thanks @mafintosh for finding this bug!

Test covers `removeBlock` with mempool empty and non-empty. Test will fail without code change.