### PR TITLE
Fixed getnettotals test

### DIFF
--- a/test/node-rpc-test.js
+++ b/test/node-rpc-test.js
@@ -31,7 +31,8 @@ const node = new FullNode({
   env: {
     'BCOIN_WALLET_HTTP_PORT': ports.wallet.toString()
   },
-  listen: true
+  listen: true,
+  publicHost: '123.123.123.123'
 });
 
 const nclient = new NodeClient({


### PR DESCRIPTION
This PR fixes the `getnettotals with peer` test in `node-rpc-test.js` . 
The test previously failed when ran in an environment where the access to any external DNS was not available(There was a size mismatch due to addr packet not being sent). 