### PR TITLE
tx: allow 0-input serialization

### DIFF
--- a/lib/primitives/address.js
+++ b/lib/primitives/address.js
@@ -42,8 +42,8 @@ class Address {
    */
 
   constructor(options, network) {
-    this.type = Address.types.PUBKEYHASH;
-    this.version = -1;
+    this.type = Address.types.WITNESS;
+    this.version = 0;
     this.hash = ZERO_HASH160;
 
     if (options)

--- a/lib/primitives/tx.js
+++ b/lib/primitives/tx.js
@@ -2422,9 +2422,6 @@ class TX {
    */
 
   writeNormal(bw) {
-    if (this.inputs.length === 0 && this.outputs.length !== 0)
-      throw new Error('Cannot serialize zero-input tx.');
-
     bw.writeU32(this.version);
 
     bw.writeVarint(this.inputs.length);
@@ -2451,9 +2448,6 @@ class TX {
    */
 
   writeWitness(bw) {
-    if (this.inputs.length === 0 && this.outputs.length !== 0)
-      throw new Error('Cannot serialize zero-input tx.');
-
     bw.writeU32(this.version);
     bw.writeU8(0);
     bw.writeU8(1);

--- a/lib/primitives/tx.js
+++ b/lib/primitives/tx.js
@@ -2256,7 +2256,15 @@ class TX {
    */
 
   static fromReader(br, block) {
-    return new this().fromReader(br, block);
+    const start = br.offset;
+    try {
+      return new this().fromWitnessReader(br, block);
+    } catch (e) {
+      // Reset BufferReader and try again with legacy format
+      br.end();
+      br.offset = start;
+      return new this().fromLegacyReader(br, block);
+    }
   }
 
   /**
@@ -2270,16 +2278,36 @@ class TX {
   }
 
   /**
+   * Instantiate a transaction from a buffer reader.
+   * @param {BufferReader} br
+   * @param {Boolean} block
+   * @returns {TX}
+   */
+
+  fromReader(br, block) {
+    const start = br.offset;
+    try {
+      return this.fromWitnessReader(br, block);
+    } catch (e) {
+      // Clear misinterpreted witness format data
+      this.inputs.length = 0;
+      this.outputs.length = 0;
+
+      // Reset BufferReader and try again with legacy format
+      br.end();
+      br.offset = start;
+      return this.fromLegacyReader(br, block);
+    }
+  }
+
+  /**
    * Inject properties from buffer reader.
    * @private
    * @param {BufferReader} br
    * @param {Boolean} block
    */
 
-  fromReader(br, block) {
-    if (hasWitnessBytes(br))
-      return this.fromWitnessReader(br, block);
-
+  fromLegacyReader(br, block) {
     const start = br.start();
 
     this.version = br.readU32();
@@ -2547,14 +2575,6 @@ class TX {
 /*
  * Helpers
  */
-
-function hasWitnessBytes(br) {
-  if (br.left() < 6)
-    return false;
-
-  return br.data[br.offset + 4] === 0
-    && br.data[br.offset + 5] !== 0;
-}
 
 class RawTX {
   constructor(size, witness) {

--- a/test/mtx-test.js
+++ b/test/mtx-test.js
@@ -1,0 +1,43 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const MTX = require('../lib/primitives/mtx');
+const Address = require('../lib/primitives/address');
+const Input = require('../lib/primitives/input');
+const Output = require('../lib/primitives/output');
+
+describe('MTX', function () {
+  it('should en/decode mtx with 1 in, 1 out', () => {
+    const input = new Input({
+      prevout: {
+        hash: Buffer.alloc(32),
+        index: 0
+      }
+    });
+    const output = new Output({
+      value: 1e8,
+      address: new Address()
+    });
+    const mtx1 = new MTX({
+      inputs: [input],
+      outputs: [output]
+    });
+    const mtx2 = MTX.fromRaw(mtx1.toRaw());
+    assert.deepStrictEqual(mtx1, mtx2);
+  });
+
+  it('should en/decode mtx with 0 in, 1 out', () => {
+    const output = new Output({
+      value: 1e8,
+      address: new Address()
+    });
+    const mtx1 = new MTX({
+      outputs: [output]
+    });
+    const mtx2 = MTX.fromRaw(mtx1.toRaw());
+    assert.deepStrictEqual(mtx1, mtx2);
+  });
+});

--- a/test/node-rpc-test.js
+++ b/test/node-rpc-test.js
@@ -532,4 +532,18 @@ describe('RPC', function() {
       });
     });
   });
+
+  describe('utilities', function() {
+    // 0-in, 2-out
+    const rawTX1 =
+      '0100000000024e61bc00000000001976a914fbdd46898a6d70a682cbd34420cc' +
+      'f0b6bb64493788acf67e4929010000001976a9141b002b6fc0f457bf8d092722' +
+      '510fce9f37f0423b88ac00000000';
+
+    it('should decoderawtransaction', async () => {
+      const result = await nclient.execute('decoderawtransaction', [rawTX1]);
+      assert.strictEqual(result.vin.length, 0);
+      assert.strictEqual(result.vout.length, 2);
+    });
+  });
 });

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -595,7 +595,9 @@ describe('Node', function() {
       address: addr.toString(node.network),
       scriptPubKey: Script.fromAddress(addr, node.network).toJSON(),
       isscript: false,
-      iswitness: false
+      iswitness: true,
+      witness_version: 0,
+      witness_program: '0'.repeat(40)
     });
   });
 

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -11,6 +11,7 @@ const Mnemonic = require('../lib/hd/mnemonic');
 const HDPrivateKey = require('../lib/hd/private');
 const Script = require('../lib/script/script');
 const Address = require('../lib/primitives/address');
+const TX = require('../lib/primitives/tx');
 const mnemonics = require('./data/mnemonic-english.json');
 const {forValue} = require('./util/common');
 
@@ -670,6 +671,31 @@ describe('Wallet RPC Methods', function() {
       await wclient.execute('importprunedfunds', [txraw, txoutproof]);
       balance = await wclient.execute('getbalance');
       assert.equal(balance, 0.01843);
+    });
+  });
+
+  describe('raw TXs', function() {
+    // 0-in, 2-out
+    const rawTX1 =
+      '0100000000024e61bc00000000001976a914fbdd46898a6d70a682cbd34420cc' +
+      'f0b6bb64493788acf67e4929010000001976a9141b002b6fc0f457bf8d092722' +
+      '510fce9f37f0423b88ac00000000';
+
+    let fundedTX1;
+
+    before(async () => {
+      await wclient.execute('selectwallet', ['miner']);
+    });
+
+    it('should fundrawtransaction', async () => {
+      const result = await wclient.execute('fundrawtransaction', [rawTX1]);
+      assert(result.hex.length);
+      assert(result.changepos > 0);
+      assert(result.fee > 0);
+
+      fundedTX1 = TX.fromRaw(result.hex, 'hex');
+      assert.strictEqual(fundedTX1.inputs.length, 1);
+      assert.strictEqual(fundedTX1.outputs.length, 3);
     });
   });
 });


### PR DESCRIPTION
Closes #521 
Closes #629 

I'm not sure what the purpose of this check is, and I'm working on a project where a 0-input transaction is fed into Bitcoin Core's `fundrawtransaction` for inputs. 
