### PR TITLE
Fix: Type mismatch between return types and options in HD.js and private.js

### DIFF
--- a/lib/hd/hd.js
+++ b/lib/hd/hd.js
@@ -46,7 +46,7 @@ HD.generate = function generate() {
 
 /**
  * Generate an {@link HDPrivateKey} from a seed.
- * @param {Object|Mnemonic|Buffer} options - seed,
+ * @param {Buffer} options - seed,
  * mnemonic, mnemonic options.
  * @returns {HDPrivateKey}
  */
@@ -57,7 +57,7 @@ HD.fromSeed = function fromSeed(options) {
 
 /**
  * Instantiate an hd private key from a mnemonic.
- * @param {Mnemonic|Object} mnemonic
+ * @param {Mnemonic} mnemonic
  * @returns {HDPrivateKey}
  */
 

--- a/lib/hd/hd.js
+++ b/lib/hd/hd.js
@@ -46,13 +46,12 @@ HD.generate = function generate() {
 
 /**
  * Generate an {@link HDPrivateKey} from a seed.
- * @param {Buffer} options - seed,
- * mnemonic, mnemonic options.
+ * @param {Buffer} seed - seed,
  * @returns {HDPrivateKey}
  */
 
-HD.fromSeed = function fromSeed(options) {
-  return HDPrivateKey.fromSeed(options);
+HD.fromSeed = function fromSeed(seed) {
+  return HDPrivateKey.fromSeed(seed);
 };
 
 /**

--- a/lib/hd/hd.js
+++ b/lib/hd/hd.js
@@ -56,12 +56,12 @@ HD.fromSeed = function fromSeed(seed) {
 
 /**
  * Instantiate an hd private key from a mnemonic.
- * @param {Mnemonic} mnemonic
+ * @param {Mnemonic} mnemonic - mnemonic
  * @returns {HDPrivateKey}
  */
 
-HD.fromMnemonic = function fromMnemonic(options) {
-  return HDPrivateKey.fromMnemonic(options);
+HD.fromMnemonic = function fromMnemonic(mnemonic) {
+  return HDPrivateKey.fromMnemonic(mnemonic);
 };
 
 /**


### PR DESCRIPTION
Fixes #1122 

This patch fixes the issue described by changing the parameter types according the corresponding method called, as suggested in the issue solution.