### PR TITLE
browser: fix client module loading

### DIFF
--- a/lib/bcoin-browser.js
+++ b/lib/bcoin-browser.js
@@ -44,9 +44,9 @@ bcoin.Amount = require('./btc/amount');
 bcoin.URI = require('./btc/uri');
 
 // Client
-bcoin.define('client', './client');
-bcoin.define('NodeClient', './client/node');
-bcoin.define('WalletClient', './client/wallet');
+bcoin.client = require('./client');
+bcoin.NodeClient = require('./client/node');
+bcoin.WalletClient = require('./client/wallet');
 
 // Coins
 bcoin.coins = require('./coins');


### PR DESCRIPTION
Fixes a bug that was introduced in #838 which breaks browser builds of bcoin. Since the browser bcoin doesn't have `define`, an error is thrown: `TypeError: bcoin.define is not a function`. This PR uses the same module loading approach as the other modules in this file.