### PR TITLE
Add support for BIP158 filter types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@
 
 - Added `getnodeaddresses` which returns entries from the hostlist.
 
+### Indexer changes
+
+- Support for multiple compact filters added as per BIP158 specification. To enable the support of multiple filters the data previously in `~/.bcoin/index/filter` has been moved to `~/.bcoin/index/filter/BASIC`.
+- The filter indexer now also stores the filter hashes corresponding to the blockfilters.
+
+#### How to upgrade
+
+To upgrade to the multiple compact filter support we need to move filter data from `~/.bcoin/index/filter` to `~/.bcoin/index/filter/BASIC` and generate filter hashes for the existing filters.
+
+To do this you can run:
+```
+node ./migrate/indexerdb0to1.js /path/to/bcoin/index
+```
+ 
 ## v2.2.0
 
 - Support for bech32m has been added. bcoin can now validate and send BTC to

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -60,7 +60,7 @@ class ChainDB {
     this.logger.info('Opening ChainDB...');
 
     await this.db.open();
-    await this.db.verify(layout.V.encode(), 'chain', 6);
+    await this.db.verify(layout.V.encode(), 'chain', 7);
 
     const state = await this.getState();
 

--- a/lib/blockstore/common.js
+++ b/lib/blockstore/common.js
@@ -18,8 +18,17 @@
 exports.types = {
   BLOCK: 1,
   UNDO: 2,
-  FILTER: 3,
+  FILTER_BASIC: 3,
   MERKLE: 4
+};
+
+/**
+ * Filter types
+ * @enum {Number}
+ */
+
+exports.filters = {
+  BASIC: exports.types.FILTER_BASIC
 };
 
 /**

--- a/lib/blockstore/file.js
+++ b/lib/blockstore/file.js
@@ -16,7 +16,7 @@ const Network = require('../protocol/network');
 const AbstractBlockStore = require('./abstract');
 const {BlockRecord, FileRecord} = require('./records');
 const layout = require('./layout');
-const {types, prefixes} = require('./common');
+const {types, prefixes, filters} = require('./common');
 
 /**
  * File Block Store
@@ -180,6 +180,9 @@ class FileBlockStore extends AbstractBlockStore {
     await this._index(types.BLOCK);
     await this._index(types.MERKLE);
     await this._index(types.UNDO);
+    for (const filter in filters) {
+      await this._index(filters[filter]);
+    }
   }
 
   /**
@@ -345,11 +348,12 @@ class FileBlockStore extends AbstractBlockStore {
    * This method stores serialized block filter data in files.
    * @param {Buffer} hash - The block hash
    * @param {Buffer} data - The serialized block filter data.
+   * @param {Number} filterType - The filter type.
    * @returns {Promise}
    */
 
-  async writeFilter(hash, data) {
-    return this._write(types.FILTER, hash, data);
+  async writeFilter(hash, data, filterType) {
+    return this._write(filterType, hash, data);
   }
 
   /**
@@ -487,21 +491,23 @@ class FileBlockStore extends AbstractBlockStore {
   /**
    * This method will retrieve serialized block filter data.
    * @param {Buffer} hash - The block hash
+   * @param {Number} filterType - The filter type
    * @returns {Promise}
    */
 
-  async readFilter(hash) {
-    return this._read(types.FILTER, hash);
+  async readFilter(hash, filterType) {
+    return this._read(filterType, hash);
   }
 
   /**
    * This method will retrieve block filter header only.
    * @param {Buffer} hash - The block hash
+   * @param {String} filterType - The filter name
    * @returns {Promise}
    */
 
-  async readFilterHeader(hash) {
-    return this._read(types.FILTER, hash, 0, 32);
+  async readFilterHeader(hash, filterType) {
+    return this._read(filterType, hash, 0, 32);
   }
 
   /**
@@ -588,11 +594,12 @@ class FileBlockStore extends AbstractBlockStore {
   /**
    * This will free resources for storing the serialized block filter data.
    * @param {Buffer} hash - The block hash
+   * @param {String} filterType - The filter type
    * @returns {Promise}
    */
 
-  async pruneFilter(hash) {
-    return this._prune(types.FILTER, hash);
+  async pruneFilter(hash, filterType) {
+    return this._prune(filterType, hash);
   }
 
   /**
@@ -663,11 +670,12 @@ class FileBlockStore extends AbstractBlockStore {
    * This will check if a block filter has been stored
    * and is available.
    * @param {Buffer} hash - The block hash
+   * @param {Number} filterType - The filter type
    * @returns {Promise}
    */
 
-  async hasFilter(hash) {
-    return await this.db.has(layout.b.encode(types.FILTER, hash));
+  async hasFilter(hash, filterType) {
+    return await this.db.has(layout.b.encode(filterType, hash));
   }
 
   /**

--- a/lib/blockstore/level.js
+++ b/lib/blockstore/level.js
@@ -107,11 +107,12 @@ class LevelBlockStore extends AbstractBlockStore {
    * This method stores serialized block filter data in LevelDB.
    * @param {Buffer} hash - The block hash
    * @param {Buffer} data - The serialized block filter data.
+   * @param {Number} filterType - The filter type
    * @returns {Promise}
    */
 
-  async writeFilter(hash, data) {
-    return this.db.put(layout.b.encode(types.FILTER, hash), data);
+  async writeFilter(hash, data, filterType) {
+    return this.db.put(layout.b.encode(filterType, hash), data);
   }
 
   /**
@@ -137,21 +138,23 @@ class LevelBlockStore extends AbstractBlockStore {
   /**
    * This method will retrieve serialized block filter data.
    * @param {Buffer} hash - The block hash
+   * @param {Number} filterType - The filter type
    * @returns {Promise}
    */
 
-  async readFilter(hash) {
-    return this.db.get(layout.b.encode(types.FILTER, hash));
+  async readFilter(hash, filterType) {
+    return this.db.get(layout.b.encode(filterType, hash));
   }
 
   /**
    * This method will retrieve block filter header only.
    * @param {Buffer} hash - The block hash
+   * @param {Number} filterType- The filter type
    * @returns {Promise}
    */
 
-  async readFilterHeader(hash) {
-    const data = await this.db.get(layout.b.encode(types.FILTER, hash));
+  async readFilterHeader(hash, filterType) {
+    const data = await this.db.get(layout.b.encode(filterType, hash));
 
     if (!data)
       return null;
@@ -220,14 +223,15 @@ class LevelBlockStore extends AbstractBlockStore {
   /**
    * This will free resources for storing the serialized block filter data.
    * @param {Buffer} hash - The block hash
+   * @param {Number} filterType - The filter type
    * @returns {Promise}
    */
 
-  async pruneFilter(hash) {
-    if (!await this.hasFilter(hash))
+  async pruneFilter(hash, filterType) {
+    if (!await this.hasFilter(hash, filterType))
       return false;
 
-    await this.db.del(layout.b.encode(types.FILTER, hash));
+    await this.db.del(layout.b.encode(filterType, hash));
 
     return true;
   }
@@ -275,11 +279,12 @@ class LevelBlockStore extends AbstractBlockStore {
    * This will check if a block filter has been stored
    * and is available.
    * @param {Buffer} hash - The block hash
+   * @param {Number} filterType - The filter type
    * @returns {Promise}
    */
 
-  async hasFilter(hash) {
-    return this.db.has(layout.b.encode(types.FILTER, hash));
+  async hasFilter(hash, filterType) {
+    return this.db.has(layout.b.encode(filterType, hash));
   }
 
   /**

--- a/lib/golomb/golomb.js
+++ b/lib/golomb/golomb.js
@@ -46,6 +46,10 @@ class Golomb {
     this.P = P;
     this.m = null;
     this.M = M;
+
+    this._hash = null;
+    this._hhash = null;
+
     this.data = DUMMY;
   }
 
@@ -56,8 +60,23 @@ class Golomb {
    */
 
   hash(enc) {
-    const h = hash256.digest(this.toNBytes());
-    return enc === 'hex' ? h.toString('hex') : h;
+    let h = this._hash;
+
+    if (!h) {
+      h = hash256.digest(this.toNBytes());
+      this._hash = h;
+    }
+
+    if (enc === 'hex') {
+      let hex = this._hhash;
+      if (!hex) {
+        hex = h.toString('hex');
+        this._hhash = hex;
+      }
+      h = hex;
+    }
+
+    return h;
   }
 
   /**

--- a/lib/indexer/filterindexer.js
+++ b/lib/indexer/filterindexer.js
@@ -9,9 +9,23 @@
 const bdb = require('bdb');
 const assert = require('bsert');
 const Indexer = require('./indexer');
+const layout = require('./layout');
 const consensus = require('../protocol/consensus');
 const Filter = require('../primitives/filter');
+const path = require('path');
+const {filters} = require('../blockstore/common');
 
+/*
+ * FilterIndexer Database Layout:
+ *  f[hash] -> filter hash
+ *
+ *  The filter index db maps a filter hash to a block.
+ *  The filters and the filter headers are themselves stored
+ *  in the blockstore instead.
+ */
+Object.assign(layout, {
+  f: bdb.key('f', ['hash256'])
+});
 /**
  * FilterIndexer
  * @alias module:indexer.FilterIndexer
@@ -26,9 +40,10 @@ class FilterIndexer extends Indexer {
    */
 
   constructor(options) {
-    super('filter', options);
+    super(path.join('filter', options.filterType), options);
 
     this.db = bdb.create(this.options);
+    this.filterType = filters[options.filterType];
   }
 
   /**
@@ -43,7 +58,7 @@ class FilterIndexer extends Indexer {
     // Genesis prev filter headers are defined to be zero hashes
     const filter = new Filter();
     filter.header = consensus.ZERO_HASH;
-    await this.blocks.writeFilter(prevHash, filter.toRaw());
+    await this.blocks.writeFilter(prevHash, filter.toRaw(), this.filterType);
 
     await super.saveGenesis();
   }
@@ -59,12 +74,15 @@ class FilterIndexer extends Indexer {
   async indexBlock(meta, block, view) {
     const hash = block.hash();
     const prev = await this.getFilterHeader(block.prevBlock);
-    const basic = block.toFilter(view);
+    const gcsFilter = block.toFilter(view, this.filterType);
 
     const filter = new Filter();
-    filter.header = basic.header(prev);
-    filter.filter = basic.toRaw();
-    await this.blocks.writeFilter(hash, filter.toRaw());
+    filter.header = gcsFilter.header(prev);
+    filter.filter = gcsFilter.toRaw();
+
+    await this.blocks.writeFilter(hash, filter.toRaw(), this.filterType);
+
+    this.put(layout.f.encode(hash), gcsFilter.hash());
   }
 
   /**
@@ -74,20 +92,20 @@ class FilterIndexer extends Indexer {
    */
 
   async pruneBlock(meta) {
-    await this.blocks.pruneFilter(meta.hash);
+    this.del(layout.f.encode(meta.hash));
+    await this.blocks.pruneFilter(meta.hash, this.filterType);
   }
 
   /**
    * Retrieve compact filter by hash.
    * @param {Hash} hash
-   * @param {Number} type
    * @returns {Promise} - Returns {@link Filter}.
    */
 
   async getFilter(hash) {
     assert(hash);
 
-    const filter = await this.blocks.readFilter(hash);
+    const filter = await this.blocks.readFilter(hash, this.filterType);
     if (!filter)
       return null;
 
@@ -103,7 +121,19 @@ class FilterIndexer extends Indexer {
   async getFilterHeader(hash) {
     assert(hash);
 
-    return this.blocks.readFilterHeader(hash);
+    return this.blocks.readFilterHeader(hash, this.filterType);
+  }
+
+  /**
+   * Retrieve compact filter hash by block hash.
+   * @param {Hash} hash
+   * @returns {Promise} - Returns {@link Hash}.
+   */
+
+  async getFilterHash(hash) {
+    assert(hash);
+
+    return this.db.get(layout.f.encode(hash));
   }
 }
 

--- a/lib/indexer/index.js
+++ b/lib/indexer/index.js
@@ -13,3 +13,4 @@
 exports.Indexer = require('./indexer');
 exports.TXIndexer = require('./txindexer');
 exports.AddrIndexer = require('./addrindexer');
+exports.FilterIndexer = require('./filterindexer');

--- a/lib/indexer/indexer.js
+++ b/lib/indexer/indexer.js
@@ -110,7 +110,7 @@ class Indexer extends EventEmitter {
     this.closing = false;
     await this.ensure();
     await this.db.open();
-    await this.db.verify(layout.V.encode(), 'index', 0);
+    await this.db.verify(layout.V.encode(), 'index', 1);
     await this.verifyNetwork();
 
     // Initialize the indexed height.

--- a/lib/indexer/indexer.js
+++ b/lib/indexer/indexer.js
@@ -152,7 +152,7 @@ class Indexer extends EventEmitter {
     if (this.options.memory)
       return;
 
-    await fs.mkdirp(this.options.prefix);
+    await fs.mkdirp(this.options.location);
   }
 
   /**

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -185,14 +185,18 @@ class FullNode extends Node {
     }
 
     if (this.config.bool('index-filter')) {
-      this.filterindex = new FilterIndexer({
-        network: this.network,
-        logger: this.logger,
-        blocks: this.blocks,
-        chain: this.chain,
-        memory: this.config.bool('memory'),
-        prefix: this.config.str('index-prefix', this.config.prefix)
-      });
+      this.filterIndexers.set(
+        'BASIC',
+        new FilterIndexer({
+          network: this.network,
+          logger: this.logger,
+          blocks: this.blocks,
+          chain: this.chain,
+          memory: this.config.bool('memory'),
+          prefix: this.config.str('index-prefix', this.config.prefix),
+          filterType: 'BASIC'
+        })
+      );
     }
 
     this.init();
@@ -216,8 +220,11 @@ class FullNode extends Node {
     if (this.addrindex)
       this.addrindex.on('error', err => this.error(err));
 
-    if (this.filterindex)
-      this.filterindex.on('error', err => this.error(err));
+    if (this.filterIndexers) {
+      for (const filterindex of this.filterIndexers.values()) {
+        filterindex.on('error', err => this.error(err));
+      }
+    }
 
     if (this.http)
       this.http.on('error', err => this.error(err));
@@ -291,8 +298,11 @@ class FullNode extends Node {
     if (this.addrindex)
       await this.addrindex.open();
 
-    if (this.filterindex)
-      await this.filterindex.open();
+    if (this.filterIndexers) {
+      for (const filterindex of this.filterIndexers.values()) {
+        await filterindex.open();
+      }
+    }
 
     await this.openPlugins();
 
@@ -321,8 +331,11 @@ class FullNode extends Node {
     if (this.addrindex)
       await this.addrindex.close();
 
-    if (this.filterindex)
-      await this.filterindex.close();
+    if (this.filterIndexers) {
+      for (const filterindex of this.filterIndexers.values()) {
+        await filterindex.close();
+      }
+    }
 
     await this.closePlugins();
 
@@ -441,8 +454,11 @@ class FullNode extends Node {
     if (this.addrindex)
       this.addrindex.sync();
 
-    if (this.filterindex)
-      this.filterindex.sync();
+    if (this.filterIndexers) {
+      for (const filterindex of this.filterIndexers.values()) {
+        filterindex.sync();
+      }
+    }
 
     return this.pool.startSync();
   }
@@ -631,11 +647,14 @@ class FullNode extends Node {
   /**
    * Retrieve compact filter by hash.
    * @param {Hash | Number} hash
+   * @param {Number} type
    * @returns {Promise} - Returns {@link Buffer}.
    */
 
-  async getBlockFilter(hash) {
-    if (!this.filterindex)
+  async getBlockFilter(hash, filterType) {
+    const Indexer = this.filterIndexers.get(filterType);
+
+    if (!Indexer)
       return null;
 
     if (typeof hash === 'number')
@@ -644,7 +663,7 @@ class FullNode extends Node {
     if (!hash)
       return null;
 
-    return this.filterindex.getFilter(hash);
+    return Indexer.getFilter(hash);
   }
 }
 

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -66,7 +66,7 @@ class Node extends EventEmitter {
     this.http = null;
     this.txindex = null;
     this.addrindex = null;
-    this.filterindex = null;
+    this.filterIndexers = new Map();
 
     this._init(file);
   }

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -34,6 +34,7 @@ const Output = require('../primitives/output');
 const TX = require('../primitives/tx');
 const consensus = require('../protocol/consensus');
 const pkg = require('../pkg');
+const {filters} = require('../blockstore/common');
 const RPCBase = bweb.RPC;
 const RPCError = bweb.RPCError;
 
@@ -742,15 +743,21 @@ class RPC extends RPCBase {
 
   async getBlockFilter(args, help) {
     if (help || args.length < 1 || args.length > 2)
-      throw new RPCError(errs.MISC_ERROR, 'getblockfilter "hash"');
+      throw new RPCError(errs.MISC_ERROR, 'getblockfilter "hash" ( "type" )');
 
     const valid = new Validator(args);
     const hash = valid.brhash(0);
+    const filterName = valid.str(1, 'BASIC').toUpperCase();
+
+    const filterType = filters[filterName];
 
     if (!hash)
       throw new RPCError(errs.MISC_ERROR, 'Invalid block hash.');
 
-    const filter = await this.node.getBlockFilter(hash);
+    if (!filterType)
+      throw new RPCError(errs.MISC_ERROR, 'Filter type not supported');
+
+    const filter = await this.node.getBlockFilter(hash, filterName);
 
     if (!filter)
       throw new RPCError(errs.MISC_ERROR, 'Block filter not found.');

--- a/lib/primitives/block.js
+++ b/lib/primitives/block.js
@@ -23,6 +23,7 @@ const {encoding} = bio;
 const {inspectSymbol} = require('../utils');
 const {opcodes} = require('../script/common');
 const BasicFilter = require('../golomb/basicFilter');
+const {filters} = require('../blockstore/common');
 
 /**
  * Block
@@ -842,14 +843,13 @@ class Block extends AbstractBlock {
     return obj instanceof Block;
   }
 
-  /*
-   * Get block filter (BIP 158)
-   * @see https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki
+  /**
+   * Get basic block filter
    * @param {CoinView} view
-   * @returns {Object} See {@link Golomb}
+   * @returns {Object}
    */
 
-  toFilter(view) {
+  toBasicFilter(view) {
     const hash = this.hash();
     const key = hash.slice(0, 16);
     const items = new BufferSet();
@@ -882,6 +882,23 @@ class Block extends AbstractBlock {
 
     return new BasicFilter().fromItems(key, items);
   }
+
+  /**
+   * Get block filter (BIP 158)
+   * @see https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki
+   * @param {CoinView} view
+   * @param {Number} filterType
+   * @returns {Object} See {@link Golomb}
+   */
+
+  toFilter(view, filterType) {
+    switch (filterType) {
+      case filters.BASIC:
+        return this.toBasicFilter(view);
+      default:
+        return null;
+    }
+ }
 }
 
 /*

--- a/migrate/indexerdb0to1.js
+++ b/migrate/indexerdb0to1.js
@@ -1,0 +1,225 @@
+'use strict';
+
+const assert = require('assert');
+const hash256 = require('bcrypto/lib/hash256');
+const Filter = require('../lib/primitives/filter');
+const layout = require('../lib/indexer/layout');
+const FileBlockStore = require('../lib/blockstore/file');
+const bdb = require('bdb');
+const path = require('path');
+const fs = require('bfile');
+const {filters} = require('../lib/blockstore/common');
+
+assert(process.argv.length > 2, 'Please pass in a database path.');
+
+// change:
+// Move filter data present in ~/.../filter/ to ~/.../filter/BASIC
+
+const location = path.resolve(process.argv[2], '../blocks');
+const blockStore = new FileBlockStore({
+  location: location
+});
+
+Object.assign(layout, {
+  f: bdb.key('f', ['hash256'])
+});
+
+async function getVersion(db) {
+  const data = await db.get(layout.V.encode());
+  assert(data, 'No version.');
+
+  return data.readUInt32LE(5, true);
+}
+
+async function updateVersion(db, version) {
+  console.log('Updating version to %d.', version);
+
+  await checkVersion(db, version - 1);
+
+  const buf = Buffer.allocUnsafe(5 + 4);
+  buf.write('index', 0, 'ascii');
+  buf.writeUInt32LE(version, 5, true);
+
+  const parent = db.batch();
+  parent.put(layout.V.encode(), buf);
+  await parent.write();
+}
+
+async function updateChainVersion(db, version) {
+  console.log('Updating chainDB version to %d.', version);
+
+  await checkVersion(db, version - 1);
+
+  const buf = Buffer.allocUnsafe(5 + 4);
+  buf.write('chain', 0, 'ascii');
+  buf.writeUInt32LE(version, 5, true);
+
+  const parent = db.batch();
+  parent.put(layout.V.encode(), buf);
+  await parent.write();
+}
+
+async function checkVersion(db, version) {
+  console.log('Checking version.');
+
+  const ver = await getVersion(db);
+
+  if (ver !== version)
+    throw Error(`DB is version ${ver}.`);
+
+  return ver;
+}
+
+async function migrateFilter(db) {
+  console.log('Migrating filters..');
+  let parent  = db.batch();
+
+  const iter = db.iterator({
+    gte: layout.h.min(),
+    lte: layout.h.max(),
+    keys: true,
+    values: true
+  });
+
+  const migratedDB = bdb.create({
+    location: path.join(db.location, 'BASIC'),
+    memory: false,
+    compression: true,
+    createIfMissing: true
+  });
+
+  await migratedDB.open();
+
+  let parentMigratedDB = migratedDB.batch();
+
+  let migratedFilters = 0;
+
+  await iter.each(async (height, hash) => {
+    const rawFilter = await blockStore.readFilter(hash, filters.BASIC);
+    const filter = Filter.fromRaw(rawFilter);
+    const filterHash = hash256.digest(filter.filter);
+
+    parentMigratedDB.put(height, hash);
+    parent.del(height);
+
+    parentMigratedDB.put(layout.f.encode(hash), filterHash);
+    parent.del(layout.f.encode(hash));
+
+    migratedFilters += 1;
+
+    if (migratedFilters % 10000 === 0) {
+      console.log('migrated %d filters.', migratedFilters);
+      await parentMigratedDB.write();
+      await parent.write();
+
+      parentMigratedDB = migratedDB.batch();
+      parent = db.batch();
+    }
+  });
+
+  let raw = await db.get(layout.R.encode());
+  parentMigratedDB.put(layout.R.encode(), raw);
+  parent.del(layout.R.encode());
+
+  raw = await db.get(layout.O.encode());
+  parentMigratedDB.put(layout.O.encode(), raw);
+  parent.del(layout.O.encode());
+
+  await updateVersion(db, 1);
+  raw = await db.get(layout.V.encode());
+  parentMigratedDB.put(layout.V.encode(), raw);
+  parent.del(layout.V.encode());
+  console.log('Filter DB updated to version 1');
+
+  await parentMigratedDB.write();
+  await parent.write();
+
+  console.log('%d filters migrated.', migratedFilters);
+
+  await db.close();
+  await db.destroy();
+
+  await migratedDB.close();
+}
+
+/*
+ * Execute
+ */
+
+let count = 0;
+
+(async () => {
+  const indexesLocation = path.resolve(process.argv[2]);
+  const indexes = ['tx', 'addr', 'filter'];
+
+  for (const index of indexes) {
+    const location = path.join(indexesLocation, index);
+    if (!(await fs.exists(location))) {
+      continue;
+    }
+
+    const db = bdb.create({
+      location: location,
+      memory: false,
+      compression: true,
+      createIfMissing: false
+    });
+
+    console.log('Opened %s.', location);
+    try {
+      await db.open();
+    } catch (e) {
+      continue;
+    }
+
+    const version = await getVersion(db);
+
+    switch (version) {
+      case 0:
+        if (index === 'filter') {
+          await blockStore.ensure();
+          await blockStore.open();
+          await migrateFilter(db);
+          count += 1;
+
+          await blockStore.close();
+        } else {
+          await updateVersion(db, 1);
+          count += 1;
+
+          await db.close();
+        }
+        console.log('Migration complete');
+        break;
+      case 1:
+        console.log('Already upgraded.');
+        break;
+      default:
+        console.log(`DB version is ${version}.`);
+    }
+  }
+
+  // Updating chainDB version to ensure
+  // filter indexes are not duplicated.
+  const chainDB = bdb.create({
+    location: path.resolve(process.argv[2], '../chain'),
+    compression: true,
+    cacheSize: 32 << 20,
+    createIfMissing: false
+  });
+
+  console.log('Opened %s.', path.resolve(process.argv[2], '../chain'));
+  await chainDB.open();
+
+  const chainVersion = await getVersion(chainDB);
+  if (chainVersion === 6) {
+    await updateChainVersion(chainDB, 7);
+  }
+  await chainDB.close();
+})().then(() => {
+  console.log('Migrated %d databases.', count);
+  process.exit(0);
+}).catch((err) => {
+  console.error(err.stack);
+  process.exit(1);
+});

--- a/migrate/latest
+++ b/migrate/latest
@@ -34,6 +34,7 @@ const prefix = argv[2];
 
 const chain = resolve(prefix, 'chain');
 const spvchain = resolve(prefix, 'spvchain');
+const index = resolve(prefix, 'index');
 
 (async () => {
   if (await fs.exists(chain))
@@ -41,6 +42,9 @@ const spvchain = resolve(prefix, 'spvchain');
 
   if (await fs.exists(spvchain))
     exec(node, resolve(__dirname, 'chaindb4to6.js'), spvchain);
+
+  if (await fs.exists(index))
+    exec(node, resolve(__dirname, 'indexerdb0to1.js'), index);
 })().catch((err) => {
   console.error(err.stack);
   process.exit(1);

--- a/test/block-test.js
+++ b/test/block-test.js
@@ -22,6 +22,7 @@ const CoinView = require('../lib/coins/coinview');
 const random = require('bcrypto/lib/random');
 const Output = require('../lib/primitives/output');
 const Outpoint = require('../lib/primitives/outpoint');
+const {filters} = require('../lib/blockstore/common');
 
 // Block test vectors
 const block300025 = common.readBlock('block300025');
@@ -506,7 +507,7 @@ describe('Block', function() {
         view.addOutput(new Outpoint(hash, 0), output);
       }
 
-      const filter = block.toFilter(view);
+      const filter = block.toFilter(view, filters.BASIC);
       assert.strictEqual(filter.toRaw().toString('hex'), json[5]);
 
       const header = filter.header(Buffer.from(json[4], 'hex').reverse());

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -1,0 +1,337 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const hash256 = require('bcrypto/lib/hash256');
+const FullNode = require('../lib/node/fullnode');
+const {filters} = require('../lib/blockstore/common');
+const {BufferSet} = require('buffer-map');
+const {opcodes} = require('../lib/script/common');
+const FilterIndexer = require('../lib/indexer/filterindexer');
+const Block = require('../lib/primitives/block');
+const Golomb = require('../lib/golomb/golomb');
+const {U64} = require('n64');
+const BasicFilter = require('../lib/golomb/basicFilter');
+
+class TestFilter extends Golomb {
+  constructor() {
+    super(21, new U64(744931));
+  }
+}
+
+class TestBlock extends Block {
+  constructor() {
+    super();
+  }
+
+  toTestFilter(view) {
+    const hash = this.hash();
+    const key = hash.slice(0, 16);
+    const items = new BufferSet();
+
+    for (let i = 0; i < this.txs.length; i++) {
+      const tx = this.txs[i];
+
+      for (const output of tx.outputs) {
+        if (output.script.length === 0)
+          continue;
+
+        // In order to allow the filters to later be committed
+        // to within an OP_RETURN output, we ignore all
+        // OP_RETURNs to avoid a circular dependency.
+        if (output.script.raw[0] === opcodes.OP_RETURN)
+          continue;
+
+        items.add(output.script.raw);
+      }
+    }
+
+    for (const [, coins] of view.map) {
+      for (const [, coin] of coins.outputs) {
+        if (coin.output.script.length === 0)
+          continue;
+
+        items.add(coin.output.script.raw);
+      }
+    }
+
+    return new TestFilter().fromItems(key, items);
+  }
+
+  toFilter(view, filterType) {
+    switch (filterType) {
+      case filters.BASIC:
+        return this.toBasicFilter(view);
+      case filters.TEST:
+        return this.toTestFilter(view);
+      default:
+        return null;
+    }
+  }
+}
+
+Block.fromRaw = (data, enc) => {
+  if (typeof data === 'string')
+    data = Buffer.from(data, enc);
+  return new TestBlock().fromRaw(data);
+};
+
+const node = new FullNode({
+  network: 'regtest',
+  memory: true,
+  indexFilter: true,
+  plugins: [require('../lib/wallet/plugin')]
+});
+
+filters['TEST'] = 0xffffffff;
+
+describe('Filter', function() {
+  this.timeout(15000);
+
+  before(async () => {
+    const testFilterIndex = new FilterIndexer({
+      network: node.network,
+      logger: node.logger,
+      blocks: node.blocks,
+      chain: node.chain,
+      memory: node.config.bool('memory'),
+      prefix: node.config.str('index-prefix', node.config.prefix),
+      filterType: 'TEST'
+    });
+    node.filterIndexers.set('TEST', testFilterIndex);
+
+    await node.open();
+  });
+
+  after(async () => {
+    await node.close();
+  });
+
+  it('should test blocks get generated', async () => {
+    const generateblocks = async (height, entry) => {
+      for (let i = 0; i <= height; i++) {
+        const block = await node.miner.mineBlock(entry);
+        const testBlock = new TestBlock().fromRaw(block.toRaw());
+        entry = await node.chain.add(testBlock);
+      }
+      return entry;
+    };
+    await generateblocks(5, await node.chain.getEntry(0));
+  });
+
+  it('should basic filter get generated', async () => {
+    for (let i = 0; i <= node.chain.height; i++) {
+      const hash = await node.chain.getHash(i);
+      const indexer = node.filterIndexers.get('BASIC');
+      const filter = (await indexer.getFilter(hash)).toJSON();
+
+      assert.notStrictEqual(filter.filter.length, 0);
+      assert.notStrictEqual(filter.header.length, 0);
+    }
+  });
+
+  it('should test filter get generated', async () => {
+    for (let i = 0; i <= node.chain.height; i++) {
+      const hash = await node.chain.getHash(i);
+      const indexer = node.filterIndexers.get('TEST');
+      const filter = (await indexer.getFilter(hash)).toJSON();
+
+      assert.notStrictEqual(filter.filter.length, 0);
+      assert.notStrictEqual(filter.header.length, 0);
+    }
+  });
+
+  it('should not test filter equal basic filter', async () => {
+    for (let i = 0; i <= node.chain.height; i++) {
+      const hash = await node.chain.getHash(i);
+      const basicIndexer = node.filterIndexers.get('BASIC');
+      const testIndexer = node.filterIndexers.get('TEST');
+      const basicFilter = (await basicIndexer.getFilter(hash)).toJSON();
+      const testFilter =  (await testIndexer.getFilter(hash)).toJSON();
+
+      assert.notStrictEqual(basicFilter.filter, testFilter.filter);
+      assert.notStrictEqual(basicFilter.header, testFilter.header);
+    }
+  });
+
+  it('should basic filter be reconstructed', async () => {
+    for (let i = 0; i <= node.chain.height; i++) {
+      const hash = await node.chain.getHash(i);
+      const indexer = node.filterIndexers.get('BASIC');
+      const rawBasicFilter = (await indexer.getFilter(hash));
+      const basicFilter = new BasicFilter().fromRaw(rawBasicFilter.filter);
+
+      assert.ok(basicFilter);
+    }
+  });
+
+  it('should reconstructed basic filter be matched', async () => {
+    for (let i = 0; i <= node.chain.height; i++) {
+      const hash = await node.chain.getHash(i);
+      const block = await node.chain.getBlock(hash);
+      const indexer = node.filterIndexers.get('BASIC');
+      const rawBasicFilter = (await indexer.getFilter(hash));
+      const basicFilter = new BasicFilter().fromRaw(rawBasicFilter.filter);
+
+      const key = hash.slice(0, 16);
+      const items = new BufferSet();
+      for (let i = 0; i < block.txs.length; i++) {
+        const tx = block.txs[i];
+
+        for (const output of tx.outputs) {
+          if (output.script.length === 0)
+            continue;
+
+          // In order to allow the filters to later be committed
+          // to within an OP_RETURN output, we ignore all
+          // OP_RETURNs to avoid a circular dependency.
+          if (output.script.raw[0] === opcodes.OP_RETURN)
+            continue;
+          items.add(output.script.raw);
+        }
+      }
+      const view = await node.chain.getBlockView(block);
+      for (const [, coins] of view.map) {
+        for (const [, coin] of coins.outputs) {
+          if (coin.output.script.length === 0)
+            continue;
+
+          items.add(coin.output.script.raw);
+        }
+      }
+
+      assert.ok(basicFilter);
+      for (const item of items) {
+        assert.ok(basicFilter.match(key, item));
+      }
+    }
+  });
+
+  it('should test filter be reconstructed', async () => {
+    for (let i = 0; i <= node.chain.height; i++) {
+      const hash = await node.chain.getHash(i);
+      const indexer = node.filterIndexers.get('TEST');
+      const rawTestFilter = (await indexer.getFilter(hash));
+      const testFilter = new TestFilter().fromRaw(rawTestFilter.filter);
+
+      assert.ok(testFilter);
+    }
+  });
+
+  it('should reconstructed test filter be matched', async () => {
+    for (let i = 0; i <= node.chain.height; i++) {
+      const hash = await node.chain.getHash(i);
+      const block = await node.chain.getBlock(hash);
+      const indexer = node.filterIndexers.get('TEST');
+      const rawTestFilter = (await indexer.getFilter(hash));
+      const testFilter = new TestFilter().fromRaw(rawTestFilter.filter);
+
+      const key = hash.slice(0, 16);
+      const items = new BufferSet();
+      for (let i = 0; i < block.txs.length; i++) {
+        const tx = block.txs[i];
+
+        for (const output of tx.outputs) {
+          if (output.script.length === 0)
+            continue;
+
+          // In order to allow the filters to later be committed
+          // to within an OP_RETURN output, we ignore all
+          // OP_RETURNs to avoid a circular dependency.
+          if (output.script.raw[0] === opcodes.OP_RETURN)
+            continue;
+          items.add(output.script.raw);
+        }
+      }
+      const view = await node.chain.getBlockView(block);
+      for (const [, coins] of view.map) {
+        for (const [, coin] of coins.outputs) {
+          if (coin.output.script.length === 0)
+            continue;
+
+          items.add(coin.output.script.raw);
+        }
+      }
+
+      assert.ok(testFilter);
+      for (const item of items) {
+        assert.ok(testFilter.match(key, item));
+      }
+    }
+  });
+
+  it('should basic filter hash be generated', async () => {
+    for (let i = 0; i <= node.chain.height; i++) {
+      const hash = await node.chain.getHash(i);
+      const indexer = node.filterIndexers.get('BASIC');
+      const basicFilterHash  = await indexer.getFilterHash(hash);
+
+      const rawBasicFilter = await indexer.getFilter(hash);
+      const expected = hash256.digest(rawBasicFilter.filter);
+      assert.bufferEqual(expected, basicFilterHash);
+    }
+  });
+
+  it('should test filter hash be generated', async () => {
+    for (let i = 0; i <= node.chain.height; i++) {
+      const hash = await node.chain.getHash(i);
+      const indexer = node.filterIndexers.get('TEST');
+      const testFilterHash  = await indexer.getFilterHash(hash);
+
+      const rawTestFilter = await indexer.getFilter(hash);
+      const expected = hash256.digest(rawTestFilter.filter);
+      assert.bufferEqual(expected, testFilterHash);
+    }
+  });
+
+  it('should basic filter header be generated by a chain of filter hashes', async () => {
+    const indexer = node.filterIndexers.get('BASIC');
+    const initialHash = await node.chain.getHash(0);
+    const initialFilter = await indexer.getFilter(initialHash);
+    let prev = initialFilter.header;
+
+    for (let i = 1; i <= node.chain.height; i++) {
+      const hash = await node.chain.getHash(i);
+      const basicFilterHash  = await indexer.getFilterHash(hash);
+      prev = hash256.root(basicFilterHash, prev);
+    }
+
+    const finalHash = await node.chain.getHash(node.chain.height);
+    const finalFilter = await indexer.getFilter(finalHash);
+    const expected = finalFilter.header;
+    assert.bufferEqual(prev, expected);
+  });
+
+  it('should test filter header be generated by a chain of filter hashes', async () => {
+    const indexer = node.filterIndexers.get('TEST');
+    const initialHash = await node.chain.getHash(0);
+    const initialFilter = await indexer.getFilter(initialHash);
+    let prev = initialFilter.header;
+
+    for (let i = 1; i <= node.chain.height; i++) {
+      const hash = await node.chain.getHash(i);
+      const testFilterHash = await indexer.getFilterHash(hash);
+      prev = hash256.root(testFilterHash, prev);
+    }
+
+    const finalHash = await node.chain.getHash(node.chain.height);
+    const finalFilter = await indexer.getFilter(finalHash);
+    const expected = finalFilter.header;
+    assert.bufferEqual(prev, expected);
+  });
+
+  it('should compute correct filter hash', () => {
+    // Test vectors derived from Bitcoin Core
+    const filter = new BasicFilter().fromNBytes(
+      Buffer.from('0189a630', 'hex')
+    );
+    const actual = filter.hash();
+    const expected = Buffer.from(
+      'c1bf78c13365fd48548224efdb81c5eda29982438f8f5217cc44ff752b6ab867',
+      'hex'
+    );
+    assert.bufferEqual(actual, expected);
+  });
+});

--- a/test/node-rpc-test.js
+++ b/test/node-rpc-test.js
@@ -22,6 +22,7 @@ const node = new FullNode({
   apiKey: 'foo',
   walletAuth: true,
   memory: true,
+  indexFilter: true,
   workers: true,
   workersSize: 2,
   plugins: [require('../lib/wallet/plugin')],
@@ -75,6 +76,16 @@ describe('RPC', function() {
   it('should rpc getblockhash', async () => {
     const info = await nclient.execute('getblockhash', [node.chain.tip.height]);
     assert.strictEqual(util.revHex(node.chain.tip.hash), info);
+  });
+
+  it('should rpc getblockfilter', async () => {
+    const hash = await nclient.execute('getblockhash', [node.chain.tip.height]);
+    const info = await nclient.execute('getblockfilter', [hash, 'BASIC']);
+    const indexer = node.filterIndexers.get('BASIC');
+    const filter = await indexer.getFilter(node.chain.tip.hash);
+    const expected = filter.toJSON();
+
+    assert.strictEqual(expected.filter, info.filter);
   });
 
   describe('Blockchain', function () {


### PR DESCRIPTION
- Adds support for filter types referenced in [BIP158](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki) & [BIP157](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki)
- Fixes the getblockfilter RPC message. Previously the RPC message implemented had the form 
`getblockfilter "hash"`
however as per [Bitcoin core docs](https://bitcoincore.org/en/doc/0.19.0/rpc/blockchain/getblockfilter/), the RPC message is supposed to be
`getblockfilter "hash" ( "type" )`
where the `type` by default is BASIC.
