### PR TITLE
http: fix getinfo from updated filter indexers

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -117,6 +117,15 @@ class HTTP extends Server {
 
       let addr = this.pool.hosts.getLocal();
 
+      const filter = {};
+      for (const type of this.node.filterIndexers.keys()) {
+        const indexer = this.node.filterIndexers.get(type);
+        filter[type] = {
+          enabled: true,
+          height: indexer.height
+        };
+      }
+
       if (!addr)
         addr = this.pool.hosts.address;
 
@@ -137,10 +146,7 @@ class HTTP extends Server {
             enabled: Boolean(this.node.txindex),
             height: this.node.txindex ? this.node.txindex.height : 0
           },
-          filter: {
-            enabled: Boolean(this.node.filterindex),
-            height: this.node.filterindex ? this.node.filterindex.height : 0
-          }
+          filter
         },
         pool: {
           host: addr.host,

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -14,6 +14,7 @@ const Block = require('../lib/primitives/block');
 const Golomb = require('../lib/golomb/golomb');
 const {U64} = require('n64');
 const BasicFilter = require('../lib/golomb/basicFilter');
+const {NodeClient} = require('../lib/client');
 
 class TestFilter extends Golomb {
   constructor() {
@@ -333,5 +334,27 @@ describe('Filter', function() {
       'hex'
     );
     assert.bufferEqual(actual, expected);
+  });
+
+  describe('HTTP', function() {
+    const nclient = new NodeClient({
+      port: node.network.rpcPort
+    });
+
+    it('should get info', async () => {
+      const info = await nclient.getInfo();
+      const {indexes} = info;
+      const {filter} = indexes;
+
+      assert.strictEqual(Object.keys(filter).length, 2);
+
+      assert(filter.BASIC);
+      assert(filter.BASIC.enabled);
+      assert.strictEqual(filter.BASIC.height, node.chain.height);
+
+      assert(filter.TEST);
+      assert(filter.TEST.enabled);
+      assert.strictEqual(filter.TEST.height, node.chain.height);
+    });
   });
 });

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -342,9 +342,7 @@ describe('Filter', function() {
     });
 
     it('should get info', async () => {
-      const info = await nclient.getInfo();
-      const {indexes} = info;
-      const {filter} = indexes;
+      const {indexes: {filter}} = await nclient.getInfo();
 
       assert.strictEqual(Object.keys(filter).length, 2);
 

--- a/test/indexer-test.js
+++ b/test/indexer-test.js
@@ -996,8 +996,7 @@ describe('Indexer', function() {
     before(async () => {
       this.timeout(120000);
 
-      // Setup a testing node with txindex and addrindex
-      // both enabled.
+      // Setup a testing node with txindex, addrindex and filterindex enabled.
       node = new FullNode({
         network: 'regtest',
         apiKey: 'foo',
@@ -1007,6 +1006,7 @@ describe('Indexer', function() {
         workersSize: 2,
         indexTX: true,
         indexAddress: true,
+        indexFilter: true,
         port: ports.p2p,
         httpPort: ports.node,
         plugins: [require('../lib/wallet/plugin')],
@@ -1354,6 +1354,18 @@ describe('Indexer', function() {
           assert(unconfirmed.includes(all[i].hash));
 
         assert.deepEqual(sanitize(one.concat(two)), sanitize(all));
+      });
+
+      it('should get info', async () => {
+        const info = await nclient.getInfo();
+        const {indexes} = info;
+        const {filter} = indexes;
+
+        assert.strictEqual(Object.keys(filter).length, 1);
+
+        assert(filter.BASIC);
+        assert(filter.BASIC.enabled);
+        assert.strictEqual(filter.BASIC.height, node.chain.height);
       });
     }
 

--- a/test/indexer-test.js
+++ b/test/indexer-test.js
@@ -1357,9 +1357,7 @@ describe('Indexer', function() {
       });
 
       it('should get info', async () => {
-        const info = await nclient.getInfo();
-        const {indexes} = info;
-        const {filter} = indexes;
+        const {indexes: {filter}} = await nclient.getInfo();
 
         assert.strictEqual(Object.keys(filter).length, 1);
 

--- a/test/node-http-test.js
+++ b/test/node-http-test.js
@@ -79,6 +79,7 @@ describe('Node HTTP', function() {
     assert(typeof info.indexes.tx === 'object');
     assert.equal(info.indexes.addr.enabled, false);
     assert.equal(info.indexes.tx.height, 0);
+    assert.deepStrictEqual(info.indexes.filter, {});
   });
 
   it('should execute an rpc call', async () => {


### PR DESCRIPTION
Since the filter indexers have been refactored, we missed one affected module: the http info response.

Tests are a bit spread out, but cover 0, 1 and 2 filter indexers.

`bcoin-cli info`

OLD:

```
  "indexes": {
    "addr": {
      "enabled": true,
      "height": 221063
    },
    "tx": {
      "enabled": true,
      "height": 243394
    },
    "filter": {
      "enabled": false,
      "height": 0
    }
  },
```

NEW:

```
  "indexes": {
    "addr": {
      "enabled": true,
      "height": 222851
    },
    "tx": {
      "enabled": true,
      "height": 245461
    },
    "filter": {
      "BASIC": {
        "enabled": true,
        "height": 189074
      }
    }
  },
```