### PR TITLE
feat: created a new bucket `u` to store only spendable credits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ## unreleased
 
+### Wallet changes
+
+- A new `u` bucket is added to `txdb` that stores only spendable coins indexed by `account` and `value`.
+- A new multi-algorithm coin selection. (Lowest Larger, Branch and Bound, and Single Random Draw)
+
+#### How to upgrade
+
+To upgrade wallet, we need to copy coins from `c` bucket to `u` bucket in `txdb`.
+
+To do this you can run:
+```
+node ./migrate/walletdb7to8.js /path/to/bcoin/wallet
+```
+
 ### Node API changes
 
 #### RPC

--- a/bench/txdb.js
+++ b/bench/txdb.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const random = require('bcrypto/lib/random');
+const bench = require('./bench');
+const WalletDB = require('../lib/wallet/walletdb');
+const MTX = require('../lib/primitives/mtx');
+const Input = require('../lib/primitives/input');
+const Output = require('../lib/primitives/output');
+const Script = require('../lib/script/script');
+const {rimraf, testdir} = require('../test/util/common');
+
+const ITERATIONS = 1000;
+
+(async () => {
+  for (const memory of [true, false]) {
+    console.log(`Memory: ${memory}`);
+
+    const location = testdir('txdb');
+
+    // Create walletDB and wallet
+    const wdb = new WalletDB({
+      memory,
+      location
+    });
+    await wdb.open();
+    const wallet = await wdb.create();
+    const addr = await wallet.receiveAddress();
+    const script = Script.fromAddress(addr);
+
+    {
+      // Fill txdb with unspent coins
+      const fund = new MTX();
+      const input = new Input();
+      // Make this a non-coinbase TX so we can spend right away
+      input.prevout.hash = random.randomBytes(32);
+      fund.inputs.push(input);
+      const output = new Output();
+      output.value = 15000;
+      output.script = script;
+      for (let i = 1; i <= ITERATIONS; i++) {
+        fund.outputs.push(output);
+      }
+
+      // Confirm
+      const dummyBlock = {
+        height: 0,
+        hash: Buffer.alloc(32),
+        time: Date.now()
+      };
+      await wdb.addTX(fund.toTX(), dummyBlock);
+    }
+
+    // Self-send small TXs so txdb is filled
+    // with spent coins
+    console.log(' Filling txdb...');
+    for (let i = 1; i <= ITERATIONS; i++) {
+      await wallet.send({
+        outputs: [{
+          address: addr,
+          value: 10000
+        }]
+      });
+    }
+
+    {
+      const end = bench('getCredits       ');
+
+      await wallet.getCredits(0);
+
+      end(ITERATIONS);
+    }
+
+    {
+      const end = bench('getCoins         ');
+
+      await wallet.getCoins(0);
+
+      end(ITERATIONS);
+    }
+
+    {
+      const end = bench('getSmartCoins    ');
+
+      await wallet.getSmartCoins(0);
+
+      end(ITERATIONS);
+    }
+
+    {
+      const end = bench('getUnspentCredits');
+
+      await wallet.getUnspentCredits(0);
+
+      end(ITERATIONS);
+    }
+
+    {
+      const end = bench('getUnspentCoins  ');
+
+      await wallet.getUnspentCoins(0);
+
+      end(ITERATIONS);
+    }
+
+    await rimraf(location);
+  }
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/lib/wallet/layout.js
+++ b/lib/wallet/layout.js
@@ -57,6 +57,7 @@ exports.wdb = {
  *   r[account] -> account balance
  *   t[hash] -> extended tx
  *   c[hash][index] -> coin
+ *   u[account][value][hash][index] -> unspent coin (by account and value)
  *   d[hash][index] -> undo coin
  *   s[hash][index] -> spent by hash
  *   p[hash] -> dummy (pending flag)
@@ -76,6 +77,7 @@ exports.txdb = {
   r: bdb.key('r', ['uint32']),
   t: bdb.key('t', ['hash256']),
   c: bdb.key('c', ['hash256', 'uint32']),
+  u: bdb.key('u', ['uint32', 'uint64', 'hash256', 'uint32']),
   d: bdb.key('d', ['hash256', 'uint32']),
   s: bdb.key('s', ['hash256', 'uint32']),
   p: bdb.key('p', ['hash256']),

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -113,7 +113,29 @@ class TXDB {
     b.put(layout.c.encode(coin.hash, coin.index), credit.toRaw());
     b.put(layout.C.encode(path.account, coin.hash, coin.index), null);
 
+    // if the credit is 'spent', we will remove it
+    // else we will add it to the 'unspent' bucket
+    if (credit.spent) {
+      this.removeUnspentCredit(b, credit, path);
+    } else {
+      this.saveUnspentCredit(b, credit, path);
+    }
+
     return this.addOutpointMap(b, coin.hash, coin.index);
+  }
+
+  /**
+   * Save unspent credit.
+   * @param {Credit} credit
+   * @param {Path} path
+   */
+
+  saveUnspentCredit(b, credit, path) {
+    const {coin} = credit;
+    b.put(
+      layout.u.encode(path.account, coin.value, coin.hash, coin.index),
+      credit.toRaw()
+    );
   }
 
   /**
@@ -128,7 +150,22 @@ class TXDB {
     b.del(layout.c.encode(coin.hash, coin.index));
     b.del(layout.C.encode(path.account, coin.hash, coin.index));
 
+    // we are sure that the credit is spent
+    // so we can remove it from the 'unspent' bucket
+    this.removeUnspentCredit(b, credit, path);
+
     return this.removeOutpointMap(b, coin.hash, coin.index);
+  }
+
+  /**
+   * Remove spent credit.
+   * @param {Credit} credit
+   * @param {Path} path
+   */
+
+  removeUnspentCredit(b, credit, path) {
+    const {coin} = credit;
+    b.del(layout.u.encode(path.account, coin.value, coin.hash, coin.index));
   }
 
   /**

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1763,6 +1763,80 @@ class TXDB {
   }
 
   /**
+   * Get unspent coins.
+   * @param {Number} acct
+   * @returns {Promise} - Returns {@link Coin}[].
+   */
+
+  async getUnspentCoins(acct) {
+    const credits = await this.getUnspentCredits(acct);
+    const coins = [];
+
+    for (const credit of credits) {
+      coins.push(credit.coin);
+    }
+
+    return coins;
+  }
+
+  /**
+   * Get unspent credits.
+   * @param {Number} acct
+   * @returns {Promise} - Returns {@link Credit}[].
+   */
+
+  async getUnspentCredits(acct) {
+    assert(typeof acct === 'number');
+
+    if (acct !== -1)
+      return this.getUnspentAccountCredits(acct);
+
+    const credits = [];
+
+    const iter = await this.bucket.iterator({
+      gte: layout.u.min(),
+      lte: layout.u.max(),
+      values: true
+    });
+
+    await iter.each((key, value) => {
+      const credit = Credit.fromRaw(value);
+      const [,, hash, index] = layout.u.decode(key);
+      credit.coin.hash = hash;
+      credit.coin.index = index;
+      credits.push(credit);
+    });
+
+    return credits;
+  }
+
+  /**
+   * Get unspent credits by account.
+   * @param {Number} acct
+   * @returns {Promise} - Returns {@link Credit}[].
+   */
+
+  async getUnspentAccountCredits(acct) {
+    const credits = [];
+
+    const iter = await this.bucket.iterator({
+      gte: layout.u.min(acct),
+      lte: layout.u.max(acct),
+      values: true
+    });
+
+    await iter.each((key, value) => {
+      const credit = Credit.fromRaw(value);
+      const [,, hash, index] = layout.u.decode(key);
+      credit.coin.hash = hash;
+      credit.coin.index = index;
+      credits.push(credit);
+    });
+
+    return credits;
+  }
+
+  /**
    * Get historical coins for a transaction.
    * @param {TX} tx
    * @returns {Promise} - Returns {@link TX}.

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1124,7 +1124,7 @@ class Wallet extends EventEmitter {
     if (options.smart) {
       coins = await this.getSmartCoins(options.account);
     } else {
-      coins = await this.getCoins(options.account);
+      coins = await this.getUnspentCoins(options.account);
       coins = this.txdb.filterLocked(coins);
     }
 
@@ -2031,14 +2031,11 @@ class Wallet extends EventEmitter {
    */
 
   async getSmartCoins(acct) {
-    const credits = await this.getCredits(acct);
+    const credits = await this.getUnspentCredits(acct);
     const coins = [];
 
     for (const credit of credits) {
       const coin = credit.coin;
-
-      if (credit.spent)
-        continue;
 
       if (this.txdb.isLocked(coin))
         continue;

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1992,6 +1992,17 @@ class Wallet extends EventEmitter {
   }
 
   /**
+   * Get all available unspent coins.
+   * @param {(String|Number)?} account
+   * @returns {Promise} - Returns {@link Coin}[].
+   */
+
+  async getUnspentCoins(acct) {
+    const account = await this.ensureIndex(acct);
+    return this.txdb.getUnspentCoins(account);
+  }
+
+  /**
    * Get all available credits.
    * @param {(String|Number)?} account
    * @returns {Promise} - Returns {@link Credit}[].
@@ -2000,6 +2011,17 @@ class Wallet extends EventEmitter {
   async getCredits(acct) {
     const account = await this.ensureIndex(acct);
     return this.txdb.getCredits(account);
+  }
+
+  /**
+   * Get all available unspent credits.
+   * @param {(String|Number)?} account
+   * @returns {Promise} - Returns {@link Credit}[].
+   */
+
+  async getUnspentCredits(acct) {
+    const account = await this.ensureIndex(acct);
+    return this.txdb.getUnspentCredits(account);
   }
 
   /**

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -179,7 +179,7 @@ class WalletDB extends EventEmitter {
   async open() {
     this.logger.info('Opening WalletDB...');
     await this.db.open();
-    await this.db.verify(layout.V.encode(), 'wallet', 7);
+    await this.db.verify(layout.V.encode(), 'wallet', 8);
 
     await this.verifyNetwork();
 

--- a/migrate/latest
+++ b/migrate/latest
@@ -35,6 +35,7 @@ const prefix = argv[2];
 const chain = resolve(prefix, 'chain');
 const spvchain = resolve(prefix, 'spvchain');
 const index = resolve(prefix, 'index');
+const wallet = resolve(prefix, 'wallet');
 
 (async () => {
   if (await fs.exists(chain))
@@ -45,6 +46,9 @@ const index = resolve(prefix, 'index');
 
   if (await fs.exists(index))
     exec(node, resolve(__dirname, 'indexerdb0to1.js'), index);
+
+  if (await fs.exists(wallet))
+    exec(node, resolve(__dirname, 'walletdb7to8.js'), wallet);
 })().catch((err) => {
   console.error(err.stack);
   process.exit(1);

--- a/migrate/walletdb7to8.js
+++ b/migrate/walletdb7to8.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const assert = require('assert');
+const bdb = require('bdb');
+const bio = require('bufio');
+const layouts = require('../lib/wallet/layout');
+const Coin = require('../lib/primitives/coin');
+const layout = layouts.wdb;
+const tlayout = layouts.txdb;
+
+// changes:
+// create u bucket to only store spendable coins
+
+let parent = null;
+
+assert(process.argv.length > 2, 'Please pass in a database path.');
+
+const db = bdb.create({
+  location: process.argv[2],
+  memory: false,
+  compression: true,
+  cacheSize: 32 << 20,
+  createIfMissing: false
+});
+
+async function getVersion() {
+  const data = await db.get(layout.V.encode());
+  assert(data, 'No version.');
+
+  return data.readUInt32LE(6);
+}
+
+async function checkVersion(version) {
+  console.log('Checking version.');
+
+  const ver = await getVersion();
+
+  if (ver > version) {
+    console.log('Already migrated');
+    process.exit(0);
+  }
+
+  if (ver !== version)
+    throw Error(`DB is version ${ver}.`);
+}
+
+async function updateVersion(version) {
+  await checkVersion(version - 1);
+
+  console.log('Updating version to %d.', version);
+
+  const buf = Buffer.allocUnsafe(6 + 4);
+  buf.write('wallet', 0, 'ascii');
+  buf.writeUInt32LE(version, 6);
+
+  parent.put(layout.V.encode(), buf);
+  await parent.write();
+}
+
+async function updateTXDB() {
+  const wids = await db.keys({
+    gte: layout.w.min(),
+    lte: layout.w.max(),
+    keys: true,
+    parse: key => layout.w.decode(key)[0]
+  });
+
+  console.log('Updating wallets...');
+
+  let total = 0;
+
+  for (const wid of wids) {
+    const bucket = db.bucket(layout.t.encode(wid));
+    const batch = bucket.wrap(parent);
+    await updateCoins(bucket, batch);
+    total += 1;
+  }
+
+  console.log('Updated %d wallets.', total);
+}
+
+async function updateCoins(bucket, batch) {
+  const keys = await bucket.keys({
+    gte: tlayout.C.min(),
+    lte: tlayout.C.max(),
+    parse: (key) => {
+      return tlayout.C.decode(key);
+    }
+  });
+
+  const promises = [];
+  // key = [account, hash, index]
+  for (const key of keys) {
+    promises.push(bucket.get(tlayout.c.encode(key[1], key[2])));
+  }
+
+  const credits = await Promise.all(promises);
+
+  for (let i = 0; i < keys.length; i++) {
+    const [account, hash, index] = keys[i];
+    const br = bio.read(credits[i]);
+    const coin = Coin.fromReader(br);
+    const spent = br.readU8() === 1;
+    if (!spent) {
+      const key = tlayout.u.encode(account, coin.value, hash, index);
+      batch.put(key, credits[i]);
+    }
+  }
+
+  await batch.write();
+}
+
+(async () => {
+  await db.open();
+
+  console.log('Opened %s.', process.argv[2]);
+
+  parent = db.batch();
+
+  await checkVersion(7);
+  await updateTXDB();
+  await updateVersion(8);
+
+  await parent.write();
+  await db.close();
+})().then(() => {
+  console.log('Migration complete.');
+  process.exit(0);
+}).catch((err) => {
+  console.error(err.stack);
+  process.exit(1);
+});

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -240,6 +240,39 @@ async function testP2SH(witness, nesting) {
   assert.strictEqual(tx.getFee(view), 10000);
 }
 
+async function compareCoinsAndCredits(wallet) {
+  // compare coins
+  const coins = await wallet.getUnspentCoins();
+  const expectedCoins = await wallet.getCoins();
+
+  assert.strictEqual(coins.length, expectedCoins.length);
+
+  coins.sort((a, b) => (a.hash > b.hash ? 1 : -1));
+  expectedCoins.sort((a, b) => (a.hash > b.hash ? 1 : -1));
+
+  for (let i = 0; i < coins.length; i++) {
+    assert.bufferEqual(coins[i].hash, expectedCoins[i].hash);
+    assert.strictEqual(coins[i].index, expectedCoins[i].index);
+  }
+
+  // compare credits
+  const credits = await wallet.getUnspentCredits();
+  let expectedCredits = await wallet.getCredits();
+
+  // we only care about the credits that are not spent
+  expectedCredits = expectedCredits.filter(c => !c.spent);
+
+  assert.strictEqual(credits.length, expectedCredits.length);
+
+  credits.sort((a, b) => (a.coin.hash > b.coin.hash ? 1 : -1));
+  expectedCredits.sort((a, b) => (a.coin.hash > b.coin.hash ? 1 : -1));
+
+  for (let i = 0; i < credits.length; i++) {
+    assert.bufferEqual(coins[i].hash, expectedCoins[i].hash);
+    assert.strictEqual(coins[i].index, expectedCoins[i].index);
+  }
+}
+
 describe('Wallet', function() {
   this.timeout(process.browser ? 20000 : 5000);
 
@@ -456,6 +489,10 @@ describe('Wallet', function() {
         return wtx.tx.hash().equals(f1.hash());
       }));
     }
+
+    // compare coins in unspent coins with coins in wallet.
+    compareCoinsAndCredits(alice);
+    compareCoinsAndCredits(bob);
   });
 
   it('should cleanup spenders after double-spend', async () => {
@@ -502,6 +539,9 @@ describe('Wallet', function() {
       }, 0);
       assert.strictEqual(total, 56000);
     }
+
+    // compare coins in unspent coins with coins in wallet.
+    compareCoinsAndCredits(wallet);
   });
 
   it('should handle double-spend (not our input)', async () => {
@@ -525,6 +565,9 @@ describe('Wallet', function() {
     await wdb.addTX(t2.toTX());
     assert.strictEqual(conflict, 1);
     assert.strictEqual((await wallet.getBalance()).unconfirmed, 0);
+
+    // compare coins in unspent coins with coins in wallet.
+    compareCoinsAndCredits(wallet);
   });
 
   it('should handle double-spend (multiple inputs)', async () => {
@@ -555,6 +598,9 @@ describe('Wallet', function() {
 
     assert.strictEqual(conflict, 1);
     assert.strictEqual((await wallet.getBalance()).unconfirmed, 49000);
+
+    // compare coins in unspent coins with coins in wallet.
+    compareCoinsAndCredits(wallet);
   });
 
   it('should handle double-spend (with block)', async () => {
@@ -586,6 +632,9 @@ describe('Wallet', function() {
     assert.strictEqual(conflict, 1);
     assert.strictEqual((await wallet.getBalance()).unconfirmed, 49000);
     assert.strictEqual((await wallet.getBalance()).confirmed, 49000);
+
+    // compare coins in unspent coins with coins in wallet.
+    compareCoinsAndCredits(wallet);
   });
 
   it('should recover from interrupt when removing conflict', async () => {
@@ -645,6 +694,9 @@ describe('Wallet', function() {
     assert.strictEqual((await wallet.getBalance()).unconfirmed, 49000);
     assert.strictEqual((await wallet.getBalance()).confirmed, 49000);
     assert.strictEqual(wdb.height, 2);
+
+    // compare coins in unspent coins with coins in wallet.
+    compareCoinsAndCredits(wallet);
   });
 
   it('should handle more missed txs', async () => {
@@ -755,6 +807,10 @@ describe('Wallet', function() {
       const balance = await bob.getBalance();
       assert.strictEqual(balance.unconfirmed, 10000);
     }
+
+    // compare coins in unspent coins with coins in wallet.
+    compareCoinsAndCredits(alice);
+    compareCoinsAndCredits(bob);
   });
 
   it('should fill tx with inputs', async () => {
@@ -1714,6 +1770,10 @@ describe('Wallet', function() {
     await wdb.addBlock(nextBlock(wdb), [t3.toTX()]);
 
     assert.strictEqual((await bob.getBalance()).unconfirmed, 30000);
+
+    // compare coins in unspent coins with coins in wallet.
+    compareCoinsAndCredits(alice);
+    compareCoinsAndCredits(bob);
   });
 
   it('should recover from a missed tx and double spend', async () => {
@@ -1785,6 +1845,10 @@ describe('Wallet', function() {
     await wdb.addBlock(nextBlock(wdb), [t3.toTX()]);
 
     assert.strictEqual((await bob.getBalance()).unconfirmed, 30000);
+
+    // compare coins in unspent coins with coins in wallet.
+    compareCoinsAndCredits(alice);
+    compareCoinsAndCredits(bob);
   });
 
   it('should remove a wallet', async () => {
@@ -1912,6 +1976,9 @@ describe('Wallet', function() {
     assert.strictEqual(bal1.confirmed, 0);
     assert.strictEqual(bal1.unconfirmed, 1020304);
 
+    // compare coins in unspent coins with coins in wallet.
+    compareCoinsAndCredits(wallet);
+
     // Import private key into wallet
     assert(!await wallet.hasAddress(addr2));
     await wallet.importKey('default', ring2);
@@ -1931,6 +1998,9 @@ describe('Wallet', function() {
     // Confirm TX with dummy block in txdb
     const details = await wallet.txdb.confirm(wtx, block);
     assert.bufferEqual(details.tx.hash(), hash);
+
+    // compare coins in unspent coins with coins in wallet.
+    compareCoinsAndCredits(wallet);
 
     // Check balance
     const bal2 = await wallet.getBalance();
@@ -1986,6 +2056,9 @@ describe('Wallet', function() {
     // Confirm TX with dummy block in txdb
     await wallet.txdb.confirm(wtx1, block1);
 
+    // compare coins in unspent coins with coins in wallet.
+    compareCoinsAndCredits(wallet);
+
     // Build TX to both addresses, known and unknown
     const mtx2 = new MTX();
     mtx2.addTX(tx1, 0, 99);
@@ -1996,6 +2069,9 @@ describe('Wallet', function() {
 
     // Add unconfirmed TX to txdb (no block provided)
     await wallet.txdb.add(tx2, null);
+
+    // compare coins in unspent coins with coins in wallet.
+    compareCoinsAndCredits(wallet);
 
     // Check
     const bal1 = await wallet.getBalance();
@@ -2023,6 +2099,9 @@ describe('Wallet', function() {
     // Confirm TX with dummy block in txdb
     const details = await wallet.txdb.confirm(wtx2, block2);
     assert.bufferEqual(details.tx.hash(), hash);
+
+    // compare coins in unspent coins with coins in wallet.
+    compareCoinsAndCredits(wallet);
 
     // Check balance
     const bal2 = await wallet.getBalance();


### PR DESCRIPTION
The `u` bucket will only store the following:

1. Coins that have not been included in any transaction (used as inputs)
2. Outputs of confirmed transactions (we are absolutely sure that these coins are spendable)
3. Outputs of unconfirmed transactions (in case of a `zap` we will remove these from `u`)