### PR TITLE
Add new rules to eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -147,6 +147,21 @@
     "strict": "error",
     "unicode-bom": ["error", "never"],
     "valid-jsdoc": "error",
-    "wrap-iife": ["error", "inside"]
+    "wrap-iife": ["error", "inside"],
+    "space-unary-ops": ["error", {
+      "words": true,
+      "nonwords": false
+    }],
+    "space-infix-ops": ["error", {
+      "int32Hint": false
+    }],
+    "comma-spacing": ["error", {
+      "before": false,
+      "after": true
+    }],
+    "keyword-spacing": ["error",{
+      "before": true,
+      "after": true
+    }]
   }
 }

--- a/lib/blockchain/chainentry.js
+++ b/lib/blockchain/chainentry.js
@@ -179,7 +179,7 @@ class ChainEntry {
     this.time = block.time;
     this.bits = block.bits;
     this.nonce = block.nonce;
-    this.height = prev ? prev.height + 1: 0;
+    this.height = prev ? prev.height + 1 : 0;
     this.chainwork = this.getChainwork(prev);
     return this;
   }

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -172,7 +172,7 @@ class FullNode extends Node {
     }
 
     if (this.config.bool('index-address')) {
-      this.addrindex= new AddrIndexer({
+      this.addrindex = new AddrIndexer({
         network: this.network,
         logger: this.logger,
         blocks: this.blocks,

--- a/lib/primitives/address.js
+++ b/lib/primitives/address.js
@@ -290,7 +290,7 @@ class Address {
 
     // Otherwise, it's most likely bech32.
     try {
-      try{
+      try {
         return this.fromBech32(addr, network);
       } catch (e) {
         return this.fromBech32m(addr, network);

--- a/test/address-test.js
+++ b/test/address-test.js
@@ -57,7 +57,7 @@ describe('Address', function() {
                           + '084861c5c3291ccffef4ec687441048d2455d240'
                           + '3e08708fc1f556002f1b6cd83f992d085097f997'
                           + '4ab08a28838f07896fbab08f39495e15fa6fad6e'
-                          + 'dbfb1e754e35fa1c7844c41f322a1863d4621353ae','hex');
+                          + 'dbfb1e754e35fa1c7844c41f322a1863d4621353ae', 'hex');
     const script = Script.fromRaw(p2sh);
     const addr = Address.fromScript(script);
     const expectedAddr = '3QJmV3qfvL9SuYo34YihAf3sRCW3qSinyC';

--- a/test/net-test.js
+++ b/test/net-test.js
@@ -782,7 +782,7 @@ describe('Net', function() {
 
         try {
           await peer.handlePacket();
-        } catch(e) {
+        } catch (e) {
           err = e;
         }
 

--- a/test/node-rpc-test.js
+++ b/test/node-rpc-test.js
@@ -85,7 +85,7 @@ describe('RPC', function() {
     it('should rpc getchaintips for chain fork', async () => {
       // function to generate blocks
       const generateblocks = async (height, entry) => {
-        for (let i = 0; i <= height; i ++) {
+        for (let i = 0; i <= height; i++) {
           const block = await node.miner.mineBlock(entry);
           entry = await node.chain.add(block);
         }

--- a/test/outpoint-test.js
+++ b/test/outpoint-test.js
@@ -14,7 +14,7 @@ describe('Outpoint', () => {
   let raw1, tx1, out1;
   beforeEach(() => {
     tx1 = common.readTX('tx1').getRaw();
-    raw1 = tx1.slice(5, 5+OUTPOINT_SIZE);
+    raw1 = tx1.slice(5, 5 + OUTPOINT_SIZE);
     out1 = Outpoint.fromRaw(raw1);
   });
 

--- a/test/pow-test.js
+++ b/test/pow-test.js
@@ -80,7 +80,7 @@ describe('Difficulty', function() {
       prev.time = 1269211443 + i * network.pow.targetSpacing;
       prev.bits = 0x207fffff;
       if (i > 0)
-        prev.chainwork = prev.getProof().addn(blocks[i-1].chainwork.toNumber());
+        prev.chainwork = prev.getProof().addn(blocks[i - 1].chainwork.toNumber());
       blocks[i] = prev;
     }
 

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -1815,7 +1815,7 @@ describe('Wallet', function() {
 
         const key2 = await wallet.getKey(address);
         assert(key2, `Could not get key for ${address.toString()}` +
-          `, Key: xpub/${type.branch}/${i+1}`);
+          `, Key: xpub/${type.branch}/${i + 1}`);
 
         assert.strictEqual(key2.name, key1.name);
         assert.strictEqual(key2.account, key1.account);


### PR DESCRIPTION
Added new rules to eslint config [spaces after keywords like if, for, etc](https://eslint.org/docs/rules/keyword-spacing), [spaces between operators and operands](https://eslint.org/docs/rules/space-infix-ops), [space after commas](https://eslint.org/docs/rules/comma-spacing) and [no spaces between unary operator and operand](https://eslint.org/docs/rules/space-unary-ops). The second commit fixes the errors due to new rules.