### PR TITLE
[wallet-RPC] Add and Cover test rescan abortrescan RPC commands

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -1290,6 +1290,16 @@ class Chain extends AsyncEmitter {
   }
 
   /**
+   * Stop rescanning Blockchain if the rescanning already triggered.
+   */
+
+  async abortRescan() {
+    if (!this.db.abortRescan) {
+      this.db.abortRescan = true;
+    }
+  }
+
+  /**
    * Add a block to the chain, perform all necessary verification.
    * @param {Block} block
    * @param {Number?} flags

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -49,6 +49,8 @@ class ChainDB {
 
     this.cacheHash = new LRU(this.options.entryCache, null, BufferMap);
     this.cacheHeight = new LRU(this.options.entryCache);
+
+    this.abortRescan = false;
   }
 
   /**
@@ -1064,8 +1066,18 @@ class ChainDB {
       throw new Error('Cannot rescan an alternate chain.');
 
     let total = 0;
-
+    this.abortRescan = false;
     while (entry) {
+      if (this.abortRescan) {
+        this.logger.warning(
+          'Aborting rescan at height %d after %d blocks.',
+          entry.height,
+          total
+        );
+
+        this.abortRescan = false;
+        return;
+      }
       const block = await this.getBlock(entry.hash);
       const txs = [];
 

--- a/lib/client/node.js
+++ b/lib/client/node.js
@@ -311,6 +311,15 @@ class NodeClient extends Client {
 
     return this.call('rescan', start);
   }
+
+  /**
+   * Abort scanning blockchain
+   * @returns {Promise}
+   */
+
+  abortRescan() {
+    return this.call('abortrescan');
+  }
 }
 
 /*

--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -525,6 +525,10 @@ class HTTP extends Server {
 
       return this.scan(socket, start);
     });
+
+    socket.hook('abortrescan', () => {
+      return this.chain.abortRescan();
+    });
   }
 
   /**

--- a/lib/wallet/client.js
+++ b/lib/wallet/client.js
@@ -77,6 +77,10 @@ class WalletClient extends NodeClient {
 
     return super.rescan(start);
   }
+
+  abortRescan() {
+    return super.abortRescan();
+  }
 }
 
 /*

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -207,6 +207,17 @@ class HTTP extends Server {
       await this.wdb.rescan(height);
     });
 
+    // Abort rescan
+    this.post('/abortrescan', (req, res) => {
+      if (!req.admin) {
+        res.json(403);
+        return;
+      }
+
+      this.wdb.abortRescan();
+      res.json(200, { success: true });
+    });
+
     // Resend
     this.post('/resend', async (req, res) => {
       if (!req.admin) {

--- a/lib/wallet/nodeclient.js
+++ b/lib/wallet/nodeclient.js
@@ -215,6 +215,15 @@ class NodeClient extends AsyncEmitter {
       return this.emitAsync('block rescan', entry, txs);
     });
   }
+
+  /**
+   * stop rescanning the blockchain
+   * @returns {Promise}
+   */
+
+  abortRescan() {
+    return this.node.chain.abortRescan();
+  }
 }
 
 /*

--- a/lib/wallet/nullclient.js
+++ b/lib/wallet/nullclient.js
@@ -162,6 +162,15 @@ class NullClient extends EventEmitter {
   async rescan(start) {
     ;
   }
+
+  /**
+   * Abort rescan
+   * @returns {Promise}
+   */
+
+  async abortRescan() {
+    ;
+  }
 }
 
 /*

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -128,6 +128,8 @@ class RPC extends RPCBase {
     this.add('dumpprivkey', this.dumpPrivKey);
     this.add('dumpwallet', this.dumpWallet);
     this.add('encryptwallet', this.encryptWallet);
+    this.add('rescan', this.rescan);
+    this.add('abortrescan', this.abortrescan);
     this.add('getaddressinfo', this.getAddressInfo);
     this.add('getaccountaddress', this.getAccountAddress);
     this.add('getaccount', this.getAccount);
@@ -350,6 +352,27 @@ class RPC extends RPCBase {
     await fs.writeFile(file, dump, 'utf8');
 
     return null;
+  }
+
+  async rescan(args, help) {
+    if (help || args.length > 1)
+      throw new RPCError(errs.MISC_ERROR, 'rescan ( "height" )');
+
+    const valid = new Validator(args);
+    const height = valid.u32(0, 0);
+
+    await this.wdb.rescan(height);
+  }
+
+  abortrescan(args, help) {
+    if (help || args.length > 0)
+      throw new RPCError(errs.MISC_ERROR, 'abortrescan');
+
+    if (!this.wdb.rescanning)
+      throw new RPCError(errs.WALLET_ERROR, 'WalletDB is not rescanning.');
+
+    this.wdb.abortRescan();
+    return true;
   }
 
   async encryptWallet(args, help) {

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -485,6 +485,14 @@ class WalletDB extends EventEmitter {
   }
 
   /**
+   * Abort Rescanning.
+   */
+
+  abortRescan() {
+    return this.client.abortRescan();
+  }
+
+  /**
    * Broadcast a transaction via chain server.
    * @param {TX} tx
    * @returns {Promise}


### PR DESCRIPTION
## RPC commands
- `rescan` make wallets rolled back to the specified height and check the blockchain for transactions containing specified address hashes. 
- `abortrescan` allows users to stop rescanning process triggered by the `rescan` RPC command.