### PR TITLE
Test coverage

### DIFF
--- a/test/wallet-http-test.js
+++ b/test/wallet-http-test.js
@@ -49,6 +49,7 @@ let txFee = 0;
 
 const coinValue = 50000;
 const witnessOptions = [true, false];
+const wallets = ['primary'];
 
 for (const witnessOpt of witnessOptions) {
   describe(`Wallet HTTP - witness: ${witnessOpt}`, function() {
@@ -71,6 +72,7 @@ for (const witnessOpt of witnessOptions) {
 
     it('should create wallet', async () => {
       const info = await wclient.createWallet(name, {witness: witnessOpt});
+      wallets.push(name);
       assert.strictEqual(info.id, name);
       wallet = wclient.wallet(name, info.token);
       await wallet.open();
@@ -78,7 +80,6 @@ for (const witnessOpt of witnessOptions) {
 
     it('should list wallets', async () => {
       const info = await wclient.getWallets();
-      const wallets = ['primary', 'test'];
       assert.equal(JSON.stringify(info), JSON.stringify(wallets));
     });
 

--- a/test/wallet-http-test.js
+++ b/test/wallet-http-test.js
@@ -91,25 +91,23 @@ for (const witnessOpt of witnessOptions) {
       assert(typeof str === 'string');
       addr = Address.fromString(str, node.network);
     });
-    
+
     it('should change passphrase', async () => {
       await wallet.setPassphrase('initial');
       await wclient.lock('test');
-      
+
       // Incorrect Passphrase should not work
       try {
         await wallet.unlock('badpass');
         throw new Error('Unlocked with INCORRECT passphrase!');
-      }
-      catch(e) {
+      } catch(e) {
         assert.strictEqual(e.message, 'Could not decrypt.', e.message);
       }
 
       // Correct Passphrase should work
       try {
         await wallet.unlock('initial');
-      }
-      catch(e) {
+      } catch(e) {
         throw new Error('Could not unlock with correct passphrase.');
       }
 
@@ -120,8 +118,7 @@ for (const witnessOpt of witnessOptions) {
       try {
         await wallet.unlock('initial');
         throw new Error('Unlocked with OLD passphrase!');
-      }
-      catch(e) {
+      } catch(e) {
         assert.strictEqual(e.message, 'Could not decrypt.', e.message);
       }
 
@@ -129,8 +126,7 @@ for (const witnessOpt of witnessOptions) {
       try {
         // wallet needs to stay unlocked for later tests
         await wallet.unlock('newpass', 15000);
-      }
-      catch(e) {
+      } catch(e) {
         throw new Error('Could not unlock with new passphrase.');
       }
     });

--- a/test/wallet-http-test.js
+++ b/test/wallet-http-test.js
@@ -76,6 +76,12 @@ for (const witnessOpt of witnessOptions) {
       await wallet.open();
     });
 
+    it('should list wallets', async () => {
+      const info = await wclient.getWallets();
+      const wallets = ['primary', 'test'];
+      assert.equal(JSON.stringify(info), JSON.stringify(wallets));
+    });
+
     it('should get wallet info', async () => {
       const info = await wallet.getInfo();
       assert.strictEqual(info.id, name);

--- a/test/wallet-http-test.js
+++ b/test/wallet-http-test.js
@@ -84,6 +84,49 @@ for (const witnessOpt of witnessOptions) {
       assert(typeof str === 'string');
       addr = Address.fromString(str, node.network);
     });
+    
+    it('should change passphrase', async () => {
+      await wallet.setPassphrase('initial');
+      await wclient.lock('test');
+      
+      // Incorrect Passphrase should not work
+      try {
+        await wallet.unlock('badpass');
+        throw new Error('Unlocked with INCORRECT passphrase!');
+      }
+      catch(e) {
+        assert.strictEqual(e.message, 'Could not decrypt.', e.message);
+      }
+
+      // Correct Passphrase should work
+      try {
+        await wallet.unlock('initial');
+      }
+      catch(e) {
+        throw new Error('Could not unlock with correct passphrase.');
+      }
+
+      await wallet.setPassphrase('newpass', 'initial');
+      await wclient.lock('test');
+
+      // Old Passphrase should not work
+      try {
+        await wallet.unlock('initial');
+        throw new Error('Unlocked with OLD passphrase!');
+      }
+      catch(e) {
+        assert.strictEqual(e.message, 'Could not decrypt.', e.message);
+      }
+
+      // New Passphrase should work
+      try {
+        // wallet needs to stay unlocked for later tests
+        await wallet.unlock('newpass', 15000);
+      }
+      catch(e) {
+        throw new Error('Could not unlock with new passphrase.');
+      }
+    });
 
     it('should fill with funds', async () => {
       const mtx = new MTX();


### PR DESCRIPTION
1. list wallets: primary and test
2. change passphrase: locked wallet should be unlocked only by the correct passphrase