### PR TITLE
Added functions `estimateSpendingSize()` and `estimateSizeWithoutInputs()` for better tx size estimation

### DIFF
--- a/lib/primitives/coin.js
+++ b/lib/primitives/coin.js
@@ -16,6 +16,7 @@ const Network = require('../protocol/network');
 const consensus = require('../protocol/consensus');
 const Outpoint = require('./outpoint');
 const {inspectSymbol} = require('../utils');
+const {encoding} = require('bufio');
 
 /**
  * Coin
@@ -307,6 +308,187 @@ class Coin extends Output {
 
   getSize() {
     return 17 + this.script.getVarSize();
+  }
+
+  /**
+   * Estimate spending size.
+   * @param {Function?} getAccount - Returns account that can spend
+   * from a given address.
+   * @returns {Number}
+   */
+
+  async estimateSpendingSize(getAccount) {
+    let total = 0;
+
+    // Outpoint (hash and index) + sequence
+    total += 32 + 4 + 4;
+
+    const scale = consensus.WITNESS_SCALE_FACTOR;
+
+    // Previous output script.
+    const script = this.script;
+
+    // P2PK
+    if (script.isPubkey()) {
+      // varint script size
+      total += 1;
+      // OP_PUSHDATA0 [signature]
+      total += 1 + 73;
+      return total;
+    }
+
+    // P2PKH
+    if (script.isPubkeyhash()) {
+      // varint script size
+      total += 1;
+      // OP_PUSHDATA0 [signature]
+      total += 1 + 73;
+      // OP_PUSHDATA0 [key]
+      total += 1 + 33;
+      return total;
+    }
+
+    // Multisig
+    let [m] = script.getMultisig();
+    if (m !== -1) {
+      let size = 0;
+      // Bare Multisig
+      // OP_0
+      size += 1;
+      // OP_PUSHDATA0 [signature] ...
+      size += (1 + 73) * m;
+      // varint len
+      size += encoding.sizeVarint(size);
+      total += size;
+      return total;
+    }
+
+    // P2WPKH
+    if (script.isWitnessPubkeyhash()) {
+      let size = 0;
+      // legacy script size (0x00)
+      total += 1;
+      // varint-items-len
+      size += 1;
+      // varint-len [signature]
+      size += 1 + 73;
+      // varint-len [key]
+      size += 1 + 33;
+      // vsize
+      size = (size + scale - 1) / scale | 0;
+      total += size;
+      return total;
+    }
+
+    // Assume 2-of-3 multisig for P2SH
+    m = 2;
+    let n = 3;
+    let type = 1;
+    let witness = false;
+
+    // check if getAccount is defined
+    if (getAccount) {
+      const account = await getAccount(script.getAddress());
+      // if account is defined,
+      // update m, n, type and witness
+      if (account) {
+        m = account.m;
+        n = account.n;
+        type = account.type;
+        witness = account.witness;
+      }
+    }
+
+    // P2SH
+    if (script.isScripthash()) {
+      let size = 0;
+      if (!witness) {
+        // Multisig
+        // OP_0
+        size += 1;
+        // varint-len [signature] ...
+        size += (1 + 73) * m;
+        // script (OP_PUSHDATA1, varint length)
+        size += 1 + 1;
+        // OP_2
+        size += 1;
+        // varint [pubkey] ...
+        size += (1 + 33) * n;
+        // OP_3 OP_CHECKMULTISIG
+        size += 1 + 1;
+        total += size;
+      } else {
+        // 0 = PubKeyHash, 1 = Multisig
+        if (type) {
+          // Multisig
+
+          // scriptSig (varint-len, OP_0, varint-len, scriptHash)
+          total += 1 + 1 + 1 + 32;
+
+          // OP_0
+          size += 1;
+          // OP_PUSHDATA0 [signature] ...
+          size += (1 + 73) * m;
+          // script (OP_PUSHDATA1, varint length)
+          size += 1 + 1;
+          // OP_2
+          size += 1;
+          // [pubkey] ...
+          size += (1 + 33) * n;
+          // OP_3 OP_CHECKMULTISIG
+          size += 1 + 1;
+          // vsize
+          size = (size + scale - 1) / scale | 0;
+          total += size;
+        } else {
+          // PubKeyHash
+
+          // scriptSig (varint-len, OP_0, varint-len, pubKeyHash)
+          total += 1 + 1 + 1 + 32;
+
+          // varint script size
+          size += 1;
+          // OP_PUSHDATA0 [signature]
+          size += 1 + 73;
+          // OP_PUSHDATA0 [key]
+          size += 1 + 33;
+          // vsize
+          size = (size + scale - 1) / scale | 0;
+          total += size;
+        }
+      }
+      return total;
+    }
+
+    // P2WSH
+    if (script.isWitnessScripthash()) {
+      // legacy script size (0x00)
+      total += 1;
+      let size = 0;
+      // varint-items-len
+      size += 1;
+      // OP_0
+      size += 1;
+      // OP_PUSHDATA0 [signature] ...
+      size += (1 + 73) * m;
+      // script (OP_PUSHDATA1, varint length)
+      size += 1 + 1;
+      // OP_2
+      size += 1;
+      // [pubkey] ...
+      size += (1 + 33) * n;
+      // OP_3 OP_CHECKMULTISIG
+      size += 1 + 1;
+      // vsize
+      size = (size + scale - 1) / scale | 0;
+      total += size;
+      return total;
+    }
+
+    // Unknown.
+    // Assume it's a P2PKH :(
+    total += 110;
+    return total;
   }
 
   /**

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1090,30 +1090,37 @@ class MTX extends TX {
 
   /**
    * Estimate maximum possible size.
-   * @param {Function?} estimate - Input script size estimator.
+   * @param {Function?} getAccount - Returns account that can spend
+   * from a given address.
    * @returns {Number}
    */
 
-  async estimateSize(estimate) {
-    const scale = consensus.WITNESS_SCALE_FACTOR;
-
+  async estimateSize(getAccount) {
     let total = 0;
 
-    // Calculate the size, minus the input scripts.
+    // Version
     total += 4;
-    total += encoding.sizeVarint(this.inputs.length);
-    total += this.inputs.length * 40;
 
+    // timelock
+    total += 4;
+
+    // Number of inputs
+    total += encoding.sizeVarint(this.inputs.length);
+
+    // Number of outputs
     total += encoding.sizeVarint(this.outputs.length);
 
+    // since outputs are final, we can get final size
     for (const output of this.outputs)
       total += output.getSize();
 
-    total += 4;
+    // Assume it's a witness txin
+    // Witness marker and flag
+    total += 2;
 
-    // Add size for signatures and public keys
-    for (const {prevout} of this.inputs) {
-      const coin = this.view.getOutput(prevout);
+    // Add size for inputs
+    for (const input of this.inputs) {
+      const coin = this.view.getCoinFor(input);
 
       // We're out of luck here.
       // Just assume it's a p2pkh.
@@ -1122,91 +1129,7 @@ class MTX extends TX {
         continue;
       }
 
-      // Previous output script.
-      const prev = coin.script;
-
-      // P2PK
-      if (prev.isPubkey()) {
-        // varint script size
-        total += 1;
-        // OP_PUSHDATA0 [signature]
-        total += 1 + 73;
-        continue;
-      }
-
-      // P2PKH
-      if (prev.isPubkeyhash()) {
-        // varint script size
-        total += 1;
-        // OP_PUSHDATA0 [signature]
-        total += 1 + 73;
-        // OP_PUSHDATA0 [key]
-        total += 1 + 33;
-        continue;
-      }
-
-      const [m] = prev.getMultisig();
-      if (m !== -1) {
-        let size = 0;
-        // Bare Multisig
-        // OP_0
-        size += 1;
-        // OP_PUSHDATA0 [signature] ...
-        size += (1 + 73) * m;
-        // varint len
-        size += encoding.sizeVarint(size);
-        total += size;
-        continue;
-      }
-
-      // P2WPKH
-      if (prev.isWitnessPubkeyhash()) {
-        let size = 0;
-        // varint-items-len
-        size += 1;
-        // varint-len [signature]
-        size += 1 + 73;
-        // varint-len [key]
-        size += 1 + 33;
-        // vsize
-        size = (size + scale - 1) / scale | 0;
-        total += size;
-        continue;
-      }
-
-      // Call out to the custom estimator.
-      if (estimate) {
-        const size = await estimate(prev);
-        if (size !== -1) {
-          total += size;
-          continue;
-        }
-      }
-
-      // P2SH
-      if (prev.isScripthash()) {
-        // varint size
-        total += 1;
-        // 2-of-3 multisig input
-        total += 149;
-        continue;
-      }
-
-      // P2WSH
-      if (prev.isWitnessScripthash()) {
-        let size = 0;
-        // varint-items-len
-        size += 1;
-        // 2-of-3 multisig input
-        size += 149;
-        // vsize
-        size = (size + scale - 1) / scale | 0;
-        total += size;
-        continue;
-      }
-
-      // Unknown.
-      total += 110;
+      total += await coin.estimateSpendingSize(getAccount);
     }
 
     return total;
@@ -1597,7 +1520,7 @@ class CoinSelector {
     this.inputs = new BufferMap();
 
     // Needed for size estimation.
-    this.estimate = null;
+    this.getAccount = null;
 
     this.injectInputs();
 
@@ -1687,9 +1610,9 @@ class CoinSelector {
       }
     }
 
-    if (options.estimate) {
-      assert(typeof options.estimate === 'function');
-      this.estimate = options.estimate;
+    if (options.getAccount) {
+      assert(typeof options.getAccount === 'function');
+      this.getAccount = options.getAccount;
     }
 
     if (options.inputs) {
@@ -1937,7 +1860,7 @@ class CoinSelector {
     // Keep recalculating the fee and funding
     // until we reach some sort of equilibrium.
     do {
-      const size = await this.tx.estimateSize(this.estimate);
+      const size = await this.tx.estimateSize(this.getAccount);
 
       this.fee = this.getFee(size);
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1139,7 +1139,7 @@ class Wallet extends EventEmitter {
       height: this.wdb.state.height,
       rate: rate,
       maxFee: options.maxFee,
-      estimate: prev => this.estimateSize(prev)
+      getAccount: this.getAccountByAddress.bind(this)
     });
 
     assert(mtx.getFee() <= MTX.Selector.MAX_FEE, 'TX exceeds MAX_FEE.');

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -28,7 +28,6 @@ const Account = require('./account');
 const MasterKey = require('./masterkey');
 const policy = require('../protocol/policy');
 const consensus = require('../protocol/consensus');
-const {encoding} = bio;
 const {Mnemonic} = HD;
 const {inspectSymbol} = require('../utils');
 const {BufferSet} = require('buffer-map');
@@ -1159,84 +1158,6 @@ class Wallet extends EventEmitter {
       return null;
 
     return this.getAccount(path.account);
-  }
-
-  /**
-   * Input size estimator for max possible tx size.
-   * @param {Script} prev
-   * @returns {Number}
-   */
-
-  async estimateSize(prev) {
-    const scale = consensus.WITNESS_SCALE_FACTOR;
-    const address = prev.getAddress();
-
-    if (!address)
-      return -1;
-
-    const account = await this.getAccountByAddress(address);
-
-    if (!account)
-      return -1;
-
-    let size = 0;
-
-    if (prev.isScripthash()) {
-      // Nested bullshit.
-      if (account.witness) {
-        switch (account.type) {
-          case Account.types.PUBKEYHASH:
-            size += 23; // redeem script
-            size *= 4; // vsize
-            break;
-          case Account.types.MULTISIG:
-            size += 35; // redeem script
-            size *= 4; // vsize
-            break;
-        }
-      }
-    }
-
-    switch (account.type) {
-      case Account.types.PUBKEYHASH:
-        // P2PKH
-        // OP_PUSHDATA0 [signature]
-        size += 1 + 73;
-        // OP_PUSHDATA0 [key]
-        size += 1 + 33;
-        break;
-      case Account.types.MULTISIG:
-        // P2SH Multisig
-        // OP_0
-        size += 1;
-        // OP_PUSHDATA0 [signature] ...
-        size += (1 + 73) * account.m;
-        // OP_PUSHDATA2 [redeem]
-        size += 3;
-        // m value
-        size += 1;
-        // OP_PUSHDATA0 [key] ...
-        size += (1 + 33) * account.n;
-        // n value
-        size += 1;
-        // OP_CHECKMULTISIG
-        size += 1;
-        break;
-    }
-
-    if (account.witness) {
-      // Varint witness items length.
-      size += 1;
-      // Calculate vsize if
-      // we're a witness program.
-      size = (size + scale - 1) / scale | 0;
-    } else {
-      // Byte for varint
-      // size of input script.
-      size += encoding.sizeVarint(size);
-    }
-
-    return size;
   }
 
   /**


### PR DESCRIPTION
This PR is based on [this](https://github.com/bcoin-org/bcoin/pull/858)

The idea is to calculate the `effectiveValue` of a coin for a new coin selection algorithm.
EffectiveValue = IntrinsicValue - Cost of Spending this coin

To calculate the `effectiveValue` of a coin, we need to estimate its accurate size, `estimateSpendingSize()` is used for that.

Since the output size is fixed, we can calculate the total required input value (total amount to be spent + fee based on the size of outputs). To calculate the fee based on output size, we need to calculate the size of tx without inputs. `estimateSizeWithoutInputs()` is used to calculate that.