### PR TITLE
wallet-rpc: getreceviedbyaddress should ignore non-address outputs

### DIFF
--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -602,7 +602,14 @@ class RPC extends RPCBase {
         continue;
 
       for (const output of wtx.tx.outputs) {
-        if (output.getHash().equals(hash))
+        // Some transaction outputs don't have scripts with address hashes.
+        // One example is OP_RETURN data, like a coinbase witness commitment.
+        const addr = output.getAddress();
+
+        if (!addr)
+          continue;
+
+        if (addr.getHash().equals(hash))
           total += output.value;
       }
     }


### PR DESCRIPTION
Closes https://github.com/bcoin-org/bcoin/issues/1015

Users are getting the error `"Cannot read property 'equals' of null"` when generating blocks to their wallet in regtest. The error is due to failed attempts to decode an output script address when none exist (like the OPRETURN witness commitment of a coinbase TX)