### PR TITLE
Fix NetworkType type

### DIFF
--- a/lib/protocol/network.js
+++ b/lib/protocol/network.js
@@ -373,7 +373,6 @@ Network.type = null;
 Network.main = null;
 Network.testnet = null;
 Network.regtest = null;
-Network.segnet4 = null;
 Network.simnet = null;
 
 /*

--- a/lib/types.js
+++ b/lib/types.js
@@ -92,7 +92,7 @@
  */
 
 /**
- * One of `main`, `testnet`, `regtest`, `simnet`, `segnet4`.
+ * One of `main`, `testnet`, `regtest`, `simnet`.
  * @typedef {String} NetworkType
  * @see {module:network.types}
  * @global

--- a/lib/types.js
+++ b/lib/types.js
@@ -92,7 +92,7 @@
  */
 
 /**
- * One of `main`, `testnet`, `regtest`, `segnet3`, `segnet4`.
+ * One of `main`, `testnet`, `regtest`, `simnet`, `segnet4`.
  * @typedef {String} NetworkType
  * @see {module:network.types}
  * @global

--- a/scripts/gen.js
+++ b/scripts/gen.js
@@ -83,20 +83,6 @@ const regtest = createGenesisBlock({
   nonce: 2
 });
 
-const segnet3 = createGenesisBlock({
-  version: 1,
-  time: 1452831101,
-  bits: 486604799,
-  nonce: 0
-});
-
-const segnet4 = createGenesisBlock({
-  version: 1,
-  time: 1452831101,
-  bits: 503447551,
-  nonce: 0
-});
-
 const btcd = createGenesisBlock({
   version: 1,
   time: 1401292357,
@@ -110,10 +96,6 @@ console.log(testnet);
 console.log('');
 console.log(regtest);
 console.log('');
-console.log(segnet3);
-console.log('');
-console.log(segnet4);
-console.log('');
 console.log('');
 console.log('main hash: %s', main.rhash());
 console.log('main raw: %s', main.toRaw().toString('hex'));
@@ -123,12 +105,6 @@ console.log('testnet raw: %s', testnet.toRaw().toString('hex'));
 console.log('');
 console.log('regtest hash: %s', regtest.rhash());
 console.log('regtest raw: %s', regtest.toRaw().toString('hex'));
-console.log('');
-console.log('segnet3 hash: %s', segnet3.rhash());
-console.log('segnet3 raw: %s', segnet3.toRaw().toString('hex'));
-console.log('');
-console.log('segnet4 hash: %s', segnet4.rhash());
-console.log('segnet4 raw: %s', segnet4.toRaw().toString('hex'));
 console.log('');
 console.log('btcd simnet hash: %s', btcd.rhash());
 console.log('btcd simnet raw: %s', btcd.toRaw().toString('hex'));


### PR DESCRIPTION
Currently the type description (modified on this PR) of `NetworkType` provides a list of possible values different from [the list that is on the source code](https://github.com/bcoin-org/bcoin/blob/master/lib/protocol/network.js#L373). This PR makes that list consistent.