### PR TITLE
test: fix http-test for rescanning with bloom filter

### DIFF
--- a/test/http-test.js
+++ b/test/http-test.js
@@ -517,11 +517,10 @@ describe('HTTP', function() {
   it('should initiate rescan from socket WITH a bloom filter', async () => {
     // Create an SPV-standard Bloom filter and add one of our wallet addresses
     const filter = BloomFilter.fromRate(20000, 0.001, BloomFilter.flags.ALL);
-    const walletAddr = addr.toString('regtest');
-    filter.add(walletAddr, 'ascii');
+    filter.add(addr.getHash());
 
     // Send Bloom filter to server
-    await nclient.call('set filter', filter.filter);
+    await nclient.call('set filter', filter.toRaw());
 
     // `rescan` commands the node server to check blocks against a bloom filter.
     // When the server matches a transaction in a block to the filter, it
@@ -535,7 +534,7 @@ describe('HTTP', function() {
       const cbtx = MTX.fromRaw(txs[0]);
       assert.strictEqual(
         cbtx.outputs[0].getAddress().toString('regtest'),
-        walletAddr
+        addr.toString('regtest')
       );
 
       // Blocks are returned as raw ChainEntry


### PR DESCRIPTION
Closes https://github.com/bcoin-org/bcoin/issues/957
(hopefully)

See https://github.com/bcoin-org/bcoin-org.github.io/pull/159

Amazingly, the errant bloom filter in this test was apparently false-positive enough to pass _most_ of the time.