### PR TITLE
Fix: readd old algorithm to fix progress for SPV nodes

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2035,6 +2035,13 @@ class Chain extends AsyncEmitter {
    */
 
   getProgress() {
+    if (this.options.spv) {
+      const start = this.network.genesis.time;
+      const current = this.tip.time - start;
+      const end = util.now() - start - 40 * 60;
+      return Math.min(1, current / end);
+    }
+
     const time = util.now();
 
     const currentCount = this.db.state.tx;


### PR DESCRIPTION
As discussed in #1110 , there was a problem with the sync progress for SPV nodes. This PR readds the old algorithm just for SPV nodes. 