### PR TITLE
update to minimum fee rate 

### DIFF
--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -477,7 +477,7 @@ main.minRelay = 1000;
  * @default
  */
 
-main.feeRate = 1000;
+main.feeRate = 5000;
 
 /**
  * Maximum normal relay rate.


### PR DESCRIPTION
**Resolves** #1017 
This PR tries to resolve the hard minimum fee rate in `bcoin`, previously this rate was `100 sat/kb` (unchanged since 2017 before segwit), but after segwit, this has to update as for a segwit transaction in `SPV mode`, which doesn't have any fee estimation method. Therefore SPV mode uses the hardcoded minimum fee rate (`100 sat/kbyte`), which is too much for a `segwit transaction`.
