### PR TITLE
Integration tests will not run by default locally but will run on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "test-browser": "NODE_BACKEND=js bmocha --reporter spec test/*.js",
     "test-file": "bmocha --reporter spec",
     "test-file-browser": "NODE_BACKEND=js bmocha --reporter spec",
-    "test-ci": "nyc -a -n 'lib/**/*.js' --reporter=lcov --reporter=text npm run test"
+    "test-ci": "BCOIN_RUN_LONG_TESTS=true nyc -a -n 'lib/**/*.js' --reporter=lcov --reporter=text npm run test"
   },
   "browser": {
     "./lib/hd/nfkd": "./lib/hd/nfkd-compat.js",

--- a/test/coinselector-test.js
+++ b/test/coinselector-test.js
@@ -200,7 +200,10 @@ describe('Coin Selector', function () {
 });
 
 describe('Integration', function () {
-  this.timeout(360000);
+  if (!process.env.BCOIN_RUN_LONG_TESTS)
+    this.skip();
+
+  this.timeout(0);
 
   const workers = new WorkerPool({
     enabled: true,


### PR DESCRIPTION
- added `BCOIN_RUN_LONG_TESTS` to `package.json` which defaults to `true` when running `npm run test-ci`
- modified wallet integration tests to run only on CI

To run integration tests locally, you can run `export BCOIN_RUN_LONG_TESTS=true` before running the tests.

If a test needs to be only run on CI in the future then we can use:
```js
  if (!process.env.BCOIN_RUN_LONG_TESTS)
    this.skip();
```