### PR TITLE
Sending compactBlocks via HighBW Peers

### DIFF
--- a/lib/net/common.js
+++ b/lib/net/common.js
@@ -79,6 +79,22 @@ exports.COMPACT_VERSION = 70014;
 exports.COMPACT_WITNESS_VERSION = 70015;
 
 /**
+ * Compact blocks low bandwidth mode
+ * @const {Number}
+ * @default
+ */
+
+exports.COMPACT_BLOCKS_LOWBW = 0;
+
+/**
+ * Compact blocks high bandwidth mode
+ * @const {Number}
+ * @default
+ */
+
+exports.COMPACT_BLOCKS_HIGHBW = 1;
+
+/**
  * Service bits.
  * @enum {Number}
  * @default

--- a/lib/net/peer.js
+++ b/lib/net/peer.js
@@ -113,7 +113,8 @@ class Peer extends EventEmitter {
     this.hashContinue = null;
     this.spvFilter = null;
     this.feeRate = -1;
-    this.compactMode = -1;
+    this.compactModeTo = -1;
+    this.compactModeFrom = 0;
     this.compactWitness = false;
     this.merkleBlock = null;
     this.merkleTime = -1;
@@ -528,7 +529,7 @@ class Peer extends EventEmitter {
 
       // Send them the block immediately if
       // they're using compact block mode 1.
-      if (this.compactMode === 1) {
+      if (this.compactModeTo === 1) {
         this.invFilter.add(block.hash());
         this.sendCompactBlock(block);
         continue;
@@ -1662,7 +1663,7 @@ class Peer extends EventEmitter {
       'Peer initialized compact blocks (mode=%d, version=%d) (%s).',
       packet.mode, packet.version, this.hostname());
 
-    this.compactMode = packet.mode;
+    this.compactModeTo = packet.mode;
     this.compactWitness = packet.version === 2;
   }
 
@@ -1895,7 +1896,7 @@ class Peer extends EventEmitter {
    */
 
   hasCompact() {
-    if (this.compactMode === -1)
+    if (this.compactModeFrom === -1)
       return false;
 
     if (!this.options.hasWitness())

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -2997,6 +2997,22 @@ class Pool extends EventEmitter {
   }
 
   /**
+   * Find oldest outbound peer.
+   * @param {Peer} peer
+   */
+
+  findOldestHBOutbound() {
+    if (this.highBWPeers.outbound > 1) {
+      for (let peer = this.highBWPeers.head(); peer; peer = peer.next) {
+        if (peer.outbound) {
+          return peer;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
    * Attempt to refill the pool with peers (no lock).
    * @private
    */

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -3528,6 +3528,139 @@ class Pool extends EventEmitter {
 
     return enabled;
   }
+
+  /**
+   * Selects peers for highBW mode - BIP152
+  */
+
+  async setHighBWPeer(peer) {
+    //before adding peer to the list, checking whether the peer is un-destroyed
+    let peerStatus = false;
+    try {
+      await peer.handlePacket();
+      peerStatus = true;
+    } catch(e) {
+      console.log(e)
+    }
+
+    this.bindPeer(peer);
+
+    if (peerStatus) {
+      if (peer.inbound) {
+        // remove oldest outbound iff there exists atleast 1 outbound peer.
+        if (this.highBWPeers.size() < this.highBWMax && this.highBWPeers.outbound <= 1) {
+          // simply add the new peer to the peer list
+          this.highBWPeers.add(peer);
+            peer.compactModeFrom = common.COMPACT_BLOCKS_HIGHBW;
+            peer.sendCompact(peer.compactModeFrom);
+        }
+
+        else if (this.highBWPeers.size() > this.highBWMax) {
+          // remove the oldest peer
+          this.highBWPeers.remove(this.highBWPeers.head());
+            peer.compactModeFrom = common.COMPACT_BLOCKS_LOWBW;
+            peer.sendCompact(peer.compactModeFrom);
+
+          // add the new peer
+          this.highBWPeers.add(peer);
+            peer.compactModeFrom = common.COMPACT_BLOCKS_HIGHBW;
+            peer.sendCompact(peer.compactModeFrom);
+        }
+        else {
+          const OldestOutboundPeer = this.findOldestHBOutbound();
+
+          // if the peer exists remove that peer
+          if (OldestOutboundPeer != null) {
+            // sending cmpct block mode=0 on removal from highBW Peers list
+            // sending cmpct block mode=1 on addition to highBW Peers list
+            this.highBWPeers.remove(OldestOutboundPeer);
+              peer.compactModeFrom = common.COMPACT_BLOCKS_LOWBW;
+              peer.sendCompact(peer.compactModeFrom);
+
+            // if the size < 3, simply add to the peer list
+            if (this.highBWPeers.size() < this.highBWMax) {
+              this.highBWPeers.add(peer);
+                peer.compactModeFrom = common.COMPACT_BLOCKS_HIGHBW;
+                peer.sendCompact(peer.compactModeFrom);
+            }
+            else if (this.highBWPeers.size() > this.highBWMax) {
+              // if the size > 3, remove the oldest peer and add the new peer
+              this.highBWPeers.remove(this.highBWPeers.head());
+                peer.compactModeFrom = common.COMPACT_BLOCKS_LOWBW;
+                peer.sendCompact(peer.compactModeFrom);
+
+              this.highBWPeers.add(peer);
+                peer.compactModeFrom = common.COMPACT_BLOCKS_HIGHBW;
+                peer.sendCompact(peer.compactModeFrom);
+            }
+          }
+        }
+      }
+
+      if (peer.outbound) {
+        if (this.highBWPeers.size() < this.highBWMax && this.highBWPeers.outbound <= 1) {
+          this.highBWPeers.add(peer);
+            peer.compactModeFrom = common.COMPACT_BLOCKS_HIGHBW;
+            peer.sendCompact(peer.compactModeFrom);
+        }
+        else if (this.highBWPeers.size() > this.highBWMax) {
+          this.highBWPeers.remove(this.highBWPeers.head());
+            peer.compactModeFrom = common.COMPACT_BLOCKS_LOWBW;
+            peer.sendCompact(peer.compactModeFrom);
+
+          this.highBWPeers.add(peer);
+            peer.compactModeFrom = common.COMPACT_BLOCKS_HIGHBW;
+            peer.sendCompact(peer.compactModeFrom);
+        }
+        else {
+          const OldestOutboundPeer = this.findOldestHBOutbound();
+
+          if (OldestOutboundPeer != null) {
+            this.highBWPeers.remove(OldestOutboundPeer);
+              peer.compactModeFrom = common.COMPACT_BLOCKS_LOWBW;
+              peer.sendCompact(peer.compactModeFrom);
+
+            if (this.highBWPeers.size() < this.highBWMax) {
+              this.highBWPeers.add(peer);
+                peer.compactModeFrom = common.COMPACT_BLOCKS_HIGHBW;
+                peer.sendCompact(peer.compactModeFrom);
+            }
+
+            else if (this.highBWPeers.size() > this.highBWMax) {
+              // remove the oldest peer
+              this.highBWPeers.remove(this.highBWPeers.head());
+                peer.compactModeFrom = common.COMPACT_BLOCKS_LOWBW;
+                peer.sendCompact(peer.compactModeFrom);
+
+              this.highBWPeers.add(peer);
+                peer.compactModeFrom = common.COMPACT_BLOCKS_HIGHBW;
+                peer.sendCompact(peer.compactModeFrom);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Removes a highBW peer.
+   */
+
+  async removeHighBWPeer(peer) {
+    let peerStatus = false;
+    try {
+      await peer.handlePacket();
+      peerStatus = true;
+    } catch(e) {
+      console.log(e)
+    }
+
+    if (peerStatus && this.highBWPeers.includes(peer)) {
+      this.highBWPeers.remove(peer);
+        peer.compactModeFrom = common.COMPACT_BLOCKS_LOWBW;
+        peer.sendCompact(peer.compactModeFrom);
+    }
+  }
 }
 
 /**

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -84,6 +84,9 @@ class Pool extends EventEmitter {
     this.hosts = new HostList(this.options);
     this.id = 0;
 
+    this.highBWPeers = new PeerList();
+    this.highBWMax = 3;
+
     if (this.options.spv) {
       this.spvFilter = BloomFilter.fromRate(
         20000, 0.001, BloomFilter.flags.ALL);
@@ -294,6 +297,7 @@ class Pool extends EventEmitter {
     this.disconnecting = true;
 
     this.peers.destroy();
+    this.highBWPeers.destroy();
 
     this.blockMap.clear();
     this.txMap.clear();
@@ -1276,7 +1280,7 @@ class Pool extends EventEmitter {
 
     // We want compact blocks!
     if (this.options.compact)
-      peer.sendCompact(this.options.blockMode);
+      peer.sendCompact(peer.compactModeFrom);
 
     // Find some more peers.
     if (!this.hosts.isFull())

--- a/test/net-test.js
+++ b/test/net-test.js
@@ -1243,30 +1243,30 @@ describe('Net', function() {
     describe('handleSendCmpct (BIP152)', function() {
       it('switch compact blocks modes (mode=0) to (mode=1)', async () => {
         const peer = Peer.fromOptions({});
-        assert.equal(peer.compactMode, -1);
+        assert.equal(peer.compactModeTo, -1);
 
         const pkt = new packets.SendCmpctPacket(0, 2);
         await peer.handleSendCmpct(pkt);
-        assert.equal(peer.compactMode, 0);
+        assert.equal(peer.compactModeTo, 0);
 
         const pkt2 = new packets.SendCmpctPacket(1, 2);
         await peer.handleSendCmpct(pkt2);
-        assert.equal(peer.compactMode, 1);
+        assert.equal(peer.compactModeTo, 1);
       });
 
       it('should ignore duplicate sendcmpct (v2 to v1)', async () => {
         const peer = Peer.fromOptions({});
-        assert.equal(peer.compactMode, -1);
+        assert.equal(peer.compactModeTo, -1);
         assert.equal(peer.compactWitness, false);
 
         const pkt = new packets.SendCmpctPacket(0, 2);
         await peer.handleSendCmpct(pkt);
-        assert.equal(peer.compactMode, 0);
+        assert.equal(peer.compactModeTo, 0);
         assert.equal(peer.compactWitness, true);
 
         const pkt2 = new packets.SendCmpctPacket(0, 1);
         await peer.handleSendCmpct(pkt2);
-        assert.equal(peer.compactMode, 0);
+        assert.equal(peer.compactModeTo, 0);
         assert.equal(peer.compactWitness, true);
       });
 
@@ -1274,21 +1274,21 @@ describe('Net', function() {
         const peer = Peer.fromOptions({});
         const pkt = new packets.SendCmpctPacket(0, 2);
         await peer.handleSendCmpct(pkt);
-        assert.equal(peer.compactMode, 0);
+        assert.equal(peer.compactModeTo, 0);
       });
 
       it('will set high-bandwidth mode (mode=1)', async () => {
         const peer = Peer.fromOptions({});
         const pkt = new packets.SendCmpctPacket(1, 2);
         await peer.handleSendCmpct(pkt);
-        assert.equal(peer.compactMode, 1);
+        assert.equal(peer.compactModeTo, 1);
       });
 
       it('will not set compact mode (mode=2)', async () => {
         const peer = Peer.fromOptions({});
         const pkt = new packets.SendCmpctPacket(2, 1);
         await peer.handleSendCmpct(pkt);
-        assert.equal(peer.compactMode, -1);
+        assert.equal(peer.compactModeTo, -1);
         assert.equal(peer.compactWitness, false);
       });
 
@@ -1296,7 +1296,7 @@ describe('Net', function() {
         const peer = Peer.fromOptions({});
         const pkt = new packets.SendCmpctPacket(0, 1);
         await peer.handleSendCmpct(pkt);
-        assert.equal(peer.compactMode, -1);
+        assert.equal(peer.compactModeTo, -1);
         assert.equal(peer.compactWitness, false);
       });
 
@@ -1304,7 +1304,7 @@ describe('Net', function() {
         const peer = Peer.fromOptions({});
         const pkt = new packets.SendCmpctPacket(0, 2);
         await peer.handleSendCmpct(pkt);
-        assert.equal(peer.compactMode, 0);
+        assert.equal(peer.compactModeTo, 0);
         assert.equal(peer.compactWitness, true);
       });
 
@@ -1312,7 +1312,7 @@ describe('Net', function() {
         const peer = Peer.fromOptions({});
         const pkt = new packets.SendCmpctPacket(0, 3);
         await peer.handleSendCmpct(pkt);
-        assert.equal(peer.compactMode, -1);
+        assert.equal(peer.compactModeTo, -1);
         assert.equal(peer.compactWitness, false);
       });
     });


### PR DESCRIPTION
- Changed implementation of compact blocks from `compactMode` to `compactModeTo` and `compactModeFrom`.
- Created a highBW Peer List to incorporate highBW compact blocks sending peers.
- Created function `setHighBWPeer` that checks if the peer is `inbound` or `outbound`, effectively responding with appropriate `compactBlock` request. (HighBW or LowBW). 
- Created function `removeHighBWPeer` to remove a highBW peer from the peer list. 
- Added compact blocks constants - `COMPACT_BLOCKS_HIGHBW` and `COMPACT_BLOCKS_LOWBW` in `common.js` to change `peer.sendCompact` nature.
- [ ]  Added test to test out the functionality.