### PR TITLE
upgrade bcrypto to 5.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "bcfg": "git+https://github.com/bcoin-org/bcfg.git#semver:~0.1.6",
-    "bcrypto": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.0.4",
+    "bcrypto": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.4.0",
     "bcurl": "git+https://github.com/bcoin-org/bcurl.git#semver:^0.1.6",
     "bdb": "git+https://github.com/bcoin-org/bdb.git#semver:~1.2.1",
     "bdns": "git+https://github.com/bcoin-org/bdns.git#semver:~0.1.5",

--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     "bsocks": "git+https://github.com/bcoin-org/bsocks.git#semver:~0.2.6",
     "btcp": "git+https://github.com/bcoin-org/btcp.git#semver:~0.1.5",
     "buffer-map": "git+https://github.com/chjj/buffer-map.git#semver:~0.0.7",
-    "bufio": "git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6",
+    "bufio": "git+https://github.com/bcoin-org/bufio.git#semver:~1.0.7",
     "bupnp": "git+https://github.com/bcoin-org/bupnp.git#semver:~0.2.6",
     "bval": "git+https://github.com/bcoin-org/bval.git#semver:~0.1.6",
     "bweb": "git+https://github.com/bcoin-org/bweb.git#semver:=0.1.9",
-    "loady": "git+https://github.com/chjj/loady.git#semver:~0.0.1",
+    "loady": "git+https://github.com/chjj/loady.git#semver:~0.0.5",
     "n64": "git+https://github.com/chjj/n64.git#semver:~0.2.10",
     "nan": "git+https://github.com/braydonf/nan.git#semver:=2.14.0"
   },


### PR DESCRIPTION
bumps bcrypto version from 5.0.4 to 5.4.0

fixes related when running on OSX 10.15 
 [56](https://github.com/bcoin-org/bcrypto/issues/56)
[55](https://github.com/bcoin-org/bcrypto/issues/55)
