### PR TITLE
wallet: remove checkpoints that skip transactions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,7 +167,6 @@ access from a local machine, you would launch bcoin with the command:
 - `max-files`: Max open files for leveldb.
 - `cache-size`: Size (in MB) of leveldb cache and write buffer.
 - `witness`: Make SegWit enabled wallets.
-- `checkpoints`: Trust hard-coded blockchain checkpoints.
 
 ### Wallet http server:
 

--- a/lib/wallet/node.js
+++ b/lib/wallet/node.js
@@ -49,7 +49,6 @@ class WalletNode extends Node {
       maxFiles: this.config.uint('max-files'),
       cacheSize: this.config.mb('cache-size'),
       witness: this.config.bool('witness'),
-      checkpoints: this.config.bool('checkpoints'),
       wipeNoReally: this.config.bool('wipe-no-really'),
       spv: this.config.bool('spv')
     });

--- a/lib/wallet/plugin.js
+++ b/lib/wallet/plugin.js
@@ -53,7 +53,6 @@ class Plugin extends EventEmitter {
       maxFiles: this.config.uint('max-files'),
       cacheSize: this.config.mb('cache-size'),
       witness: this.config.bool('witness'),
-      checkpoints: this.config.bool('checkpoints'),
       wipeNoReally: this.config.bool('wipe-no-really'),
       spv: node.spv
     });

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -1975,14 +1975,6 @@ class WalletDB extends EventEmitter {
       return 0;
     }
 
-    if (this.options.checkpoints && !this.state.marked) {
-      if (tip.height <= this.network.lastCheckpoint) {
-        // Sync the state to the new tip.
-        await this.setTip(tip);
-        return 0;
-      }
-    }
-
     let total = 0;
 
     for (const tx of txs) {
@@ -2216,7 +2208,6 @@ class WalletOptions {
 
     this.spv = false;
     this.witness = false;
-    this.checkpoints = false;
     this.wipeNoReally = false;
 
     if (options)
@@ -2293,11 +2284,6 @@ class WalletOptions {
     if (options.witness != null) {
       assert(typeof options.witness === 'boolean');
       this.witness = options.witness;
-    }
-
-    if (options.checkpoints != null) {
-      assert(typeof options.checkpoints === 'boolean');
-      this.checkpoints = options.checkpoints;
     }
 
     if (options.wipeNoReally != null) {


### PR DESCRIPTION
The behavior of checkpoints in the wallet will skip transactions before the last checkpoint. This is likely an optimization for wallets that do not have transactions before the last checkpoint. In the case that there are transactions before they would be skipped. This type of optimization can be later added to instead use the known date the wallet was generated.

This is a follow-up PR to https://github.com/bcoin-org/bcoin/pull/931.