### PR TITLE
docs: add pinheadmz PGP key to maintainers

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -262,6 +262,7 @@ See [Configuration][configuration].
 
 - Christopher Jeffrey (B4B1 F62D BAC0 84E3 33F3 A04A 8962 AB9D E666 6BBD)
 - Braydon Fuller (5B7D C58D 90FE C1E9 90A3  10BA F24F 232D 108B 3AD4)
+- Matthew Zipkin (E617 73CD 6E01 040E 2F1B D78C E7E2 984B 6289 C93A)
 
 [keybase]: https://keybase.io/chjj#show-public
 [configuration]: configuration.md


### PR DESCRIPTION
Since we are asking users to install and verify bcoin and its dependencies with [GPK](https://github.com/braydonf/gpk) we need to make sure they have (and "trust") all the PGP keys that will be used to sign releases and HEAD commits in the github repos. 

This includes https://github.com/bcoin-org/bfilter/releases/tag/v2.2.0 and soon I hope to sign a tagged release for bcoin v2.2.0