### PR TITLE
256 bit mnemonic update

### DIFF
--- a/lib/hd/mnemonic.js
+++ b/lib/hd/mnemonic.js
@@ -45,7 +45,7 @@ class Mnemonic {
    */
 
   constructor(options) {
-    this.bits = common.MIN_ENTROPY;
+    this.bits = 256; // previously using 128
     this.language = 'english';
     this.entropy = null;
     this.phrase = null;

--- a/test/hd-test.js
+++ b/test/hd-test.js
@@ -107,7 +107,7 @@ describe('HD', function() {
     const fmt = nodejsUtil.format(mne);
     assert(typeof fmt === 'string');
     assert(fmt.includes('Mnemonic'));
-    assert.strictEqual(fmt.split(' ').length, 13);
+    assert.strictEqual(fmt.split(' ').length, 25);
   });
 
   for (const vector of [vector1, vector2]) {


### PR DESCRIPTION
This commit changes the mnemonics length to 256 bits to get 24 seed phrases instead of 12 previously being used by bcoin-wallet. Also, this closes the previously opened draft PR #1060.