### PR TITLE
removed [warning] (chain) unknown version bits in block

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -1054,13 +1054,6 @@ class Chain extends AsyncEmitter {
       await this.reorganize(entry);
     }
 
-    // Warn of unknown versionbits.
-    if (entry.hasUnknown(this.network)) {
-      this.logger.warning(
-        'Unknown version bits in block %d: %s.',
-        entry.height, entry.version.toString(16));
-    }
-
     // Otherwise, everything is in order.
     // Do "contextual" verification on our block
     // now that we're certain its previous
@@ -1127,13 +1120,6 @@ class Chain extends AsyncEmitter {
           entry.hash, entry.height);
       }
       throw err;
-    }
-
-    // Warn of unknown versionbits.
-    if (entry.hasUnknown(this.network)) {
-      this.logger.warning(
-        'Unknown version bits in block %d: %s.',
-        entry.height, entry.version.toString(16));
     }
 
     await this.db.save(entry, block);

--- a/lib/blockchain/chainentry.js
+++ b/lib/blockchain/chainentry.js
@@ -146,23 +146,6 @@ class ChainEntry {
   }
 
   /**
-   * Test whether the entry contains an unknown version bit.
-   * @param {Network} network
-   * @returns {Boolean}
-   */
-
-  hasUnknown(network) {
-    const TOP_MASK = consensus.VERSION_TOP_MASK;
-    const TOP_BITS = consensus.VERSION_TOP_BITS;
-    const bits = (this.version & TOP_MASK) >>> 0;
-
-    if (bits !== TOP_BITS)
-      return false;
-
-    return (this.version & network.unknownBits) !== 0;
-  }
-
-  /**
    * Test whether the entry contains a version bit.
    * @param {Number} bit
    * @returns {Boolean}


### PR DESCRIPTION
Resolves #1028  
- As miners are using OvertAsic boost to produce blocks with random version numbers, which adds more false positives to the [BIP91](https://github.com/bitcoin/bips/blob/master/bip-0091.mediawiki) signalling. 
- This removes the warning which is haunting users for a long time.