### PR TITLE
rpc: getblock fix

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2736,6 +2736,11 @@ class RPC extends RPCBase {
   async blockToJSON(entry, block, details) {
     const mtp = await this.chain.getMedianTime(entry);
     const next = await this.chain.getNextHash(entry.hash);
+
+    let confirmations = -1;
+    if (await this.chain.isMainChain(entry))
+      confirmations = this.chain.height - entry.height + 1;
+
     const txs = [];
 
     for (const tx of block.txs) {
@@ -2749,7 +2754,7 @@ class RPC extends RPCBase {
 
     return {
       hash: entry.rhash(),
-      confirmations: this.chain.height - entry.height + 1,
+      confirmations: confirmations,
       strippedsize: block.getBaseSize(),
       size: block.getSize(),
       weight: block.getWeight(),
@@ -2761,9 +2766,11 @@ class RPC extends RPCBase {
       tx: txs,
       time: entry.time,
       mediantime: mtp,
+      nonce: entry.nonce,
       bits: entry.bits,
       difficulty: toDifficulty(entry.bits),
       chainwork: entry.chainwork.toString('hex', 64),
+      nTx: txs.length,
       previousblockhash: !entry.prevBlock.equals(consensus.ZERO_HASH)
         ? util.revHex(entry.prevBlock)
         : null,

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2709,15 +2709,20 @@ class RPC extends RPCBase {
     const mtp = await this.chain.getMedianTime(entry);
     const next = await this.chain.getNextHash(entry.hash);
 
+    let confirmations = -1;
+    if (await this.chain.isMainChain(entry))
+      confirmations = this.chain.height - entry.height + 1;
+
     return {
       hash: entry.rhash(),
-      confirmations: this.chain.height - entry.height + 1,
+      confirmations: confirmations,
       height: entry.height,
       version: entry.version,
       versionHex: hex32(entry.version),
       merkleroot: util.revHex(entry.merkleRoot),
       time: entry.time,
       mediantime: mtp,
+      nonce: entry.nonce,
       bits: entry.bits,
       difficulty: toDifficulty(entry.bits),
       chainwork: entry.chainwork.toString('hex', 64),

--- a/test/node-rpc-test.js
+++ b/test/node-rpc-test.js
@@ -68,6 +68,76 @@ describe('RPC', function() {
     assert.deepEqual(info.localservicenames, ['NETWORK', 'WITNESS']);
   });
 
+  describe('getblock', function () {
+    it('should rpc getblock', async () => {
+      const {chain} = await nclient.getInfo();
+      const info = await nclient.execute('getblock', [chain.tip]);
+
+      const properties = [
+        'hash', 'confirmations', 'strippedsize',
+        'size', 'weight', 'height', 'version',
+        'versionHex', 'merkleroot', 'coinbase',
+        'tx', 'time', 'mediantime', 'nonce',
+        'bits', 'difficulty', 'chainwork',
+        'nTx', 'previousblockhash', 'nextblockhash'
+      ];
+
+      for (const property of properties)
+        assert(property in info);
+
+      assert.deepEqual(chain.height, info.height);
+      assert.deepEqual(chain.tip, info.hash);
+    });
+
+    it('should return correct height', async () => {
+      // Create an address to mine with.
+      const wallet = await node.plugins.walletdb.wdb.get(0);
+      const key = await wallet.createReceive(0);
+      const address = key.getAddress().toString(node.network.type);
+
+      // Mine two blocks.
+      await nclient.execute('generatetoaddress', [2, address]);
+
+      const {chain} = await nclient.getInfo();
+      const info = await nclient.execute('getblock', [chain.tip]);
+
+      // Assert the heights match.
+      assert.deepEqual(chain.height, info.height);
+    });
+
+    it('should return confirmations (main chain)', async () => {
+      const {chain} = await nclient.getInfo();
+
+      const {genesis} = node.network;
+      const hash = genesis.hash.reverse().toString('hex');
+
+      const info = await nclient.execute('getblock', [hash]);
+
+      assert.deepEqual(chain.height, info.confirmations - 1);
+    });
+
+    it('should return confirmations (orphan)', async () => {
+      // Get the current chain state
+      const {chain} = await nclient.getInfo();
+
+      // Get the chain entry associated with
+      // the genesis block.
+      const {genesis} = node.network;
+      let entry = await node.chain.getEntry(genesis.hash.reverse());
+
+      // Reorg from the genesis block.
+      for (let i = 0; i < chain.height + 1; i++) {
+        const block = await node.miner.mineBlock(entry);
+        await node.chain.add(block);
+        entry = await node.chain.getEntry(block.hash());
+      }
+
+      // Call getblock using the previous tip
+      const info = await nclient.execute('getblock', [chain.tip]);
+      assert.deepEqual(info.confirmations, -1);
+    });
+  });
+
   describe('signmessagewithprivkey', function () {
     const message = 'This is just a test message';
     const privKeyWIF = 'cUeKHd5orzT3mz8P9pxyREHfsWtVfgsfDjiZZBcjUBAaGk1BTj7N';


### PR DESCRIPTION
Fixes the `confirmation` field in both `getblock` and `getblockheader`. It is supposed to return `-1` if the block is not in the main chain. This allows applications to be able to determine if blocks are in the main chain or not.

Also adds properties to the `getblock` RPC verbose output that are in `bitcoind` but not `bcoin`. These include:

- `nonce`
- `nTx`

I also added the property `nonce` to `getblockheader` verbose output but skipped `nTx` for now because that would involve a bigger change. If that is something that people would also like as part of this PR, would be happy to add it.

Includes tests for the RPC `getblock`.

Closes https://github.com/bcoin-org/bcoin/issues/918