### PR TITLE
mtx: the CoinSelector will first check if the transaction is prefunded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+node_modules/
 node_modules/**/build
 node_modules/.yarn-integrity
 .nyc_output

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1866,14 +1866,14 @@ class CoinSelector {
       if (!this.isSpendable(coin))
         continue;
 
+      if (this.isFull())
+        break;
+
       this.tx.addCoin(coin);
       this.chosen.push(coin);
 
       if (this.selection === 'all')
         continue;
-
-      if (this.isFull())
-        break;
     }
   }
 


### PR DESCRIPTION
Allow for specifying inputs in the `mtx` before calling the CoinSelector - this fixes a bug where a prefunded tx would have an extra input even if though the existing input was enough to cover the outputs.