### PR TITLE
Compact blocks tests: Switching bandwidth modes

### DIFF
--- a/lib/net/peer.js
+++ b/lib/net/peer.js
@@ -1642,13 +1642,6 @@ class Peer extends EventEmitter {
    */
 
   async handleSendCmpct(packet) {
-    if (this.compactMode !== -1) {
-      this.logger.debug(
-        'Peer sent a duplicate sendcmpct (%s).',
-        this.hostname());
-      return;
-    }
-
     if (packet.version > 2) {
       // Ignore
       this.logger.info(

--- a/lib/net/peer.js
+++ b/lib/net/peer.js
@@ -1642,7 +1642,8 @@ class Peer extends EventEmitter {
    */
 
   async handleSendCmpct(packet) {
-    if (packet.version > 2) {
+    // Only support compact block relay with witnesses
+    if (packet.version !== 2) {
       // Ignore
       this.logger.info(
         'Peer request compact blocks version %d (%s).',

--- a/test/net-test.js
+++ b/test/net-test.js
@@ -1245,25 +1245,41 @@ describe('Net', function() {
         const peer = Peer.fromOptions({});
         assert.equal(peer.compactMode, -1);
 
-        const pkt = new packets.SendCmpctPacket(0, 1);
+        const pkt = new packets.SendCmpctPacket(0, 2);
         await peer.handleSendCmpct(pkt);
         assert.equal(peer.compactMode, 0);
 
-        const pkt2 = new packets.SendCmpctPacket(1, 1);
+        const pkt2 = new packets.SendCmpctPacket(1, 2);
         await peer.handleSendCmpct(pkt2);
         assert.equal(peer.compactMode, 1);
       });
 
+      it('should ignore duplicate sendcmpct (v2 to v1)', async () => {
+        const peer = Peer.fromOptions({});
+        assert.equal(peer.compactMode, -1);
+        assert.equal(peer.compactWitness, false);
+
+        const pkt = new packets.SendCmpctPacket(0, 2);
+        await peer.handleSendCmpct(pkt);
+        assert.equal(peer.compactMode, 0);
+        assert.equal(peer.compactWitness, true);
+
+        const pkt2 = new packets.SendCmpctPacket(0, 1);
+        await peer.handleSendCmpct(pkt2);
+        assert.equal(peer.compactMode, 0);
+        assert.equal(peer.compactWitness, true);
+      });
+
       it('will set low-bandwidth mode (mode=0)', async () => {
         const peer = Peer.fromOptions({});
-        const pkt = new packets.SendCmpctPacket(0, 1);
+        const pkt = new packets.SendCmpctPacket(0, 2);
         await peer.handleSendCmpct(pkt);
         assert.equal(peer.compactMode, 0);
       });
 
       it('will set high-bandwidth mode (mode=1)', async () => {
         const peer = Peer.fromOptions({});
-        const pkt = new packets.SendCmpctPacket(1, 1);
+        const pkt = new packets.SendCmpctPacket(1, 2);
         await peer.handleSendCmpct(pkt);
         assert.equal(peer.compactMode, 1);
       });
@@ -1276,10 +1292,11 @@ describe('Net', function() {
         assert.equal(peer.compactWitness, false);
       });
 
-      it('will set witness=false (version=1)', async () => {
+      it('will ignore witness=false (version=1)', async () => {
         const peer = Peer.fromOptions({});
         const pkt = new packets.SendCmpctPacket(0, 1);
         await peer.handleSendCmpct(pkt);
+        assert.equal(peer.compactMode, -1);
         assert.equal(peer.compactWitness, false);
       });
 
@@ -1287,6 +1304,7 @@ describe('Net', function() {
         const peer = Peer.fromOptions({});
         const pkt = new packets.SendCmpctPacket(0, 2);
         await peer.handleSendCmpct(pkt);
+        assert.equal(peer.compactMode, 0);
         assert.equal(peer.compactWitness, true);
       });
 

--- a/test/net-test.js
+++ b/test/net-test.js
@@ -1241,12 +1241,17 @@ describe('Net', function() {
     });
 
     describe('handleSendCmpct (BIP152)', function() {
-      it('will not set compact mode (already set)', async () => {
+      it('switch compact blocks modes (mode=0) to (mode=1)', async () => {
         const peer = Peer.fromOptions({});
-        const pkt = new packets.SendCmpctPacket(1, 1);
-        peer.compactMode = 2;
+        assert.equal(peer.compactMode, -1);
+
+        const pkt = new packets.SendCmpctPacket(0, 1);
         await peer.handleSendCmpct(pkt);
-        assert.equal(peer.compactMode, 2);
+        assert.equal(peer.compactMode, 0);
+
+        const pkt2 = new packets.SendCmpctPacket(1, 1);
+        await peer.handleSendCmpct(pkt2);
+        assert.equal(peer.compactMode, 1);
       });
 
       it('will set low-bandwidth mode (mode=0)', async () => {

--- a/test/p2p-test.js
+++ b/test/p2p-test.js
@@ -1,0 +1,104 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const FullNode = require('../lib/node/fullnode');
+const {forValue} = require('./util/common');
+const packets = require('../lib/net/packets');
+
+describe('Compact Blocks', function() {
+  this.timeout(30000);
+
+  const node = new FullNode({
+    network: 'regtest',
+    memory: true,
+    port: 10000,
+    httpPort: 20000,
+    only: '127.0.0.1'
+  });
+
+  const node2 = new FullNode({
+    network: 'regtest',
+    memory: true,
+    listen: true
+  });
+
+  let peer;
+
+  before(async () => {
+    const waitForConnection = new Promise((resolve, reject) => {
+      node.pool.once('peer open', async (peer) => {
+        resolve(peer);
+      });
+    });
+
+    await node.open();
+    await node2.open();
+    await node.connect();
+    await node2.connect();
+    node.startSync();
+    node2.startSync();
+
+    peer = await waitForConnection;
+  });
+
+  after(async () => {
+    await node.close();
+    await node2.close();
+  });
+
+  const nodePackets = [];
+
+  node.pool.on('packet', (packet) => {
+    nodePackets.push(packet);
+  });
+
+  beforeEach(() => {
+    nodePackets.length = 0;
+  });
+
+  it('should get compact block in low bandwidth mode', async () => {
+    const block = await node2.miner.mineBlock();
+    await node2.chain.add(block);
+
+    await forValue(node.chain, 'height', node2.chain.height);
+
+    let inv = false;
+    let compactBlock = false;
+
+    for (const packet of nodePackets) {
+      if (packet.type === packets.types.INV)
+        inv = true;
+      if (packet.type === packets.types.CMPCTBLOCK)
+        compactBlock = true;
+    }
+
+    assert(inv);
+    assert(compactBlock);
+  });
+
+  it('should switch to high bandwidth mode', async () => {
+    peer.sendCompact(1);
+    node.pool.options.blockMode = 1;
+
+    const block = await node2.miner.mineBlock();
+    await node2.chain.add(block);
+
+    await forValue(node.chain, 'height', node2.chain.height);
+
+    let inv = false;
+    let compactBlock = false;
+
+    for (const packet of nodePackets) {
+      if (packet.type === packets.types.INV)
+        inv = true;
+      if (packet.type === packets.types.CMPCTBLOCK)
+        compactBlock = true;
+    }
+
+    assert(!inv);
+    assert(compactBlock);
+  });
+});


### PR DESCRIPTION
- Implemented unit and peer-to-peer tests to witness compact blocks `bandwidth switching` between 2 bcoin nodes.
- Updated `compactBlocks` implementation to support compact block relay with witnesses by default (v2).
