### PR TITLE
Fix wallet rpc method to import tx

### DIFF
--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -27,6 +27,7 @@ const TX = require('../primitives/tx');
 const consensus = require('../protocol/consensus');
 const pkg = require('../pkg');
 const common = require('./common');
+const {BlockMeta} = require('./records');
 const RPCBase = bweb.RPC;
 const RPCError = bweb.RPCError;
 
@@ -1616,18 +1617,14 @@ class RPC extends RPCBase {
     if (!block.hasTX(tx.hash()))
       throw new RPCError(errs.VERIFY_ERROR, 'Invalid proof.');
 
-    const height = await this.client.getEntry(hash);
+    const entry = await this.client.getEntry(hash);
 
-    if (height === -1)
+    if (!entry)
       throw new RPCError(errs.VERIFY_ERROR, 'Invalid proof.');
 
-    const entry = {
-      hash: hash,
-      time: block.time,
-      height: height
-    };
+    const meta = BlockMeta.fromEntry(entry);
 
-    if (!await this.wdb.addTX(tx, entry))
+    if (!await this.wdb.addTX(tx, meta))
       throw new RPCError(errs.WALLET_ERROR,
         'Address for TX not in wallet, or TX already in wallet');
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -2118,13 +2118,14 @@ class WalletDB extends EventEmitter {
    * to wallet IDs, potentially store orphans, resolve
    * orphans, or confirm a transaction.
    * @param {TX} tx
+   * @param {BlockMeta?} block
    * @returns {Promise}
    */
 
-  async addTX(tx) {
+  async addTX(tx, block) {
     const unlock = await this.txLock.lock();
     try {
-      return await this._addTX(tx);
+      return await this._addTX(tx, block);
     } finally {
       unlock();
     }


### PR DESCRIPTION
Tested manually using these steps, checking the balance along the way via `bwallet-cli balance`:

1. Starting a regtest node via `bcoin --network=regtest`.
2. Getting address from the wallet using `bwallet-cli address default`.
3. Mining blocks with `bcoin-cli rpc generatetoaddress <blocks> <address>`.
4. Getting another address and then sending funds to that address via `bwallet send <address> <value>`.
5. Mining a block.
6. Removing the tx from the wallet via `bwallet-cli removeprunedfunds <tx-hash>`.
7. Getting a txoutproof for the tx via `bcoin-cli rpc gettxoutproof '["<tx-hash>"]' <block-hash>`.
8. Importing the tx via `bwallet-cli rpc importprunedfunds <rawtx> <txoutproof>`.