### PR TITLE
12 seed words to 24 seed words

### DIFF
--- a/lib/hd/common.js
+++ b/lib/hd/common.js
@@ -24,7 +24,7 @@ common.HARDENED = 0x80000000;
  * @default
  */
 
-common.MIN_ENTROPY = 128;
+common.MIN_ENTROPY = 256;
 
 /**
  * Max entropy bits.


### PR DESCRIPTION
This commit changes the mnemonics length to 256 bits to get 24 seed phrases instead of 12 previously being used by bcoin-wallet.