### PR TITLE
mnemonic: use 256 bits by default

### DIFF
--- a/lib/hd/mnemonic.js
+++ b/lib/hd/mnemonic.js
@@ -35,7 +35,7 @@ class Mnemonic {
    * @constructor
    * @param {Object} options
    * @param {Number?} options.bit - Bits of entropy (Must
-   * be a multiple of 8) (default=128).
+   * be a multiple of 8) (default=256).
    * @param {Buffer?} options.entropy - Entropy bytes. Will
    * be generated with `options.bits` bits of entropy
    * if not present.
@@ -45,7 +45,7 @@ class Mnemonic {
    */
 
   constructor(options) {
-    this.bits = common.MIN_ENTROPY;
+    this.bits = 256;
     this.language = 'english';
     this.entropy = null;
     this.phrase = null;

--- a/test/hd-test.js
+++ b/test/hd-test.js
@@ -103,7 +103,7 @@ describe('HD', function() {
   });
 
   it('should inspect Mnemonic', () => {
-    const mne = new HD.Mnemonic();
+    const mne = new HD.Mnemonic({bits: 128});
     const fmt = nodejsUtil.format(mne);
     assert(typeof fmt === 'string');
     assert(fmt.includes('Mnemonic'));


### PR DESCRIPTION
Update the mnemonic to use a default of 256 bits of entropy. This was recently updated in `hsd`  here https://github.com/handshake-org/hsd/commit/d88cabf067a29222b1926f96e1eb1e345fe5cafa and would also be useful for bcoin.