### PR TITLE
Adds descriptor module with getdescriptorinfo rpc

### DIFF
--- a/lib/bcoin.js
+++ b/lib/bcoin.js
@@ -75,8 +75,23 @@ bcoin.define('Coins', './coins/coins');
 bcoin.define('CoinEntry', './coins/coinentry');
 bcoin.define('CoinView', './coins/coinview');
 
+// Descriptor
+bcoin.define('descriptor', './descriptor');
+bcoin.define('AddressDescriptor', './descriptor/type/addr');
+bcoin.define('ComboDescriptor', './descriptor/type/combo');
+bcoin.define('MultisigDescriptor', './descriptor/type/multisig');
+bcoin.define('PKDescriptor', './descriptor/type/pk');
+bcoin.define('PKHDescriptor', './descriptor/type/pkh');
+bcoin.define('RawDescriptor', './descriptor/type/raw');
+bcoin.define('SHDescriptor', './descriptor/type/sh');
+bcoin.define('WPKHDescriptor', './descriptor/type/wpkh');
+bcoin.define('WSHDescriptor', './descriptor/type/wsh');
+bcoin.define('KeyProvider', './descriptor/keyprovider');
+bcoin.define('parser', './descriptor/parser');
+
 // HD
 bcoin.define('hd', './hd');
+bcoin.define('KeyOriginInfo', './hd/keyorigininfo');
 bcoin.define('HDPrivateKey', './hd/private');
 bcoin.define('HDPublicKey', './hd/public');
 bcoin.define('Mnemonic', './hd/mnemonic');

--- a/lib/descriptor/abstractdescriptor.js
+++ b/lib/descriptor/abstractdescriptor.js
@@ -1,0 +1,241 @@
+/*!
+ * abstractdescriptor.js - abstract descriptor object for bcoin
+ * Copyright (c) 2023, the bcoin developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const assert = require('bsert');
+const common = require('./common');
+const Network = require('../protocol/network');
+const KeyProvider = require('./keyprovider');
+
+/**
+ * Constants
+ */
+
+/**
+ * String type for key in a descriptor.
+ * stringType.PUBLIC for descriptor with public key(s)
+ * stringType.PRIVATE for descriptor with private key(s)
+ * @const {Object}
+ */
+
+const stringType = {
+  PUBLIC: 'PUBLIC',
+  PRIVATE: 'PRIVATE'
+};
+
+/**
+ * AbstractDescriptor
+ * The class which all descriptor-like objects inherit from.
+ * Represents an output script.
+ * @alias module:descriptor.AbstractDescriptor
+ * @see https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
+ * @property {String} type - script expression of descriptor function.
+ * @property {KeyProvider[]} keyProviders - parsed key arguments
+ * for the descriptor
+ * (size 1 for PK, PKH, WPKH; any size for WSH and Multisig).
+ * @property {AbstractDescriptor[]} subdescriptors - sub-descriptor arguments
+ * for the descriptor (empty for everything but SH and WSH)
+ * @property {Network} network
+ */
+
+class AbstractDescriptor {
+  /**
+   * Create a abstract descriptor.
+   * @constructor
+   */
+
+  constructor() {
+    this.type = null;
+    this.keyProviders = [];
+    this.subdescriptors = [];
+    this.network = null;
+  }
+
+  /**
+   * Inject properties from options object.
+   * @param {Object} options
+   * @returns {AbstractDescriptor}
+   */
+
+  fromOptions(options) {
+    throw new Error('Abstract method.');
+  }
+
+  /**
+   * Inject properties from string.
+   * @param {String} desc
+   * @returns {AbstractDescriptor}
+   */
+
+  fromString(desc) {
+    throw new Error('Abstract method.');
+  }
+
+  /**
+   * Inject properties from options object.
+   * @private
+   * @param {Object} options
+   */
+
+  parseOptions(options) {
+    assert(options, 'Required options for descriptor');
+
+    this.network = Network.get(options.network);
+
+    if (options.keyProviders) {
+      assert(Array.isArray(options.keyProviders));
+      for (const provider of options.keyProviders) {
+        assert(provider instanceof KeyProvider);
+        assert(provider.network === this.network);
+      }
+      this.keyProviders = options.keyProviders;
+    }
+
+    if (options.subdescriptors) {
+      assert(Array.isArray(options.subdescriptors));
+      for (const desc of options.subdescriptors) {
+        assert(desc instanceof AbstractDescriptor);
+        assert(desc.network === this.network);
+      }
+      this.subdescriptors = options.subdescriptors;
+    }
+
+    return this;
+  }
+
+  /**
+   * Test whether the descriptor contains any private key.
+   * @returns {Boolean}
+   */
+
+  hasPrivateKeys() {
+    return this.keyProviders.some(key => key.hasPrivateKey())
+      || this.subdescriptors.some(desc => desc.hasPrivateKeys());
+  }
+
+  /**
+   * Test whether the descriptor contains public/private keys
+   * in the form of HD chains
+   * @returns {Boolean}
+   */
+
+  isRange() {
+    return this.keyProviders.some(key => key.isRange())
+      || this.subdescriptors.some(desc => desc.isRange());
+  }
+
+  /**
+   * Whether this descriptor has all information about signing
+   * (ignoring private keys).
+   * Returns false only for `addr` and `raw` type.
+   * @returns {Boolean}
+   */
+
+  isSolvable() {
+    return this.subdescriptors.every(desc => desc.isSolvable());
+  }
+
+  /**
+   * Get string form for address and raw descriptors.
+   * Also returns threshold string for multisig.
+   * Used once in toStringHelper()
+   * @returns {String}
+   */
+
+  toStringExtra() {
+    return '';
+  }
+
+  _toStringSubScript(type) {
+    let res = '';
+    let pos = 0;
+
+    for (const subdesc of this.subdescriptors) {
+      if (pos++) {
+        res += ',';
+      }
+      res += subdesc._toString(type);
+    }
+
+    return res;
+  }
+
+  /**
+   * Helper function to get a descriptor in string form based on string type
+   * (Public, Private, Normalized)
+   * @param {String} type
+   * @returns {String}
+   */
+
+  _toString(type) {
+    const extra = this.toStringExtra();
+    let pos = extra.length === 0 ? 0 : 1;
+    let res = this.type + '(' + extra;
+
+    for (const provider of this.keyProviders) {
+      if (pos++) {
+        res += ',';
+      }
+      switch (type) {
+        case stringType.PUBLIC:
+          res += provider.toString();
+          break;
+        case stringType.PRIVATE: {
+          const privkey = provider.toPrivateString();
+          const pubkey = provider.toString();
+          assert(privkey, `Private key not available for ${pubkey}`);
+          res += privkey;
+        }
+      }
+    }
+
+    const subdesc = this._toStringSubScript(type);
+
+    if (pos && subdesc.length) {
+      res += ',';
+    }
+
+    res += subdesc + ')';
+    return res;
+  }
+
+  /**
+   * Get a descriptor string (public keys only)
+   * @returns {String}
+   */
+
+  toString() {
+    const res = this._toString(stringType.PUBLIC);
+    return common.addChecksum(res);
+  }
+
+  /**
+   * Get descriptor string including private keys if available
+   * @returns {String}
+   */
+
+  toPrivateString() {
+    const res = this._toString(stringType.PRIVATE);
+    return common.addChecksum(res);
+  }
+
+  /**
+   * Test whether this descriptor will return one scriptPubKey or
+   * multiple (aka is or is not combo)
+   * @returns {Boolean}
+   */
+
+  isSingleType() {
+    return true;
+  }
+}
+
+/*
+ * Expose
+ */
+
+module.exports = AbstractDescriptor;

--- a/lib/descriptor/common.js
+++ b/lib/descriptor/common.js
@@ -1,0 +1,260 @@
+/*!
+ * common.js - common functions for descriptor
+ * Copyright (c) 2023, the bcoin developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const assert = require('bsert');
+const common = exports;
+
+/**
+ * Types of script expressions in descriptors
+ * @see https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md#reference
+ * @const {Object}
+ */
+
+common.types = {
+  PK: 'pk',
+  PKH: 'pkh',
+  WPKH: 'wpkh',
+  SH: 'sh',
+  WSH: 'wsh',
+  COMBO: 'combo',
+  ADDR: 'addr',
+  MULTI: 'multi',
+  SORTEDMULTI: 'sortedmulti',
+  RAW: 'raw'
+};
+
+/**
+ * Types of script expressions by value in descriptors
+ * @const {Object}
+ */
+
+common.typesByVal = {
+  pk: 'PK',
+  pkh: 'PKH',
+  wpkh: 'WPKH',
+  sh: 'SH',
+  wsh: 'WSH',
+  combo: 'COMBO',
+  addr: 'ADDR',
+  multi: 'MULTI',
+  sortedmulti: 'SORTEDMULTI',
+  raw: 'RAW'
+};
+
+/**
+ * parse script context for descriptor
+ * @const {Object}
+ */
+
+common.scriptContext = {
+  TOP: 'TOP',
+  P2SH: 'P2SH',
+  P2WPKH: 'P2WPKH',
+  P2WSH: 'P2WSH'
+};
+
+/**
+ * Allowed characters in descriptor expressions for checksum to work.
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki#character-set
+ * @const {String}
+ */
+
+const INPUT_CHARSET = '0123456789()[],\'/*abcdefgh@:$%{}IJKLMNOPQRSTUVWXYZ' +
+                       '&+-.;<=>?!^_|~ijklmnopqrstuvwxyzABCDEFGH`#"\\ ';
+
+ /**
+ * Checksum character set.
+ * The checksum itself uses the same character set as bech32
+ * @const {String}
+ */
+
+const CHECKSUM_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+
+/**
+ * Test whether this descriptor string starts with particular script type
+ * ('pk', 'pkh', 'wpkh' etc.)
+ * @param {String} scriptType script type
+ * @param {String} desc descriptor string
+ * @returns {Boolean}
+ */
+
+common.isType = function isType(scriptType, desc) {
+  assert(typeof scriptType === 'string');
+  assert(typeof desc === 'string');
+
+  /**
+   * First check whether descriptor string length is atleast greater than
+   * scriptType length + 2 (for brackets)
+   * Then check character at scriptType length is '(' and last character is ')'
+   * in descriptor string
+   * Then check whether descriptor string starts with scriptType
+   */
+
+  return desc.length >= scriptType.length + 2
+         && desc[scriptType.length] === '('
+         && desc[desc.length - 1] === ')'
+         && scriptType === desc.substring(0, scriptType.length);
+};
+
+/**
+ * Test whether a string is hex string.
+ * @param {String} str
+ * @returns {Boolean}
+ */
+
+common.isHex = function isHex(str) {
+  assert(typeof str === 'string');
+  return (str.length % 2 === 0 && /^[0-9a-fA-F]+$/.test(str)) ;
+};
+
+/**
+ * Get the top level script expression of the descriptor.
+ * @param {String} desc descriptor string
+ * @returns {String} script expression of descriptor
+ */
+
+common.getType = function getType(desc) {
+  const scriptType = desc.substring(0, desc.indexOf('('));
+
+  if (common.typesByVal[scriptType]) {
+    return scriptType;
+  }
+
+  return null;
+};
+
+/**
+ * Strip script expression string from descriptor
+ * @param {String} desc descriptor string
+ * @returns {String} descriptor string without script expression
+ */
+
+common.strip = function strip(desc) {
+  return desc.substring(desc.indexOf('(') + 1, desc.length - 1);
+};
+
+/**
+ * Internal function that computes the descriptor checksum
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki#checksum
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki
+ * @param {BigInt} c
+ * @param {BigInt} val
+ * @returns {BigInt} checksum
+ */
+
+function polyMod(c, val) {
+  const c0 = c >> 35n;
+  c = ((c & 0x7ffffffffn) << 5n) ^ val;
+
+  if (c0 & 1n)
+    c ^= 0xf5dee51989n;
+  if (c0 & 2n)
+    c ^= 0xa9fdca3312n;
+  if (c0 & 4n)
+    c ^= 0x1bab10e32dn;
+  if (c0 & 8n)
+    c ^= 0x3706b1677an;
+  if (c0 & 16n)
+    c ^= 0x644d626ffdn;
+
+  return c;
+}
+
+/**
+ * Get the checksum of a descriptor string
+ * @param {String} desc
+ * @returns {String} checksum string
+ */
+
+common.createChecksum = function createChecksum(desc) {
+  let c = 1n;
+  let cls = 0n;
+  let clscount = 0n;
+
+  for (let i = 0; i < desc.length; ++i) {
+    const ch = desc[i];
+    const pos = BigInt(INPUT_CHARSET.indexOf(ch));
+
+    assert(pos !== -1n, `Invalid character ${ch} at position ${i}`);
+
+    c = polyMod(c, pos & 31n);
+    cls = cls * 3n + (pos >> 5n);
+
+    if (++clscount === 3n) {
+      c = polyMod(c, cls);
+      cls = 0n;
+      clscount = 0n;
+    }
+  }
+
+  if (clscount > 0) {
+    c = polyMod(c, cls);
+  }
+
+  for (let j = 0; j < 8; ++j) {
+    c = polyMod(c, 0n);
+  }
+
+  c ^= 1n;
+
+  let checksum = '';
+  for (let k = 0n; k < 8n; ++k) {
+    const v = (c >> (5n * (7n - k))) & 31n;
+    checksum += CHECKSUM_CHARSET[v];
+  }
+
+  return checksum;
+};
+
+/**
+ * Test whether the descriptor has valid checksum (if present).
+ * If requireChecksum is true, will error if no checksum is present.
+ * @param {String} desc
+ * @param {Boolean?} requireChecksum
+ * @returns {String} descriptor string without checksum part
+ * @throws {AssertionError}
+ */
+
+common.checkChecksum = function checkChecksum(desc, requireChecksum = false) {
+  const checkSplit = desc.split('#');
+  assert(checkSplit.length <= 2, 'Multiple # symbols');
+
+  if (checkSplit.length === 1) {
+    assert(!requireChecksum, 'Missing checksum');
+  }
+
+  if (checkSplit.length === 2) {
+    assert(
+      checkSplit[1].length === 8,
+      `Expected 8 characters checksum, not ${checkSplit[1].length} characters`
+    );
+  }
+
+  const checksum = common.createChecksum(checkSplit[0]);
+
+  if (checkSplit.length === 2) {
+    assert(
+      checksum === checkSplit[1],
+      `Expected checksum ${checksum}, found ${checkSplit[1]}`
+    );
+  }
+
+  return checkSplit[0];
+};
+
+/**
+ * Get descriptor string with checksum appended.
+ * @param {String} desc
+ * @returns {String} descriptor string with checksum appended
+ */
+
+common.addChecksum = function addChecksum(desc) {
+  const split = desc.split('#');
+  const checksum = common.createChecksum(split[0]);
+  return split[0] + '#' + checksum;
+};

--- a/lib/descriptor/index.js
+++ b/lib/descriptor/index.js
@@ -1,0 +1,27 @@
+/*!
+ * descriptor/index.js - Output script descriptor for bcoin.
+ * Copyright (c) 2023, the bcoin developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+/**
+ * @module descriptor
+ */
+
+const {parse} = require('./parser');
+
+exports.AbstractDescriptor = require('./abstractdescriptor');
+exports.parse = parse;
+exports.PKDescriptor = require('./type/pk');
+exports.PKHDescriptor = require('./type/pkh');
+exports.WPKHDescriptor = require('./type/wpkh');
+exports.SHDescriptor = require('./type/sh');
+exports.WSHDescriptor = require('./type/wsh');
+exports.ComboDescriptor = require('./type/combo');
+exports.MultisigDescriptor = require('./type/multisig');
+exports.RawDescriptor = require('./type/raw');
+exports.AddressDescriptor = require('./type/addr');
+exports.KeyProvider = require('./keyprovider');
+exports.common = require('./common');

--- a/lib/descriptor/keyprovider.js
+++ b/lib/descriptor/keyprovider.js
@@ -1,0 +1,439 @@
+/*!
+ * keyprovider.js - parsed key object for descriptor in bcoin
+ * Copyright (c) 2023, the bcoin developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const assert = require('bsert');
+const HD = require('../hd/hd');
+const KeyRing = require('../primitives/keyring');
+const {scriptContext, isHex} = require('./common');
+const Network = require('../protocol/network');
+
+/**
+ * Constants
+ */
+
+/**
+ * Derive type for a key in a descriptor
+ * @const {Object}
+ */
+
+const deriveType = {
+  NO: 'NO',
+  UNHARDENED: 'UNHARDENED',
+  HARDENED: 'HARDENED'
+};
+
+/**
+ * KeyProvider
+ * Base class for key object in a descriptor.
+ * @alias module:descriptor.KeyProvider
+ * @property {KeyRing} ring
+ * @property {Network} network
+ * @property {KeyOriginInfo} originInfo - key origin information
+ * @property {String} hardenedMarker - hardened marker for derivation path
+ * default is `h`
+ */
+
+class KeyProvider {
+  /**
+   * @constructor
+   */
+
+  constructor() {
+    this.ring = null;
+    this.network = null;
+    this.originInfo = null;
+    this.hardenedMarker = 'h';
+  }
+
+  parseOptions(options) {
+    this.ring = options.ring;
+    this.originInfo = options.originInfo;
+    this.hardenedMarker = options.hardenedMarker;
+    this.network = Network.get(options.network);
+  }
+
+  /**
+   * Get the key object.
+   * @param {String} keyString
+   * @param {String?} context - script context
+   * @returns {ConstKeyProvider|HDKeyProvider}
+   */
+
+  _parseKey(keyString, context) {
+    const keySplit = keyString.split('/'); // split the key and derivation path
+    assert(keySplit.length > 0 && keySplit[0] !== '', 'No key provided');
+
+    const str = keySplit[0];
+
+    /**
+     * Check whether uncompressed keys are allowed or not.
+     * permit is true if uncompressed keys are allowed.
+     */
+
+    const permit = [scriptContext.TOP, scriptContext.P2SH].includes(context);
+
+    if (keySplit.length === 1) {
+      let ring = null;
+
+      if (isHex(str)) {
+        ring = KeyRing.fromPublic(Buffer.from(str, 'hex')); // pubkey (hex)
+      } else if (!HD.isBase58(str, this.network)) {
+        ring = KeyRing.fromSecret(str, this.network); // privkey (WIF)
+      }
+
+      if (ring) {
+        assert(
+          permit || ring.publicKey.length === 33,
+          'Uncompressed keys are not allowed'
+        );
+
+        return new ConstKeyProvider({
+          originInfo: this.originInfo,
+          ring,
+          hardenedMarker: this.hardenedMarker,
+          network: this.network
+        });
+      }
+    }
+
+    // xpriv or xpub (including derivation path if any) -> HDKeyProvider
+    const hdkey = HD.fromBase58(str, this.network);
+    const key = hdkey.privateKey || hdkey.publicKey;
+    const ring = KeyRing.fromKey(key);
+
+    let type = deriveType.NO;
+    const last = keySplit[keySplit.length - 1];
+
+    if (last === '*') {
+      type = deriveType.UNHARDENED;
+      keySplit.pop();
+    } else if ((last === '*\'' || last === '*h')) {
+      this.hardenedMarker = last[last.length - 1];
+      type = deriveType.HARDENED;
+      keySplit.pop();
+    }
+
+    const pathArray = keySplit.slice(1);
+    const marker = getHardenedMarker(pathArray);
+
+    if (marker) {
+      this.hardenedMarker = marker;
+    }
+
+    const path = HD.common.parsePathFromArray(pathArray, true);
+
+    return new HDKeyProvider({
+      originInfo: this.originInfo,
+      ring,
+      hdkey,
+      path,
+      type,
+      hardenedMarker: this.hardenedMarker,
+      network: this.network
+    });
+  }
+
+  /**
+   * Get the parsed key object including the key origin info
+   * (if available)
+   * @param {String} keyExpr
+   * @param {String?} context script context
+   * @returns {ConstKeyProvider|HDKeyProvider}
+   * @throws parse error
+   */
+
+  parseKey(keyExpr, context) {
+    // split the key and origin info
+    const originSplit = keyExpr.split(']');
+    assert(
+      originSplit.length <= 2,
+      'Multiple ] characters found for a single pubkey'
+    );
+
+    // key with no origin info
+    if (originSplit.length === 1) {
+      const keyString = originSplit[0];
+      return this._parseKey(keyString, context);
+    }
+
+    // key with origin info
+    assert(
+      originSplit.length && originSplit[0][0] === '[',
+      `Key origin start expected '[', found ${originSplit[0][0]} instead`
+    );
+
+    const originInfoString = originSplit[0].slice(1); // remove starting '['
+    const originPathArray = originInfoString.split('/').slice(1);
+
+    const marker = getHardenedMarker(originPathArray);
+    if (marker) {
+      this.hardenedMarker = marker;
+    }
+
+    const originInfo = HD.KeyOriginInfo.fromString(originInfoString);
+    const keyString = originSplit[1]; // key with derivation path (if any)
+    this.originInfo = originInfo;
+
+    return this._parseKey(keyString, context);
+  }
+
+  /**
+   * Inject properties from string
+   * @param {String} keyExpr
+   * @param {Network} network
+   * @param {String?} context script context
+   * @returns {ConstKeyProvider|HDKeyProvider}
+   */
+
+  fromString(keyExpr, network, context) {
+    this.network = Network.get(network);
+    return this.parseKey(keyExpr, context);
+  }
+
+  /**
+   * Instantiate KeyProvider from string.
+   * @param {String} keyExpr
+   * @param {Network} network
+   * @param {String?} context script context
+   * @returns {ConstKeyProvider|HDKeyProvider}
+   */
+
+  static fromString(keyExpr, network, context = scriptContext.TOP) {
+    return new this().fromString(keyExpr, network, context);
+  }
+
+  /**
+   * Get the string form of the origin info path (if available)
+   * @returns {String}
+   */
+
+  getOriginString() {
+    if (this.originInfo) {
+      return `[${this.originInfo.toString(this.hardenedMarker)}]`;
+    }
+    return '';
+  }
+
+  /**
+   * Test whether this represent multiple keys at different positions
+   * @returns {Boolean}
+   */
+
+  isRange() {
+    return false;
+  }
+
+  /**
+   * Get the size of the generated public key(s) in bytes
+   * @returns {Number} 33 or 65
+   */
+
+  getSize() {
+    throw new Error('Abstract method.');
+  }
+
+  /**
+   * Get the string form of the public key
+   * @returns {String}
+   */
+
+  toString() {
+    throw new Error('Abstract method.');
+  }
+
+  /**
+   * Get the string form of the private key (if available)
+   * @returns {String}
+   */
+
+  toPrivateString() {
+    throw new Error('Abstract method.');
+  }
+
+  /**
+   * Test whether this key provider has private key
+   * @returns {Boolean}
+   */
+
+  hasPrivateKey() {
+    return this.ring.privateKey !== null;
+  }
+}
+
+/**
+ * ConstKeyProvider
+ * Represents a non-hd key object with origin info (if any) in a descriptor
+ * @extends KeyProvider
+ */
+
+class ConstKeyProvider extends KeyProvider {
+  constructor(options) {
+    super();
+
+    if (options) {
+      this.fromOptions(options);
+    }
+  }
+
+  /**
+   * Inject properties from options object.
+   * @param {Object} options
+   * @returns {ConstKeyProvider}
+   */
+
+  fromOptions(options) {
+    this.parseOptions(options);
+
+    return this;
+  }
+
+  /**
+   * Instantiate ConstKeyProvider from options object.
+   * @param {Object} options
+   * @returns {ConstKeyProvider}
+   */
+
+  static fromOptions(options) {
+    return new this().fromOptions(options);
+  }
+
+  getSize() {
+    return this.ring.publicKey.length;
+  }
+
+  toString() {
+    return this.getOriginString() + this.ring.getPublicKey('hex');
+  }
+
+  toPrivateString() {
+    const privKey = this.ring.getPrivateKey('base58', this.network);
+    if (privKey) {
+      return this.getOriginString() + privKey;
+    }
+    return null;
+  }
+}
+
+/**
+ * HDKeyProvider
+ * Represents an hd key object with origin info (if any) in a descriptor
+ * @property {HDPublicKey|HDPrivateKey} hdkey
+ * @property {Number[]} path - array of derivation indices
+ * @property {String} type - derivation type - Normal, Hardened, or Unhardened
+ * @extends KeyProvider
+ */
+
+class HDKeyProvider extends KeyProvider {
+  constructor(options) {
+    super();
+
+    if (options) {
+      this.fromOptions(options);
+    }
+  }
+
+  /**
+   * Inject properties from options object
+   * @param {Object} options
+   * @returns {HDKeyProvider}
+   */
+
+  fromOptions(options) {
+    this.parseOptions(options);
+
+    this.hdkey = options.hdkey;
+    this.path = options.path;
+    this.type = options.type;
+
+    return this;
+  }
+
+  /**
+   * Instantiate HDKeyProvider from options object
+   * @param {Object} options
+   * @returns {HDKeyProvider}
+   */
+
+  static fromOptions(options) {
+    return new this().fromOptions(options);
+  }
+
+  isRange() {
+    return this.type !== deriveType.NO;
+  }
+
+  /**
+   * Test whether the derivation path is normal, hardened, unhardened
+   * @returns {Boolean}
+   */
+
+  isHardened() {
+    return (
+      this.path.some(index => index & HD.common.HARDENED) ||
+      this.type === deriveType.HARDENED
+    );
+  }
+
+  getSize() {
+    return 33;
+  }
+
+  _toString(key) {
+    const path = HD.common.format(this.path, this.hardenedMarker);
+    let result = `${key}${path}`;
+    if (this.isRange()) {
+      result += '/*';
+      if (this.type === deriveType.HARDENED) {
+        result += this.hardenedMarker;
+      }
+    }
+    return result;
+  }
+
+  toString() {
+    const key = this.hdkey.xpubkey(this.network);
+    return this.getOriginString() + this._toString(key);
+  }
+
+  toPrivateString() {
+    const key = this.hdkey.xprivkey(this.network);
+    if (key) {
+      return this.getOriginString() + this._toString(key);
+    }
+    return null;
+  }
+}
+
+/**
+ * Helpers
+ */
+
+/**
+ * Get the hardened marker at the last hardened step in a path
+ * @param {Array} path
+ * @returns {String} `'`, `h`, or null
+ */
+
+function getHardenedMarker(path) {
+  assert(Array.isArray(path));
+
+  let hardenedMarker = null;
+  for (const p of path) {
+   const last = p[p.length - 1];
+    if (last === '\'' || last === 'h') {
+      hardenedMarker = last;
+    }
+  }
+  return hardenedMarker;
+};
+
+/**
+ * Expose
+ */
+
+module.exports = KeyProvider;

--- a/lib/descriptor/parser.js
+++ b/lib/descriptor/parser.js
@@ -1,0 +1,71 @@
+/*!
+ * parser.js -  descriptor parser for bcoin
+ * Copyright (c) 2023, the bcoin developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const PKDescriptor = require('./type/pk');
+const PKHDescriptor = require('./type/pkh');
+const WPKHDescriptor = require('./type/wpkh');
+const SHDescriptor = require('./type/sh');
+const WSHDescriptor = require('./type/wsh');
+const ComboDescriptor = require('./type/combo');
+const AddressDescriptor = require('./type/addr');
+const MultisigDescriptor = require('./type/multisig');
+const RawDescriptor = require('./type/raw');
+const common = require('./common');
+const assert = require('bsert');
+const {getType, checkChecksum, types} = common;
+
+/**
+ * Parse the descriptor string based on script expression.
+ * @param {String} desc
+ * @param {Network} network
+ * @returns {Descriptor}
+ * @throws parse error
+ */
+
+function parseType(desc, network) {
+  const type = getType(desc);
+
+  switch (type) {
+    case types.PK:
+      return PKDescriptor.fromString(desc, network);
+    case types.PKH:
+      return PKHDescriptor.fromString(desc, network);
+    case types.WPKH:
+      return WPKHDescriptor.fromString(desc, network);
+    case types.SH:
+      return SHDescriptor.fromString(desc, network);
+    case types.WSH:
+      return WSHDescriptor.fromString(desc, network);
+    case types.COMBO:
+      return ComboDescriptor.fromString(desc, network);
+    case types.ADDR:
+      return AddressDescriptor.fromString(desc, network);
+    case types.MULTI:
+    case types.SORTEDMULTI:
+      return MultisigDescriptor.fromString(desc, network);
+    case types.RAW:
+      return RawDescriptor.fromString(desc, network);
+    default:
+      throw new Error(`'${desc}' is not a valid descriptor function`);
+  }
+};
+
+/**
+ * Initial step for parsing a descriptor from string.
+ * @param {String} desc
+ * @param {Network} network
+ * @param {Boolean} requireChecksum
+ * @returns {Descriptor} return the parsed descriptor object
+ * @throws parse error
+ */
+
+exports.parse = function parse(desc, network, requireChecksum) {
+  assert(typeof desc === 'string');
+  desc = checkChecksum(desc, requireChecksum);
+  return parseType(desc, network);
+};

--- a/lib/descriptor/type/addr.js
+++ b/lib/descriptor/type/addr.js
@@ -1,0 +1,127 @@
+/*!
+ * addr.js - address descriptor object for bcoin
+ * Copyright (c) 2023, the bcoin developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const AbstractDescriptor = require('../abstractdescriptor');
+const assert = require('bsert');
+const common = require('../common');
+const {isType, strip, checkChecksum, scriptContext, types} = common;
+const Address = require('../../primitives/address');
+const Network = require('../../protocol/network');
+
+/**
+ * AddressDescriptor
+ * Represents the output script produced by the address in the descriptor.
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0385.mediawiki#addr
+ * @property {String} type
+ * @property {Address} address
+ * @property {Network} network
+ * @extends AbstractDescriptor
+ */
+
+class AddressDescriptor extends AbstractDescriptor {
+  /**
+   * @constructor
+   * @param {Object} options
+   */
+
+  constructor(options) {
+    super();
+    this.type = types.ADDR;
+    this.address = null;
+
+    if (options) {
+      this.fromOptions(options);
+    }
+  }
+
+  /**
+   * Inject properties from options object.
+   * @param {Object} options
+   * @returns {AddressDescriptor}
+   */
+
+  fromOptions(options) {
+    this.parseOptions(options);
+
+    if (options.type) {
+      assert(options.type === types.ADDR);
+    }
+
+    assert(options.address instanceof Address, 'Invalid address in descriptor');
+    assert(this.subdescriptors.length === 0);
+    assert(this.keyProviders.length === 0);
+
+    this.address = options.address;
+
+    return this;
+  }
+
+  /**
+   * Instantiate address descriptor from options.
+   * @param {Object} options
+   * @returns {AddressDescriptor}
+   */
+
+  static fromOptions(options) {
+    return new this().fromOptions(options);
+  }
+
+  /**
+   * Inject properties from string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String} context
+   * @returns {AddressDescriptor}
+   */
+
+  fromString(str, network, context) {
+    str = checkChecksum(str);
+
+    assert(isType(types.ADDR, str), 'Invalid addr descriptor');
+    assert(context === scriptContext.TOP, 'Can only have addr() at top level');
+
+    this.network = Network.get(network);
+
+    str = strip(str);
+    const address = Address.fromString(str, this.network);
+
+    this.address = address;
+
+    return this;
+  }
+
+  /**
+   * Instantiate address descriptor from string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String?} context
+   * @returns {AddressDescriptor}
+   */
+
+  static fromString(str, network, context = scriptContext.TOP) {
+    return new this().fromString(str, network, context);
+  }
+
+  toPrivateString() {
+    return null;
+  }
+
+  toStringExtra() {
+    return this.address.toString(this.network);
+  }
+
+  isSolvable() {
+    return false;
+  }
+}
+
+/*
+ * Expose
+ */
+
+module.exports = AddressDescriptor;

--- a/lib/descriptor/type/combo.js
+++ b/lib/descriptor/type/combo.js
@@ -1,0 +1,121 @@
+/*!
+ * combo.js - combo descriptor object for bcoin
+ * Copyright (c) 2023, the bcoin developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const assert = require('bsert');
+const AbstractDescriptor = require('../abstractdescriptor');
+const common = require('../common');
+const {isType, strip, checkChecksum, scriptContext, types} = common;
+const KeyProvider = require('../keyprovider');
+const Network = require('../../protocol/network');
+
+/**
+ * ComboDescriptor
+ * Represents a P2PK, P2PKH, P2WPKH, and P2SH-P2WPKH output scripts.
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0384.mediawiki
+ * @property {String} type
+ * @property {KeyProvider[]} keyProviders
+ * @property {Network} network
+ * @extends AbstractDescriptor
+ */
+
+class ComboDescriptor extends AbstractDescriptor {
+  /**
+   * @constructor
+   * @param {Object} options
+   */
+
+  constructor(options) {
+    super();
+    this.type = types.COMBO;
+
+    if (options) {
+      this.fromOptions(options);
+    }
+  }
+
+  /**
+   * Inject properties from options object.
+   * @param {Object} options
+   * @returns {ComboDescriptor}
+   */
+
+  fromOptions(options) {
+    this.parseOptions(options);
+
+    if (options.type) {
+      assert(options.type === types.COMBO);
+    }
+
+    assert(this.subdescriptors.length === 0);
+    assert(
+      this.keyProviders.length === 1,
+      'Can only have one key inside combo()'
+    );
+
+    return this;
+  }
+
+  /**
+   * Instantiate combo descriptor from options.
+   * @param {Object} options
+   * @returns {ComboDescriptor}
+   */
+
+  static fromOptions(options) {
+    return new this().fromOptions(options);
+  }
+
+  /**
+   * Inject properties from string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String} context
+   * @returns {ComboDescriptor}
+   */
+
+  fromString(str, network, context) {
+    str = checkChecksum(str);
+
+    assert(isType(types.COMBO, str), 'Invalid combo descriptor');
+    assert(context === scriptContext.TOP, 'Can only have combo() at top level');
+
+    str = strip(str);
+    const provider = KeyProvider.fromString(str, network, context);
+
+    this.keyProviders = [provider];
+    this.network = Network.get(network);
+
+    return this;
+  }
+
+  /**
+   * Instantiate combo descriptor from string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String?} context
+   * @returns {ComboDescriptor}
+   */
+
+  static fromString(str, network, context = scriptContext.TOP) {
+    return new this().fromString(str, network, context);
+  }
+
+  isSingleType() {
+    return false;
+  }
+
+  isSolvable() {
+    return true;
+  }
+}
+
+/*
+ * Expose
+ */
+
+module.exports = ComboDescriptor;

--- a/lib/descriptor/type/multisig.js
+++ b/lib/descriptor/type/multisig.js
@@ -1,0 +1,215 @@
+/*!
+ * multisig.js - multisig descriptor object for bcoin
+ * Copyright (c) 2023, the bcoin developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const AbstractDescriptor = require('../abstractdescriptor');
+const common = require('../common');
+const {isType, strip, checkChecksum, scriptContext, types} = common;
+const consensus = require('../../protocol/consensus');
+const {MAX_SCRIPT_PUSH, MAX_MULTISIG_PUBKEYS} = consensus;
+const KeyProvider = require('../keyprovider');
+const Network = require('../../protocol/network');
+const assert = require('bsert');
+
+/**
+ * MultisigDescriptor
+ * Represents a multisig output script.
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0383.mediawiki
+ * @property {String} type
+ * @property {KeyProvider[]} keyProviders
+ * @property {Number} threshold
+ * @property {Boolean} isSorted - true if descriptor is sortedmulti
+ * @property {Network} network
+ * @extends AbstractDescriptor
+ */
+
+class MultisigDescriptor extends AbstractDescriptor {
+  /**
+   * @constructor
+   * @param {Object} options
+   */
+
+  constructor(options) {
+    super();
+    this.type = types.SORTEDMULTI;
+    this.isSorted = false;
+    this.threshold = 0;
+
+    if (options) {
+      this.fromOptions(options);
+    }
+  }
+
+  /**
+   * Inject properties from options object.
+   * @param {Object} options
+   * @returns {MultisigDescriptor}
+   */
+
+  fromOptions(options) {
+    this.parseOptions(options);
+
+    assert(this.subdescriptors.length === 0);
+    assert(this.keyProviders.length > 0, 'Must pass at least one pubkey');
+    assert(typeof options.threshold === 'number');
+    assert(typeof options.isSorted === 'boolean');
+
+    if (options.type) {
+      if (options.isSorted) {
+        assert(options.type === types.SORTEDMULTI);
+      } else {
+        assert(options.type === types.MULTI);
+      }
+    }
+
+    const m = options.threshold;
+    const n = options.keyProviders.length;
+
+    assert(
+      (m & 0xff) === m && m > 0 && m <= MAX_MULTISIG_PUBKEYS,
+      `Multisig threshold '${m}' is not valid`
+    );
+
+    assert(isValidMultisig(m, n, options.keyProviders));
+
+    this.isSorted = options.isSorted;
+    this.type = this.isSorted ? types.SORTEDMULTI : types.MULTI;
+    this.threshold = options.threshold;
+
+    return this;
+  }
+
+  /**
+   * Instantiate multisig descriptor from options object.
+   * @param {Object} options
+   * @returns {MultisigDescriptor}
+   */
+
+  static fromOptions(options) {
+    return new this().fromOptions(options);
+  }
+
+  /**
+   * Inject properties from string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String} context
+   * @returns {MultisigDescriptor}
+   */
+
+  fromString(str, network, context) {
+    str = checkChecksum(str);
+
+    const multisigTypes = [types.SORTEDMULTI, types.MULTI];
+    const isMultisig = multisigTypes.some(type => isType(type, str));
+
+    assert(isMultisig, 'Invalid multisig descriptor');
+
+    const valid = [scriptContext.TOP, scriptContext.P2SH, scriptContext.P2WSH];
+
+    assert(
+       valid.includes(context),
+      'Can only have multi/sortedmulti at top level, in sh(), or in wsh()'
+    );
+
+    const isSorted = isType(types.SORTEDMULTI, str); // check if sortedmulti
+    str = strip(str);
+    const descArray = str.split(',');
+
+    const providers = []; // for storing KeyProviders of this multisig
+    const threshold = descArray[0];
+    const m = parseInt(threshold, 10); // threshold of multisig
+
+    assert(
+      (m & 0xff) === m && m > 0 && m <= MAX_MULTISIG_PUBKEYS,
+      `Multisig threshold '${threshold}' is not valid`
+    );
+
+    for (let i = 1; i < descArray.length; i++) {
+      const provider = KeyProvider.fromString(
+        descArray[i],
+        network,
+        context
+      );
+      providers.push(provider);
+    }
+
+    // total number of keys in multisig
+    const n = providers.length;
+
+    assert(isValidMultisig(m, n, providers, context));
+
+    this.type = isSorted ? types.SORTEDMULTI : types.MULTI;
+    this.threshold = m;
+    this.keyProviders = providers;
+    this.isSorted = isSorted;
+    this.network = Network.get(network);
+
+    return this;
+  }
+
+  /**
+   * Instantiate multisig descriptor from string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String?} context
+   * @returns {MultisigDescriptor}
+   */
+
+  static fromString(str, network, context = scriptContext.TOP) {
+    return new this().fromString(str, network, context);
+  }
+
+  toStringExtra() {
+    return this.threshold.toString();
+  }
+}
+
+/**
+ * Helpers
+ */
+
+/**
+ * Check if multisig is valid.
+ * @param {Number} m threshold of multisig
+ * @param {Number} n total number of keys in multisig
+ * @param {KeyProvider[]} providers parsed keys in multisig descriptor
+ * @param {String} context script context
+ * @returns
+ */
+
+function isValidMultisig(m, n, providers, context = scriptContext.TOP) {
+    let scriptSize = 0;
+    for (const provider of providers) {
+      scriptSize = scriptSize + provider.getSize() + 1;
+    }
+
+  assert(
+    n && n <= MAX_MULTISIG_PUBKEYS,
+    `Keys in multisig must be between 1-${MAX_MULTISIG_PUBKEYS} inclusive`
+  );
+
+  assert(m <= n, `Threshold greater than number of keys (${m} > ${n})`);
+
+  if (context === scriptContext.TOP) {
+    assert(n <= 3, `At most 3 pubkeys allowed in bare multisig not ${n}`);
+  }
+
+  if (context === scriptContext.P2SH) {
+    assert(
+      scriptSize + 3 <= MAX_SCRIPT_PUSH,
+      `P2SH script is too large (${scriptSize + 3} > ${MAX_SCRIPT_PUSH})`
+    );
+  }
+  return true;
+};
+
+/*
+ * Expose
+ */
+
+module.exports = MultisigDescriptor;

--- a/lib/descriptor/type/pk.js
+++ b/lib/descriptor/type/pk.js
@@ -1,0 +1,112 @@
+/*!
+ * pk.js - public key descriptor object for bcoin
+ * Copyright (c) 2023, the bcoin developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const AbstractDescriptor = require('../abstractdescriptor');
+const common = require('../common');
+const {isType, strip, checkChecksum, scriptContext, types} = common;
+const assert = require('bsert');
+const KeyProvider = require('../keyprovider');
+const Network = require('../../protocol/network');
+
+/**
+ * PKDescriptor
+ * Represents a P2PK output script.
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0381.mediawiki#pk
+ * @property {String} type
+ * @property {KeyProvider[]} keyProviders
+ * @property {Network} network
+ * @extends AbstractDescriptor
+ */
+
+class PKDescriptor extends AbstractDescriptor {
+  /**
+   * @constructor
+   * @param {Object} options
+   */
+
+  constructor(options) {
+    super();
+    this.type = types.PK;
+
+    if (options) {
+      this.fromOptions(options);
+    }
+  }
+
+  /**
+   * Inject properties from options object.
+   * @param {Object} options
+   * @returns {PKDescriptor}
+   */
+
+  fromOptions(options) {
+    this.parseOptions(options);
+
+    if (options.type) {
+      assert(options.type === types.PK);
+    }
+
+    assert(this.subdescriptors.length === 0);
+    assert(
+      this.keyProviders.length === 1,
+      'Can only have one key inside pk()'
+    );
+
+    return this;
+  }
+
+  /**
+   * Instantiate pk descriptor from options object.
+   * @param {Object} options
+   * @returns {PKDescriptor}
+   */
+
+  static fromOptions(options) {
+    return new this().fromOptions(options);
+  }
+
+  /**
+   * Inject properties from string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String} context
+   * @returns {PKDescriptor}
+   */
+
+  fromString(str, network, context) {
+    str = checkChecksum(str);
+
+    assert(isType(types.PK, str), 'Invalid pk descriptor');
+
+    str = strip(str);
+    const provider = KeyProvider.fromString(str, network, context);
+
+    this.keyProviders = [provider];
+    this.network = Network.get(network);
+
+    return this;
+  }
+
+  /**
+   * Instantiate pk descriptor from string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String?} context
+   * @returns {PKDescriptor}
+   */
+
+  static fromString(str, network, context = scriptContext.TOP) {
+    return new this().fromString(str, network, context);
+  }
+}
+
+/*
+ * Expose
+ */
+
+module.exports = PKDescriptor;

--- a/lib/descriptor/type/pkh.js
+++ b/lib/descriptor/type/pkh.js
@@ -1,0 +1,119 @@
+/*!
+ * pkh.js - public key hash descriptor object for bcoin
+ * Copyright (c) 2023, the bcoin developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const AbstractDescriptor = require('../abstractdescriptor');
+const common = require('../common');
+const {isType, strip, checkChecksum, scriptContext, types} = common;
+const assert = require('bsert');
+const KeyProvider = require('../keyprovider');
+const Network = require('../../protocol/network');
+
+/**
+ * PKHDescriptor
+ * Represents a P2PKH output script.
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0381.mediawiki#pkh
+ * @property {String} type
+ * @property {Network} network
+ * @property {KeyProvider[]} keyProviders
+ * @extends AbstractDescriptor
+ */
+
+class PKHDescriptor extends AbstractDescriptor {
+  /**
+   * @constructor
+   * @param {Object} options
+   */
+
+  constructor(options) {
+    super();
+    this.type = types.PKH;
+
+    if (options) {
+      this.fromOptions(options);
+    }
+  }
+
+  /**
+   * Inject properties from options object.
+   * @param {Object} options
+   * @returns {PKHDescriptor}
+   */
+
+  fromOptions(options) {
+    this.parseOptions(options);
+
+    if (options.type) {
+      assert(options.type === types.PKH);
+    }
+
+    assert(this.subdescriptors.length === 0);
+    assert(
+      this.keyProviders.length === 1,
+      'Can only have one key inside pkh()'
+    );
+
+    return this;
+  }
+
+  /**
+   * Instantiate pkh descriptor from options object.
+   * @param {Object} options
+   * @returns {PKHDescriptor}
+   */
+
+  static fromOptions(options) {
+    return new this().fromOptions(options);
+  }
+
+  /**
+   * Instantiate pkh descriptor from a string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String} context
+   * @returns {PKHDescriptor}
+   */
+
+  fromString(str, network, context) {
+    str = checkChecksum(str);
+
+    assert(isType(types.PKH, str), 'Invalid pkh descriptor');
+
+    const valid = [scriptContext.TOP, scriptContext.P2SH, scriptContext.P2WSH];
+
+    assert(
+      valid.includes(context),
+      'Can only have pkh() at top level, in sh(), or in wsh()'
+    );
+
+    str = strip(str);
+    const provider = KeyProvider.fromString(str, network, context);
+
+    this.keyProviders = [provider];
+    this.network = Network.get(network);
+
+    return this;
+  }
+
+  /**
+   * Instantiate pkh descriptor from a string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String?} context
+   * @returns {PKHDescriptor}
+   */
+
+  static fromString(str, network, context = scriptContext.TOP) {
+    return new this().fromString(str, network, context);
+  }
+}
+
+/*
+ * Expose
+ */
+
+module.exports = PKHDescriptor;

--- a/lib/descriptor/type/raw.js
+++ b/lib/descriptor/type/raw.js
@@ -1,0 +1,124 @@
+/*!
+ * raw.js - raw descriptor object for bcoin
+ * Copyright (c) 2023, the bcoin developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const AbstractDescriptor = require('../abstractdescriptor');
+const common = require('../common');
+const {isType, strip, checkChecksum, types, scriptContext} = common;
+const Script = require('../../script/script');
+const Network = require('../../protocol/network');
+const assert = require('bsert');
+
+/**
+ * Raw Descriptor
+ * Represents the script represented by HEX in input.
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0385.mediawiki#raw
+ * @property {String} type
+ * @property {Script} script
+ * @property {Network} network
+ * @extends AbstractDescriptor
+ */
+
+class RawDescriptor extends AbstractDescriptor {
+  /**
+   * @constructor
+   * @param {Object} options
+   */
+
+  constructor(options) {
+    super();
+    this.type = types.RAW;
+    this.script = null;
+
+    if (options) {
+      this.fromOptions(options);
+    }
+  }
+
+  /**
+   * Inject properties from options object.
+   * @param {Object} options
+   * @returns {RawDescriptor}
+   */
+
+  fromOptions(options) {
+    this.parseOptions(options);
+
+    if (options.type) {
+      assert(options.type === types.RAW);
+    }
+
+    assert(this.subdescriptors.length === 0);
+    assert(this.keyProviders.length === 0);
+    assert(options.script, 'Must pass script');
+    assert(options.script instanceof Script, 'Invalid script in raw()');
+
+    this.script = options.script;
+
+    return this;
+  }
+
+  /**
+   * Instantiate raw descriptor from options object.
+   * @param {Object} options
+   * @returns {RawDescriptor}
+   */
+
+  static fromOptions(options) {
+    return new this().fromOptions(options);
+  }
+
+  /**
+   * Inject properties from string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String} context
+   * @returns {RawDescriptor}
+   */
+
+  fromString(str, network, context) {
+    str = checkChecksum(str);
+
+    assert(isType(types.RAW, str), 'Invalid raw descriptor');
+    assert(context === scriptContext.TOP, 'Can only have raw() at top level');
+
+    str = strip(str);
+    const script = Script.fromRaw(str, 'hex');
+    assert(script.length, 'Raw script is not hex');
+
+    this.script = script;
+    this.network = Network.get(network);
+
+    return this;
+  }
+
+  /**
+   * Instantiate raw descriptor from string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String?} context
+   * @returns {RawDescriptor}
+   */
+
+  static fromString(str, network, context = scriptContext.TOP) {
+    return new this().fromString(str, network, context);
+  }
+
+  isSolvable() {
+    return false;
+  }
+
+  toStringExtra() {
+    return this.script.toJSON();
+  }
+}
+
+/*
+ * Expose
+ */
+
+module.exports = RawDescriptor;

--- a/lib/descriptor/type/sh.js
+++ b/lib/descriptor/type/sh.js
@@ -1,0 +1,164 @@
+/*!
+ * sh.js - script hash descriptor object for bcoin
+ * Copyright (c) 2023, the bcoin developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const AbstractDescriptor = require('../abstractdescriptor');
+const PKDescriptor = require('./pk');
+const PKHDescriptor = require('./pkh');
+const WPKHDescriptor = require('./wpkh');
+const MultisigDescriptor = require('./multisig');
+const WSHDescriptor = require('./wsh');
+const assert = require('bsert');
+const common = require('../common');
+const {isType, strip, getType, scriptContext, checkChecksum, types} = common;
+
+const Network = require('../../protocol/network');
+
+/**
+ * SHDescriptor
+ * Represents a P2SH output script.
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0381.mediawiki#sh
+ * @property {String} type
+ * @property {Descriptor[]} subdescriptors
+ * @property {Network} network
+ * @extends AbstractDescriptor
+ */
+
+class SHDescriptor extends AbstractDescriptor {
+  /**
+   * @constructor
+   * @param {Object} options
+   */
+
+  constructor(options) {
+    super();
+    this.type = types.SH;
+
+    if (options) {
+      this.fromOptions(options);
+    }
+  }
+
+  /**
+   * Inject properties from options object.
+   * @param {Object} options
+   * @returns {SHDescriptor}
+   */
+
+  fromOptions(options) {
+    this.parseOptions(options);
+
+    if (options.type) {
+      assert(options.type === types.SH);
+    }
+
+    assert(this.keyProviders.length === 0);
+    assert(
+      this.subdescriptors.length === 1,
+      'Must pass only 1 subdescriptor'
+    );
+
+    const subdesc = options.subdescriptors[0];
+    const isValid = this.isValidSubdescriptor(subdesc.type);
+
+    assert(isValid, `Can not have ${subdesc.type}() inside sh()`);
+
+    return this;
+  }
+
+  /**
+   * Instantiate sh descriptor from options object.
+   * @param {Object} options
+   * @returns {SHDescriptor}
+   */
+
+  static fromOptions(options) {
+    return new this().fromOptions(options);
+  }
+
+  /**
+   * Inject properties from string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String} context
+   * @returns {SHDescriptor}
+   */
+
+  fromString(str, network, context) {
+    str = checkChecksum(str);
+
+    assert(isType(types.SH, str), 'Invalid sh descriptor.');
+    assert(context === scriptContext.TOP, 'Can only have sh() at top level');
+
+    str = strip(str);
+    const subtype = getType(str);
+
+    let subdesc = {};
+    context = scriptContext.P2SH;
+
+    switch (subtype) {
+      case types.PK:
+        subdesc = PKDescriptor.fromString(str, network, context);
+        break;
+      case types.PKH:
+        subdesc = PKHDescriptor.fromString(str, network, context);
+        break;
+      case types.WPKH:
+        subdesc = WPKHDescriptor.fromString(str, network, context);
+        break;
+      case types.WSH:
+        subdesc = WSHDescriptor.fromString(str, network, context);
+        break;
+      case types.MULTI:
+      case types.SORTEDMULTI:
+        subdesc = MultisigDescriptor.fromString(str, network, context);
+        break;
+      default:
+        if (Object.values(types).includes(subtype)) {
+          throw new Error(`Can not have ${subtype}() inside sh()`);
+        } else {
+          throw new Error('A valid function is needed inside sh()');
+        }
+    }
+
+    this.subdescriptors = [subdesc];
+    this.network = Network.get(network);
+
+    return this;
+  }
+
+  /**
+   * Instantiate sh descriptor from string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String?} context
+   * @returns {SHDescriptor}
+   */
+
+  static fromString(str, network, context = scriptContext.TOP) {
+    return new this().fromString(str, network, context);
+  }
+
+  isValidSubdescriptor(type) {
+    const validSubTypes = [
+      types.PK,
+      types.PKH,
+      types.WPKH,
+      types.MULTI,
+      types.SORTEDMULTI,
+      types.WSH
+    ];
+
+    return validSubTypes.includes(type);
+  }
+}
+
+/*
+ * Expose
+ */
+
+module.exports = SHDescriptor;

--- a/lib/descriptor/type/wpkh.js
+++ b/lib/descriptor/type/wpkh.js
@@ -1,0 +1,118 @@
+/*!
+ * wpkh.js - witness public key hash descriptor object for bcoin
+ * Copyright (c) 2023, the bcoin developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const AbstractDescriptor = require('../abstractdescriptor');
+const common = require('../common');
+const {isType, strip, checkChecksum, types, scriptContext} = common;
+const KeyProvider = require('../keyprovider');
+const Network = require('../../protocol/network');
+const assert = require('bsert');
+
+/**
+ * WPKHDescriptor
+ * Represents a P2WPKH output script.
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0382.mediawiki#wpkh
+ * @property {String} type
+ * @property {KeyProvider[]} keyProviders
+ * @property {Network} network
+ * @extends AbstractDescriptor
+ */
+
+class WPKHDescriptor extends AbstractDescriptor {
+  /**
+   * @constructor
+   * @param {Object} options
+   */
+
+  constructor(options) {
+    super();
+    this.type = types.WPKH;
+
+    if (options) {
+      this.fromOptions(options);
+    }
+  }
+
+  /**
+   * Inject properties from options object.
+   * @param {Object} options
+   * @returns {WPKHDescriptor}
+   */
+
+  fromOptions(options) {
+    this.parseOptions(options);
+
+    if (options.type) {
+      assert(options.type === types.WPKH);
+    }
+
+    assert(this.subdescriptors.length === 0);
+    assert(
+      this.keyProviders.length === 1,
+      'Can only have one key inside wpkh()'
+    );
+
+    return this;
+  }
+
+  /**
+   * Instantiate wpkh descriptor from options object.
+   * @param {Object} options
+   * @returns {WPKHDescriptor}
+   */
+
+  static fromOptions(options) {
+    return new this().fromOptions(options);
+  }
+
+  /**
+   * Instantiate wpkh descriptor from string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String} context
+   * @returns {WPKHDescriptor}
+   */
+
+  fromString(str, network, context) {
+    str = checkChecksum(str);
+
+    assert(isType(types.WPKH, str), 'Invalid wpkh descriptor.');
+
+    assert(
+      [scriptContext.TOP, scriptContext.P2SH].includes(context),
+      'Can only have wpkh() at top level or inside sh()'
+    );
+
+    str = strip(str);
+    context = scriptContext.P2WPKH;
+    const provider = KeyProvider.fromString(str, network, context);
+
+    this.keyProviders = [provider];
+    this.network = Network.get(network);
+
+    return this;
+  }
+
+  /**
+   * Instantiate wpkh descriptor from string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String?} context
+   * @returns {WPKHDescriptor}
+   */
+
+  static fromString(str, network, context = scriptContext.TOP) {
+    return new this().fromString(str, network, context);
+  }
+}
+
+/*
+ * Expose
+ */
+
+module.exports = WPKHDescriptor;

--- a/lib/descriptor/type/wsh.js
+++ b/lib/descriptor/type/wsh.js
@@ -1,0 +1,155 @@
+/*!
+ * wsh.js - witness script hash descriptor object for bcoin
+ * Copyright (c) 2023, the bcoin developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const AbstractDescriptor = require('../abstractdescriptor');
+const PKDescriptor = require('./pk');
+const PKHDescriptor = require('./pkh');
+const MultisigDescriptor = require('./multisig');
+const assert = require('bsert');
+const common = require('../common');
+const {isType, getType, strip, scriptContext, checkChecksum, types} = common;
+const Network = require('../../protocol/network');
+
+/**
+ * WSHDescriptor
+ * Represents a P2WSH output script.
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0382.mediawiki#wsh
+ * @property {String} type
+ * @property {Descriptor[]} subdescriptors - Subdescriptors
+ * @property {Network} network
+ * @extends AbstractDescriptor
+ */
+
+class WSHDescriptor extends AbstractDescriptor {
+  /**
+   * @constructor
+   * @param {Object} options
+   */
+
+  constructor(options) {
+    super();
+    this.type = types.WSH;
+
+    if (options) {
+      this.fromOptions(options);
+    }
+  }
+
+  /**
+   * Inject properties from options object.
+   * @param {Object} options
+   * @returns {WSHDescriptor}
+   */
+
+  fromOptions(options) {
+    this.parseOptions(options);
+
+    if (options.type) {
+      assert(options.type === types.WSH);
+    }
+
+    assert(this.keyProviders.length === 0);
+    assert(
+      this.subdescriptors.length === 1,
+      'Must pass only 1 subdescriptor'
+    );
+
+    const subdesc = options.subdescriptors[0];
+    const isValid = this.isValidSubdescriptor(subdesc.type);
+
+    assert(isValid, `Can not have ${subdesc.type}() inside sh()`);
+
+    return this;
+  }
+
+  /**
+   * Instantiate wsh descriptor from options object.
+   * @param {Object} options
+   * @returns {WSHDescriptor}
+   */
+
+  static fromOptions(options) {
+    return new this().fromOptions(options);
+  }
+
+  /**
+   * Inject properties from string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String} context
+   * @returns {WSHDescriptor}
+   */
+
+  fromString(str, network, context) {
+    str = checkChecksum(str);
+
+    assert(isType(types.WSH, str), 'Invalid WSH descriptor');
+    assert(
+      [scriptContext.TOP, scriptContext.P2SH].includes(context),
+      'Can only have wsh() at top level or inside sh()'
+    );
+
+    str = strip(str);
+    const subtype = getType(str);
+    let subdesc = {};
+    context = scriptContext.P2WSH;
+
+    switch (subtype) {
+      case types.PK:
+        subdesc = PKDescriptor.fromString(str, network, context);
+        break;
+      case types.PKH:
+        subdesc = PKHDescriptor.fromString(str, network, context);
+        break;
+      case types.MULTI:
+      case types.SORTEDMULTI:
+        subdesc = MultisigDescriptor.fromString(str, network, context);
+        break;
+      default:
+        if (Object.values(types).includes(subtype)) {
+          throw new Error(`Can not have ${subtype}() inside wsh()`);
+        } else {
+          throw new Error('A valid function is needed inside wsh()');
+        }
+    }
+
+    this.subdescriptors = [subdesc];
+    this.network = Network.get(network);
+
+    return this;
+  }
+
+  /**
+   * Instantiate wsh descriptor from string.
+   * @param {String} str
+   * @param {Network} network
+   * @param {String?} context
+   * @returns {WSHDescriptor}
+   */
+
+  static fromString(str, network, context = scriptContext.TOP) {
+    return new this().fromString(str, network, context);
+  }
+
+  isValidSubdescriptor(type) {
+    const validSubTypes = [
+      types.PK,
+      types.PKH,
+      types.MULTI,
+      types.SORTEDMULTI
+    ];
+
+    return validSubTypes.includes(type);
+  }
+}
+
+/*
+ * Expose
+ */
+
+module.exports = WSHDescriptor;

--- a/lib/hd/common.js
+++ b/lib/hd/common.js
@@ -42,38 +42,27 @@ common.MAX_ENTROPY = 512;
 common.cache = new LRU(500);
 
 /**
- * Parse a derivation path and return an array of indexes.
- * @see https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
- * @param {String} path
+ * Parse a derivation path.
+ * @param {Array} path
  * @param {Boolean} hard
  * @returns {Number[]}
  */
 
-common.parsePath = function parsePath(path, hard) {
-  assert(typeof path === 'string');
+common.parsePathFromArray = function parsePathFromArray(path, hard) {
+  assert(Array.isArray(path), 'Path must be an array.');
   assert(typeof hard === 'boolean');
-  assert(path.length >= 1);
-  assert(path.length <= 3062);
-
-  const parts = path.split('/');
-  const root = parts[0];
-
-  if (root !== 'm'
-      && root !== 'M'
-      && root !== 'm\''
-      && root !== 'M\'') {
-    throw new Error('Invalid path root.');
-  }
 
   const result = [];
+  for (let i = 0; i < path.length; i++) {
+    let part = path[i];
 
-  for (let i = 1; i < parts.length; i++) {
-    let part = parts[i];
+    const last = part[part.length - 1];
 
-    const hardened = part[part.length - 1] === '\'';
+    const hardened = last === '\'' || last === 'h';
 
-    if (hardened)
+    if (hardened) {
       part = part.slice(0, -1);
+    }
 
     if (part.length > 10)
       throw new Error('Path index too large.');
@@ -85,6 +74,10 @@ common.parsePath = function parsePath(path, hard) {
 
     if ((index >>> 0) !== index)
       throw new Error('Path index out of range.');
+
+    if (index > 0x7fffffff) {
+      throw new Error(`Key path value ${index} is out of range`);
+    }
 
     if (hardened) {
       index |= common.HARDENED;
@@ -98,6 +91,56 @@ common.parsePath = function parsePath(path, hard) {
   }
 
   return result;
+};
+
+/**
+ * Parse a derivation path and return an array of indexes.
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+ * @param {String} path
+ * @param {Boolean} hard
+ * @returns {Number[]}
+ */
+
+common.parsePath = function parsePath(path, hard) {
+  assert(typeof path === 'string');
+  assert(typeof hard === 'boolean');
+  assert(path.length >= 1);
+  assert(path.length <= 3062);
+
+  let parts = path.split('/');
+  const root = parts[0];
+  parts = parts.slice(1);
+
+  if (root !== 'm'
+      && root !== 'M'
+      && root !== 'm\''
+      && root !== 'M\'') {
+    throw new Error('Invalid path root.');
+  }
+
+  return this.parsePathFromArray(parts, hard);
+};
+
+/**
+ * Format the derivation path (indexes).
+ * @param {Array} path
+ * @param {String} hardenedMarker `h` or `'`
+ * Whether to format path using apostrophes (e.g. `m/44'/0'/0'`)
+ * or with h (e.g. `m/44h/0h/0h`).
+ * @returns {String}
+ */
+
+common.format = function format(path, hardenedMarker) {
+  assert(Array.isArray(path));
+  assert(typeof hardenedMarker === 'string');
+  assert(hardenedMarker === '\'' || hardenedMarker === 'h');
+
+  let res = '';
+  for (const p of path) {
+    const hardened = p & common.HARDENED ? hardenedMarker : '';
+    res += `/${p & 0x7fffffff}${hardened}`;
+  }
+  return res;
 };
 
 /**

--- a/lib/hd/hd.js
+++ b/lib/hd/hd.js
@@ -11,6 +11,7 @@ const common = require('./common');
 const Mnemonic = require('./mnemonic');
 const HDPrivateKey = require('./private');
 const HDPublicKey = require('./public');
+const KeyOriginInfo = require('./keyorigininfo');
 const wordlist = require('./wordlist');
 
 /**
@@ -182,4 +183,5 @@ HD.PrivateKey = HDPrivateKey;
 HD.PublicKey = HDPublicKey;
 HD.HDPrivateKey = HDPrivateKey;
 HD.HDPublicKey = HDPublicKey;
+HD.KeyOriginInfo = KeyOriginInfo;
 HD.wordlist = wordlist;

--- a/lib/hd/keyorigininfo.js
+++ b/lib/hd/keyorigininfo.js
@@ -1,0 +1,370 @@
+/*!
+ * keyorigin.js - hd key path object for bcoin
+ * Copyright (c) 2023, the bcoin developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const assert = require('assert');
+const common = require('./common');
+const bio = require('bufio');
+const {inspectSymbol} = require('../utils');
+
+/**
+ * KeyOriginInfo
+ * Represents hd key path.
+ * @property {Number} fingerPrint - master key fingerprint (uint32)
+ * @property {Number[]} path - bip32 derivation path in uint32 array
+ */
+
+class KeyOriginInfo {
+  /**
+   * Create key origin info.
+   * @constructor
+   * @param {Object} options
+   */
+
+  constructor(options) {
+    this.fingerPrint = 0;
+    this.path = [];
+
+    if (options) {
+      this.fromOptions(options);
+    }
+  }
+
+  /**
+   * Inject properties from options object.
+   * @param {Object} options
+   * @returns {KeyOriginInfo}
+   */
+
+  fromOptions(options) {
+    assert(options, 'requires options');
+
+    if (options.fingerPrint != null) {
+      assert(
+        options.fingerPrint >>> 0 === options.fingerPrint,
+        'Fingerprint must be uint32'
+      );
+      this.fingerPrint = options.fingerPrint;
+    }
+
+    if (options.path != null) {
+      if (Array.isArray(options.path)) {
+        assert(
+          options.path.every(p => p >>> 0 === p),
+          'All path indices must be uint32'
+        );
+        this.path = options.path;
+      }
+    }
+
+    return this;
+  }
+
+  /**
+   * Instantiate KeyOriginInfo from options.
+   * @param {Object} options
+   * @returns {KeyOriginInfo}
+   */
+
+  static fromOptions(options) {
+    return new this().fromOptions(options);
+  }
+
+  /**
+   * Inject properties from string.
+   * @param {String} str
+   * @returns {KeyOriginInfo}
+   */
+
+  fromString(str) {
+    assert(typeof str === 'string');
+
+    const slashSplit = str.split('/');
+
+    assert(
+      slashSplit[0].length === 8,
+      `Expected 8 characters fingerprint, found ${slashSplit[0].length} instead`
+    );
+
+    this.fingerPrint = validateFingerPrint(slashSplit[0]);
+
+    const pathArray = slashSplit.slice(1);
+    this.path = common.parsePathFromArray(pathArray, true);
+
+    return this;
+  }
+
+  /**
+   * Instantiate KeyOriginInfo from string.
+   * @param {String} str
+   * @returns {KeyOriginInfo}
+   */
+
+  static fromString(str) {
+    return new this().fromString(str);
+  }
+
+  /**
+   * Test whether two KeyOriginInfo objects are equal.
+   * @param {KeyOriginInfo} keyInfo
+   * @returns {Boolean}
+   */
+
+  equals(keyInfo) {
+    if (
+      !KeyOriginInfo.isKeyOriginInfo(keyInfo)  ||
+      this.fingerPrint !== keyInfo.fingerPrint ||
+      this.path.length !== keyInfo.path.length
+    ) {
+      return false;
+    }
+
+    return (
+      this.path.every((p, i) => p === keyInfo.path[i])
+    );
+  }
+
+  /**
+   * Convert KeyOriginInfo to a more user-friendly object.
+   * @returns {Object}
+   */
+
+  inspect() {
+    return this.format();
+  }
+
+  /**
+   * Convert KeyOriginInfo to a more user-friendly object.
+   * (uses 'h' as the default hardened marker for path)
+   * @returns {Object}
+   */
+
+  format() {
+    return {
+      fingerPrint: this.fingerPrint.toString(16).padStart(8, '0'),
+      path: 'm' + common.format(this.path, 'h')
+    };
+  }
+
+   /**
+   * Inject properties from serialized data.
+   * @private
+   * @param {Buffer} data
+   * @returns {KeyOriginInfo}
+   */
+
+   fromRaw(data) {
+    return this.fromReader(bio.read(data));
+  }
+
+  /**
+   * Instantiate KeyOriginInfo from serialized data.
+   * @param {Buffer} data
+   * @returns {KeyOriginInfo}
+   */
+
+  static fromRaw(data) {
+    return new this().fromRaw(data);
+  }
+
+  /**
+   * Inject properties from buffer reader.
+   * @private
+   * @param {BufferReader} br
+   */
+
+  fromReader(br) {
+    this.fingerPrint = br.readU32BE();
+    while (br.left()) {
+      this.path.push(br.readU32BE());
+    }
+    return this;
+  }
+
+  /**
+   * Instantiate KeyOriginInfo from buffer reader.
+   * @param {BufferReader} br
+   * @returns {KeyOriginInfo}
+   */
+
+  static fromReader(br) {
+    return new this().fromReader(br);
+  }
+
+  /**
+   * Serialize the KeyOriginInfo.
+   * @returns {Buffer}
+   */
+
+  toRaw() {
+    return this.toWriter(bio.write(this.getSize())).render();
+  }
+
+  /**
+   * Write the KeyOriginInfo to a buffer writer.
+   * @param {BufferWriter} bw
+   */
+
+  toWriter(bw) {
+    bw.writeU32BE(this.fingerPrint);
+
+    for (const p of this.path) {
+      bw.writeU32BE(p);
+    }
+
+    return bw;
+  }
+
+  /**
+   * Inspect the KeyOriginInfo.
+   * @returns {Object}
+   */
+
+  [inspectSymbol]() {
+    return this.toJSON();
+  }
+
+  /**
+   * Convert KeyOriginInfo to a more json-friendly object.
+   * @returns {Object}
+   */
+
+  toJSON() {
+    return this.format();
+  }
+
+  /**
+   * Convert KeyOriginInfo to string.
+   * @param {String} [hardenedMarker = 'h']
+   * Whether to use apostrophe as the hardened marker for path.
+   * Defaults to 'h' (uses 'h' as the hardened marker).
+   * @returns {String}
+   */
+
+  toString(hardenedMarker = 'h') {
+    const fingerPrint = this.format().fingerPrint;
+    const path = common.format(this.path, hardenedMarker);
+    return `${fingerPrint}${path}`;
+  }
+
+  /**
+   * Instantiate KeyOriginInfo from json object.
+   * @param {Object} json
+   * @returns {KeyOriginInfo}
+   */
+
+  static fromJSON(json) {
+    return new this().fromJSON(json);
+  }
+
+   /**
+   * Inject properties from json object.
+   * @private
+   * @param {Object} json
+   * @returns {KeyOriginInfo}
+   */
+
+  fromJSON(json) {
+    if (json.fingerPrint) {
+      if (typeof json.fingerPrint === 'string') {
+        json.fingerPrint = validateFingerPrint(json.fingerPrint);
+      } else {
+        assert(
+          json.fingerPrint >>> 0 === json.fingerPrint,
+          'Fingerprint must be uint32'
+        );
+      }
+
+      this.fingerPrint = json.fingerPrint;
+    }
+
+    if (json.path) {
+      if (Array.isArray(json.path)) {
+        assert(
+          json.path.every(p => p >>> 0 === p),
+          'All path indices must be uint32'
+        );
+        this.path = json.path;
+      } else {
+        this.path = common.parsePath(json.path, true);
+      }
+    }
+
+    return this;
+  }
+
+  /**
+   * Test whether an object is a KeyOriginInfo.
+   * @param {Object} obj
+   * @returns {Boolean}
+   */
+
+  static isKeyOriginInfo(obj) {
+    return obj instanceof KeyOriginInfo;
+  }
+
+  /**
+   * Clone the KeyOriginInfo.
+   * @returns {KeyOriginInfo}
+   */
+
+  clone() {
+    const path = this.path.slice();
+    return new KeyOriginInfo({fingerPrint: this.fingerPrint, path});
+  }
+
+  /**
+   * Clear the KeyOriginInfo.
+   */
+
+  clear() {
+    this.fingerPrint = 0;
+    this.path = [];
+  }
+
+  /**
+   * Calculate serialization size.
+   * @returns {Number}
+   */
+
+  getSize() {
+    return 4 + this.path.length * 4;
+  }
+}
+
+/**
+ * Helpers
+ */
+
+/**
+ * Test whether a string is a valid fingerprint.
+ * @param {String} str
+ * @returns {Number}
+ */
+
+function validateFingerPrint(str) {
+  assert(
+    str.length === 8,
+    `Expected 8 characters fingerprint, found ${str.length} instead`
+  );
+
+  const fingerPrint = parseInt(str, 16);
+
+  assert(
+    !isNaN(fingerPrint),
+    `Fingerprint ${str} is not hex`
+  );
+
+  assert(
+    fingerPrint >>> 0 === fingerPrint,
+    'Fingerprint must be uint32'
+  );
+
+  return fingerPrint;
+}
+
+module.exports = KeyOriginInfo;

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -35,6 +35,8 @@ const TX = require('../primitives/tx');
 const consensus = require('../protocol/consensus');
 const pkg = require('../pkg');
 const {filters} = require('../blockstore/common');
+const {createChecksum} = require('../descriptor/common');
+const {parse} = require('../descriptor/parser');
 const RPCBase = bweb.RPC;
 const RPCError = bweb.RPCError;
 
@@ -57,6 +59,7 @@ const errs = {
   INVALID_ADDRESS_OR_KEY: -5,
   OUT_OF_MEMORY: -7,
   INVALID_PARAMETER: -8,
+  INVALID_DESCRIPTOR: -9,
   DATABASE_ERROR: -20,
   DESERIALIZATION_ERROR: -22,
   VERIFY_ERROR: -25,
@@ -225,6 +228,7 @@ class RPC extends RPCBase {
 
     this.add('getmemoryinfo', this.getMemoryInfo);
     this.add('setloglevel', this.setLogLevel);
+    this.add('getdescriptorinfo', this.getDescriptorInfo);
   }
 
   /*
@@ -2322,6 +2326,26 @@ class RPC extends RPCBase {
     return null;
   }
 
+  async getDescriptorInfo(args, help) {
+    if (help || args.length !== 1)
+      throw new RPCError(errs.MISC_ERROR, 'getdescriptorinfo "descriptor"');
+
+    const valid = new Validator(args);
+    const desc = valid.str(0, '');
+
+    const descriptor = parseDescriptor(desc, this.network);
+
+    const result = {
+      descriptor: descriptor.toString(),
+      checksum: createChecksum(desc.split('#')[0]),
+      isrange: descriptor.isRange(),
+      issolvable: descriptor.isSolvable(),
+      hasprivatekeys: descriptor.hasPrivateKeys()
+    };
+
+    return result;
+  }
+
   /*
    * Helpers
    */
@@ -2857,6 +2881,16 @@ function parseAddress(raw, network) {
     return Address.fromString(raw, network);
   } catch (e) {
     throw new RPCError(errs.INVALID_ADDRESS_OR_KEY, 'Invalid address.');
+  }
+}
+
+function parseDescriptor(raw, network) {
+  try {
+    return parse(raw, network, false);
+  } catch (e) {
+    throw new RPCError(errs.INVALID_DESCRIPTOR,
+      `Invalid descriptor: ${e.message}`
+    );
   }
 }
 

--- a/test/data/descriptors/COPYING
+++ b/test/data/descriptors/COPYING
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2009-2023 The Bitcoin Core developers
+Copyright (c) 2009-2023 Bitcoin Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/test/data/descriptors/desc-invalid.json
+++ b/test/data/descriptors/desc-invalid.json
@@ -1,0 +1,165 @@
+[
+  {
+    "input": "pk",
+    "error": "'pk' is not a valid descriptor function"
+  },
+  {
+    "input": "",
+    "error": "'' is not a valid descriptor function"
+  },
+  {
+    "input": "pk()",
+    "error": "No key provided"
+  },
+  {
+    "input": "pk(wsh(sh(pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)))",
+    "error": "Decoding failed."
+  },
+  {
+    "input": "wpkh([d34db33f/84h/0h/0h]0279be667ef9dcbbac55a06295Ce870b07029Bfcdb2dce28d959f2815b16f81798/*)#qwlqgth7",
+    "error": "Expected checksum f0guwvcj, found qwlqgth7"
+  },
+  {
+    "input": "multi(pk())",
+    "error": "Multisig threshold 'pk()' is not valid"
+  },
+  {
+    "input": "pkh([d34db33f/44'/0'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1'/1h)",
+    "network": "main",
+    "error": "Network mismatch for xpubkey."
+  },
+  {
+    "input": "raw(asdf)",
+    "error": "Raw script is not hex"
+  },
+  {
+    "input": "sh(combo(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))",
+    "error": "Can not have combo() inside sh()"
+  },
+  {
+    "input": "sh(multi(2,[00000000/111'/222]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0))#tjq09x4t",
+    "error": "Expected checksum tjg09x5t, found tjq09x4t"
+  },
+  {
+    "input": "sh(multi(3,[00000000/111'/222]àxpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0))#tjg09x5t",
+    "error": "Invalid character à at position 30"
+  },
+  {
+    "input": "sh(multi(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0))",
+    "requirechecksum": true,
+    "error": "Missing checksum"
+  },
+  {
+    "input": "sh(multi(2,[00000000/111'/222]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0))#tjg09x5tq",
+    "error": "Expected 8 characters checksum, not 9 characters"
+  },
+  {
+    "input": "sh(multi(2,[00000000/111'/222]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0))#tjg09x5",
+    "error": "Expected 8 characters checksum, not 7 characters"
+  },
+  {
+    "input": "sh(multi(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0))##ggssrxfy",
+    "error": "Multiple # symbols"
+  },
+  {
+    "input": "sh(multi(16,KzoAz5CanayRKex3fSLQ2BwJpN7U52gZvxMyk78nDMHuqrUxuSJy,KwGNz6YCCQtYvFzMtrC6D3tKTKdBBboMrLTsjr2NYVBwapCkn7Mr,KxogYhiNfwxuswvXV66eFyKcCpm7dZ7TqHVqujHAVUjJxyivxQ9X,L2BUNduTSyZwZjwNHynQTF14mv2uz2NRq5n5sYWTb4FkkmqgEE9f,L1okJGHGn1kFjdXHKxXjwVVtmCMR2JA5QsbKCSpSb7ReQjezKeoD,KxDCNSST75HFPaW5QKpzHtAyaCQC7p9Vo3FYfi2u4dXD1vgMiboK,L5edQjFtnkcf5UWURn6UuuoFrabgDQUHdheKCziwN42aLwS3KizU,KzF8UWFcEC7BYTq8Go1xVimMkDmyNYVmXV5PV7RuDicvAocoPB8i,L3nHUboKG2w4VSJ5jYZ5CBM97oeK6YuKvfZxrefdShECcjEYKMWZ,KyjHo36dWkYhimKmVVmQTq3gERv3pnqA4xFCpvUgbGDJad7eS8WE,KwsfyHKRUTZPQtysN7M3tZ4GXTnuov5XRgjdF2XCG8faAPmFruRF,KzCUbGhN9LJhdeFfL9zQgTJMjqxdBKEekRGZX24hXdgCNCijkkap,KzgpMBwwsDLwkaC5UrmBgCYaBD2WgZ7PBoGYXR8KT7gCA9UTN5a3,KyBXTPy4T7YG4q9tcAM3LkvfRpD1ybHMvcJ2ehaWXaSqeGUxEdkP,KzJDe9iwJRPtKP2F2AoN6zBgzS7uiuAwhWCfGdNeYJ3PC1HNJ8M8,L1xbHrxynrqLKkoYc4qtoQPx6uy5qYXR5ZDYVYBSRmCV5piU3JG9))",
+    "error": "P2SH script is too large (547 > 520)"
+  },
+  {
+    "input": "sh(wpkh(5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss))",
+    "error": "Uncompressed keys are not allowed"
+  },
+  {
+    "input": "sh(wsh(sortedmulti(2,[e7dd1c50/48'/1'/40'/1']tpubDFh3VaUEs71ZMcVBmscSSnP4f4r6TvnLssu8yXvpj3uMfAehciMYTrgbfu4KCxXb7oSaz4kriuWRZtQVhZR2oA9toob6aELnsYLN94fXQLF/<0;1>/*,[e7dd1c50/48'/1'/20'/1']tpubDFPemvLnpMqE1BPuturDUh46KxsR8wGSQrA6HofYE7fqxpMAKCcoYWHGA46B6zKY4xcQAc1vLFTcqQ9BvsbHZ4UhzqqF5nUeeNBjNivHxPT/<0;1>/*,[aedb3d12/48'/1'/0'/1']tpubDEbuxto5Kftus28NyPddiEev2yUhzZGpkpQdCK732KBge5FJDhaMdhG1iVw3rMJ2qvABkaLR9HxobkeFkmQZ4RqQgN1KJadDjPn9ANBLo8V/<0;1>/*)))#exzcvs8g",
+    "network": "testnet",
+    "error": "Path index is non-numeric."
+  },
+  {
+    "input": "sh(sh(pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)))",
+    "error": "Can not have sh() inside sh()"
+  },
+  {
+    "input": "sh(wpkh())",
+    "error": "No key provided"
+  },
+  {
+    "input": "sh(wpkh(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5))",
+    "error": "Not a valid public key."
+  },
+  {
+    "input": "sh(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+    "error": "A valid function is needed inside sh()"
+  },
+  {
+    "input": "sh(multi(16,KzoAz5CanayRKex3fSLQ2BwJpN7U52gZvxMyk78nDMHuqrUxuSJy,KwGNz6YCCQtYvFzMtrC6D3tKTKdBBboMrLTsjr2NYVBwapCkn7Mr,KxogYhiNfwxuswvXV66eFyKcCpm7dZ7TqHVqujHAVUjJxyivxQ9X,L2BUNduTSyZwZjwNHynQTF14mv2uz2NRq5n5sYWTb4FkkmqgEE9f,L1okJGHGn1kFjdXHKxXjwVVtmCMR2JA5QsbKCSpSb7ReQjezKeoD,KxDCNSST75HFPaW5QKpzHtAyaCQC7p9Vo3FYfi2u4dXD1vgMiboK,L5edQjFtnkcf5UWURn6UuuoFrabgDQUHdheKCziwN42aLwS3KizU,KzF8UWFcEC7BYTq8Go1xVimMkDmyNYVmXV5PV7RuDicvAocoPB8i,L3nHUboKG2w4VSJ5jYZ5CBM97oeK6YuKvfZxrefdShECcjEYKMWZ,KyjHo36dWkYhimKmVVmQTq3gERv3pnqA4xFCpvUgbGDJad7eS8WE,KwsfyHKRUTZPQtysN7M3tZ4GXTnuov5XRgjdF2XCG8faAPmFruRF,KzCUbGhN9LJhdeFfL9zQgTJMjqxdBKEekRGZX24hXdgCNCijkkap,KzgpMBwwsDLwkaC5UrmBgCYaBD2WgZ7PBoGYXR8KT7gCA9UTN5a3,KyBXTPy4T7YG4q9tcAM3LkvfRpD1ybHMvcJ2ehaWXaSqeGUxEdkP,KzJDe9iwJRPtKP2F2AoN6zBgzS7uiuAwhWCfGdNeYJ3PC1HNJ8M8,L1xbHrxynrqLKkoYc4qtoQPx6uy5qYXR5ZDYVYBSRmCV5piU3JG9,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1))",
+    "error": "P2SH script is too large (581 > 520)"
+  },
+  {
+    "input": "wpkh(04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235)",
+    "error": "Uncompressed keys are not allowed"
+  },
+  {
+    "input": "pkh(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/1aa)",
+    "error": "Path index is non-numeric."
+  },
+  {
+    "input": "pkh([deadbeef]/1/2'/3/4']L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)",
+    "error": "Multiple ] characters found for a single pubkey"
+  },
+  {
+    "input": "pkh(deadbeef/1/2'/3/4']03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+    "error": "Key origin start expected '[', found d instead"
+  },
+  {
+    "input": "pkh(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/2147483648)",
+    "error": "Key path value 2147483648 is out of range"
+  },
+  {
+    "input": "multi(3,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1,5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss)",
+    "error": "Threshold greater than number of keys (3 > 2)"
+  },
+  {
+    "input": "multi(3,03669b8afcec803a0d323e9a17f3ea8e68e8abe5a278020a929adbec52421adbd0,0260b2003c386519fc9eadf2b5cf124dd8eea4c4e68d5e154050a9346ea98ce600,0362a74e399c39ed5593852a30147f2959b56bb827dfa3e60e464b02ccf87dc5e8,0261345b53de74a4d721ef877c255429961b7e43714171ac06168d7e08c542a8b8)",
+    "error": "At most 3 pubkeys allowed in bare multisig not 4"
+  },
+  {
+    "input": "multi(0,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1,5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss)",
+    "error": "Multisig threshold '0' is not valid"
+  },
+  {
+    "input": "multi(a,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1,5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss)",
+    "error": "Multisig threshold 'a' is not valid"
+  },
+  {
+    "input": "addr(asdf)",
+    "error": "Network mismatch for base58 address."
+  },
+  {
+    "input": "wsh(pk(04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235))",
+    "error": "Uncompressed keys are not allowed"
+  },
+  {
+    "input": "wsh(wpkh(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))",
+    "error": "Can not have wpkh() inside wsh()"
+  },
+  {
+    "input": "wsh(wsh(pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)))",
+    "error": "Can not have wsh() inside wsh()"
+  },
+  {
+    "input": "wsh(sh(pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)))",
+    "error": "Can not have sh() inside wsh()"
+  },
+  {
+    "input": "wsh(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+    "error": "A valid function is needed inside wsh()"
+  },
+  {
+    "input": "wsh(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)",
+    "error": "A valid function is needed inside wsh()"
+  },
+  {
+    "input": "tr(xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc/0/*",
+    "error": "'tr(xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc/0/*' is not a valid descriptor function"
+  }
+]

--- a/test/data/descriptors/desc-privatekeys.json
+++ b/test/data/descriptors/desc-privatekeys.json
@@ -1,0 +1,23 @@
+[
+    {
+      "input": "wsh(multi(1,xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334/0,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1))",
+      "expected": "wsh(multi(1,xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334/0,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1))#eft0rtsu"
+    },
+    {
+      "input": "sortedmulti(2,xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc/*,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0/0/*)",
+      "expected": "sortedmulti(2,xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc/*,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0/0/*)#h0kvdv2w"
+    },
+    {
+      "input": "pk(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)",
+      "expected": "pk(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)#tp6f86mw"
+    },
+    {
+      "input": "sh(multi(2,xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi/10/20/30/40/*',[00000000/111'/222]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0))",
+      "error": "Private key not available for [00000000/111'/222]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL"
+    },
+    {
+      "input": "sh(wsh(sortedmulti(2,[e7dd1c50/48'/1'/40'/1']tpubDFh3VaUEs71ZMcVBmscSSnP4f4r6TvnLssu8yXvpj3uMfAehciMYTrgbfu4KCxXb7oSaz4kriuWRZtQVhZR2oA9toob6aELnsYLN94fXQLF/*,[e7dd1c50/48'/1'/20'/1']tpubDFPemvLnpMqE1BPuturDUh46KxsR8wGSQrA6HofYE7fqxpMAKCcoYWHGA46B6zKY4xcQAc1vLFTcqQ9BvsbHZ4UhzqqF5nUeeNBjNivHxPT/*,[aedb3d12/48'/1'/0'/1']tpubDEbuxto5Kftus28NyPddiEev2yUhzZGpkpQdCK732KBge5FJDhaMdhG1iVw3rMJ2qvABkaLR9HxobkeFkmQZ4RqQgN1KJadDjPn9ANBLo8V/*)))",
+      "error": "Private key not available for [e7dd1c50/48'/1'/40'/1']tpubDFh3VaUEs71ZMcVBmscSSnP4f4r6TvnLssu8yXvpj3uMfAehciMYTrgbfu4KCxXb7oSaz4kriuWRZtQVhZR2oA9toob6aELnsYLN94fXQLF/*",
+      "network": "testnet"
+    }
+]

--- a/test/data/descriptors/desc-valid.json
+++ b/test/data/descriptors/desc-valid.json
@@ -1,0 +1,491 @@
+{
+    "pk": [
+      {
+        "input": "pk(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)#gn28ywm7",
+        "descriptor": "pk(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)#gn28ywm7",
+        "checksum": "gn28ywm7",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "pk(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)",
+        "descriptor": "pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)#9pcxlpvx",
+        "checksum": "tp6f86mw",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": true
+      },
+      {
+        "input": "pk(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B)",
+        "descriptor": "pk(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B)#a63el85t",
+        "checksum": "a63el85t",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false,
+        "network": "testnet"
+      },
+      {
+        "input": "pk(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)",
+        "descriptor": "pk(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)#gn28ywm7",
+        "checksum": "gn28ywm7",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      }
+    ],
+    "pkh": [
+      {
+        "input": "pkh([d34db33f/44'/0'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1'/1h)",
+        "descriptor": "pkh([d34db33f/44h/0h/0h]tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1h/1h)#eu8aefxn",
+        "checksum": "hhj429qj",
+        "isrange": false,
+        "issolvable": true,
+        "network": "testnet",
+        "hasprivatekeys": false
+      },
+      {
+        "input": "pkh([d34db33f/44'/0'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1'/1'/*h)",
+        "descriptor": "pkh([d34db33f/44'/0'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1'/1'/*')#vl8h22y9",
+        "checksum": "uf7smeyf",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": false,
+        "network": "testnet"
+      },
+      {
+        "input": "pkh([d34db33f/44'/0'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1h/1'/*')",
+        "descriptor": "pkh([d34db33f/44'/0'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1'/1'/*')#vl8h22y9",
+        "checksum": "ax89ank4",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": false,
+        "network": "testnet"
+      },
+      {
+        "input": "pkh([d34db33f/44'/0'/0h]tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1'/1'/*')",
+        "descriptor": "pkh([d34db33f/44'/0'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1'/1'/*')#vl8h22y9",
+        "checksum": "0e0kgrxk",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": false,
+        "network": "testnet"
+      },
+      {
+        "input": "pkh([d34db33f/44h/0'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1h/1'/*')",
+        "descriptor": "pkh([d34db33f/44'/0'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1'/1'/*')#vl8h22y9",
+        "checksum": "hy7nf994",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": false,
+        "network": "testnet"
+      },
+      {
+        "input": "pkh([deadbeef/1/2h/3/4']03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+        "descriptor": "pkh([deadbeef/1/2'/3/4']03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)#v0p5w8jl",
+        "checksum": "m40lc0fy",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "pkh([deadbeef/1h/2/3/4]03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+        "descriptor": "pkh([deadbeef/1h/2/3/4]03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)#vmgrp42f",
+        "checksum": "vmgrp42f",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "pkh([d34db33f/44'/0'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1'/1h/*')",
+        "descriptor": "pkh([d34db33f/44h/0h/0h]tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1h/1h/*h)#u5f4r0y7",
+        "checksum": "3fuelxef",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": false,
+        "network": "testnet"
+      },
+      {
+        "input": "pkh([d34db33f/44h/0'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1'/1h/*')",
+        "descriptor": "pkh([d34db33f/44h/0h/0h]tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1h/1h/*h)#u5f4r0y7",
+        "checksum": "mt90ts2f",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": false,
+        "network": "testnet"
+      },
+      {
+        "input": "pkh([d34db33f/44'/0'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/*)",
+        "descriptor": "pkh([d34db33f/44'/0'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/*)#j8kcuq32",
+        "checksum": "j8kcuq32",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": false,
+        "network": "testnet"
+      },
+      {
+        "input": "pkh([deadbeef/1/2h/3/4h]03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+        "descriptor": "pkh([deadbeef/1/2h/3/4h]03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)#v6qyyr0g",
+        "checksum": "v6qyyr0g",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "pkh(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1'/2)",
+        "descriptor": "pkh(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1'/2)#hvxe7cts",
+        "checksum": "hvxe7cts",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false,
+        "network": "testnet"
+      },
+      {
+        "input": "pkh([deadbeef/1/2'/3/4']03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+        "descriptor": "pkh([deadbeef/1/2'/3/4']03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)#v0p5w8jl",
+        "checksum": "v0p5w8jl",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "pkh([01234567/10/20]xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U/2147483647'/0)",
+        "descriptor": "pkh([01234567/10/20]xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/2147483647'/0)#ppq2nuk8",
+        "checksum": "8ak5azvd",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": true
+      },
+      {
+        "input": "pkh(02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5)",
+        "descriptor": "pkh(02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5)#8fhd9pwu",
+        "checksum": "8fhd9pwu",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "pkh(5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss)",
+        "descriptor": "pkh(04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235)#9907vvwz",
+        "checksum": "pcxrjydy",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": true
+      }
+    ],
+    "combo": [
+      {
+        "input": "combo([01234567]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL)",
+        "descriptor": "combo([01234567]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL)#7a7j2khf",
+        "checksum": "7a7j2khf",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "combo(5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss)",
+        "descriptor": "combo(04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235)#dgs2cwpu",
+        "checksum": "my43jap3",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": true
+      },
+      {
+        "input": "combo([01234567]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc)",
+        "descriptor": "combo([01234567]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL)#7a7j2khf",
+        "checksum": "9jncyu3j",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": true
+      },
+      {
+        "input": "combo(xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334/*)#f68555z5",
+        "descriptor": "combo(xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV/*)#3are946j",
+        "checksum": "f68555z5",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": true
+      },
+      {
+        "input": "combo(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)",
+        "descriptor": "combo(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)#lq9sf04s",
+        "checksum": "lq9sf04s",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      }
+    ],
+    "raw": [
+      {
+        "input": "raw(160014a1a6c1de91960ea670edaba20b1cfdcd73127037)",
+        "descriptor": "raw(160014a1a6c1de91960ea670edaba20b1cfdcd73127037)#dnudcv4v",
+        "checksum": "dnudcv4v",
+        "isrange": false,
+        "issolvable": false,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "raw(76a9145fcf526a4aa6a20ffa350310e59530cbeccc0e8188ac)",
+        "descriptor": "raw(76a9145fcf526a4aa6a20ffa350310e59530cbeccc0e8188ac)#pj2nfx5g",
+        "checksum": "pj2nfx5g",
+        "isrange": false,
+        "issolvable": false,
+        "hasprivatekeys": false
+      }
+    ],
+    "sh": [
+      {
+        "input": "sh(multi(2,xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi/10/20/30/40/*',[00000000/111'/222]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0))",
+        "descriptor": "sh(multi(2,xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/10/20/30/40/*',[00000000/111'/222]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0))#0vgrps8w",
+        "checksum": "2g4wf9kr",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": true
+      },
+      {
+        "input": "sh(wsh(sortedmulti(2,[e7dd1c50/48'/1'/40'/1']tpubDFh3VaUEs71ZMcVBmscSSnP4f4r6TvnLssu8yXvpj3uMfAehciMYTrgbfu4KCxXb7oSaz4kriuWRZtQVhZR2oA9toob6aELnsYLN94fXQLF/*,[e7dd1c50/48'/1'/20'/1']tpubDFPemvLnpMqE1BPuturDUh46KxsR8wGSQrA6HofYE7fqxpMAKCcoYWHGA46B6zKY4xcQAc1vLFTcqQ9BvsbHZ4UhzqqF5nUeeNBjNivHxPT/*,[aedb3d12/48'/1'/0'/1']tpubDEbuxto5Kftus28NyPddiEev2yUhzZGpkpQdCK732KBge5FJDhaMdhG1iVw3rMJ2qvABkaLR9HxobkeFkmQZ4RqQgN1KJadDjPn9ANBLo8V/*)))",
+        "network": "testnet",
+        "descriptor": "sh(wsh(sortedmulti(2,[e7dd1c50/48'/1'/40'/1']tpubDFh3VaUEs71ZMcVBmscSSnP4f4r6TvnLssu8yXvpj3uMfAehciMYTrgbfu4KCxXb7oSaz4kriuWRZtQVhZR2oA9toob6aELnsYLN94fXQLF/*,[e7dd1c50/48'/1'/20'/1']tpubDFPemvLnpMqE1BPuturDUh46KxsR8wGSQrA6HofYE7fqxpMAKCcoYWHGA46B6zKY4xcQAc1vLFTcqQ9BvsbHZ4UhzqqF5nUeeNBjNivHxPT/*,[aedb3d12/48'/1'/0'/1']tpubDEbuxto5Kftus28NyPddiEev2yUhzZGpkpQdCK732KBge5FJDhaMdhG1iVw3rMJ2qvABkaLR9HxobkeFkmQZ4RqQgN1KJadDjPn9ANBLo8V/*)))#zlh5y6z5",
+        "checksum": "zlh5y6z5",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "sh(wsh(multi(16,KzoAz5CanayRKex3fSLQ2BwJpN7U52gZvxMyk78nDMHuqrUxuSJy,KwGNz6YCCQtYvFzMtrC6D3tKTKdBBboMrLTsjr2NYVBwapCkn7Mr,KxogYhiNfwxuswvXV66eFyKcCpm7dZ7TqHVqujHAVUjJxyivxQ9X,L2BUNduTSyZwZjwNHynQTF14mv2uz2NRq5n5sYWTb4FkkmqgEE9f,L1okJGHGn1kFjdXHKxXjwVVtmCMR2JA5QsbKCSpSb7ReQjezKeoD,KxDCNSST75HFPaW5QKpzHtAyaCQC7p9Vo3FYfi2u4dXD1vgMiboK,L5edQjFtnkcf5UWURn6UuuoFrabgDQUHdheKCziwN42aLwS3KizU,KzF8UWFcEC7BYTq8Go1xVimMkDmyNYVmXV5PV7RuDicvAocoPB8i,L3nHUboKG2w4VSJ5jYZ5CBM97oeK6YuKvfZxrefdShECcjEYKMWZ,KyjHo36dWkYhimKmVVmQTq3gERv3pnqA4xFCpvUgbGDJad7eS8WE,KwsfyHKRUTZPQtysN7M3tZ4GXTnuov5XRgjdF2XCG8faAPmFruRF,KzCUbGhN9LJhdeFfL9zQgTJMjqxdBKEekRGZX24hXdgCNCijkkap,KzgpMBwwsDLwkaC5UrmBgCYaBD2WgZ7PBoGYXR8KT7gCA9UTN5a3,KyBXTPy4T7YG4q9tcAM3LkvfRpD1ybHMvcJ2ehaWXaSqeGUxEdkP,KzJDe9iwJRPtKP2F2AoN6zBgzS7uiuAwhWCfGdNeYJ3PC1HNJ8M8,L1xbHrxynrqLKkoYc4qtoQPx6uy5qYXR5ZDYVYBSRmCV5piU3JG9)))",
+        "descriptor": "sh(wsh(multi(16,03669b8afcec803a0d323e9a17f3ea8e68e8abe5a278020a929adbec52421adbd0,0260b2003c386519fc9eadf2b5cf124dd8eea4c4e68d5e154050a9346ea98ce600,0362a74e399c39ed5593852a30147f2959b56bb827dfa3e60e464b02ccf87dc5e8,0261345b53de74a4d721ef877c255429961b7e43714171ac06168d7e08c542a8b8,02da72e8b46901a65d4374fe6315538d8f368557dda3a1dcf9ea903f3afe7314c8,0318c82dd0b53fd3a932d16e0ba9e278fcc937c582d5781be626ff16e201f72286,0297ccef1ef99f9d73dec9ad37476ddb232f1238aff877af19e72ba04493361009,02e502cfd5c3f972fe9a3e2a18827820638f96b6f347e54d63deb839011fd5765d,03e687710f0e3ebe81c1037074da939d409c0025f17eb86adb9427d28f0f7ae0e9,02c04d3a5274952acdbc76987f3184b346a483d43be40874624b29e3692c1df5af,02ed06e0f418b5b43a7ec01d1d7d27290fa15f75771cb69b642a51471c29c84acd,036d46073cbb9ffee90473f3da429abc8de7f8751199da44485682a989a4bebb24,02f5d1ff7c9029a80a4e36b9a5497027ef7f3e73384a4a94fbfe7c4e9164eec8bc,02e41deffd1b7cce11cde209a781adcffdabd1b91c0ba0375857a2bfd9302419f3,02d76625f7956a7fc505ab02556c23ee72d832f1bac391bcd2d3abce5710a13d06,0399eb0a5487515802dc14544cf10b3666623762fbed2ec38a3975716e2c29c232)))#nc9gqlkc",
+        "checksum": "umzu6cja",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": true
+      },
+      {
+        "input": "sh(wsh(pkh(02e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13)))",
+        "descriptor": "sh(wsh(pkh(02e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13)))#2wtr0ej5",
+        "checksum": "2wtr0ej5",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "sh(wpkh(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556))",
+        "descriptor": "sh(wpkh(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556))#qkrrc7je",
+        "checksum": "qkrrc7je",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "sh(multi(2,022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01,03acd484e2f0c7f65309ad178a9f559abde09796974c57e714c35f110dfc27ccbe))",
+        "descriptor": "sh(multi(2,022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01,03acd484e2f0c7f65309ad178a9f559abde09796974c57e714c35f110dfc27ccbe))#y9zthqta",
+        "checksum": "y9zthqta",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "sh(wsh(multi(20,KzoAz5CanayRKex3fSLQ2BwJpN7U52gZvxMyk78nDMHuqrUxuSJy,KwGNz6YCCQtYvFzMtrC6D3tKTKdBBboMrLTsjr2NYVBwapCkn7Mr,KxogYhiNfwxuswvXV66eFyKcCpm7dZ7TqHVqujHAVUjJxyivxQ9X,L2BUNduTSyZwZjwNHynQTF14mv2uz2NRq5n5sYWTb4FkkmqgEE9f,L1okJGHGn1kFjdXHKxXjwVVtmCMR2JA5QsbKCSpSb7ReQjezKeoD,KxDCNSST75HFPaW5QKpzHtAyaCQC7p9Vo3FYfi2u4dXD1vgMiboK,L5edQjFtnkcf5UWURn6UuuoFrabgDQUHdheKCziwN42aLwS3KizU,KzF8UWFcEC7BYTq8Go1xVimMkDmyNYVmXV5PV7RuDicvAocoPB8i,L3nHUboKG2w4VSJ5jYZ5CBM97oeK6YuKvfZxrefdShECcjEYKMWZ,KyjHo36dWkYhimKmVVmQTq3gERv3pnqA4xFCpvUgbGDJad7eS8WE,KwsfyHKRUTZPQtysN7M3tZ4GXTnuov5XRgjdF2XCG8faAPmFruRF,KzCUbGhN9LJhdeFfL9zQgTJMjqxdBKEekRGZX24hXdgCNCijkkap,KzgpMBwwsDLwkaC5UrmBgCYaBD2WgZ7PBoGYXR8KT7gCA9UTN5a3,KyBXTPy4T7YG4q9tcAM3LkvfRpD1ybHMvcJ2ehaWXaSqeGUxEdkP,KzJDe9iwJRPtKP2F2AoN6zBgzS7uiuAwhWCfGdNeYJ3PC1HNJ8M8,L1xbHrxynrqLKkoYc4qtoQPx6uy5qYXR5ZDYVYBSRmCV5piU3JG9,KzRedjSwMggebB3VufhbzpYJnvHfHe9kPJSjCU5QpJdAW3NSZxYS,Kyjtp5858xL7JfeV4PNRCKy2t6XvgqNNepArGY9F9F1SSPqNEMs3,L2D4RLHPiHBidkHS8ftx11jJk1hGFELvxh8LoxNQheaGT58dKenW,KyLPZdwY4td98bKkXqEXTEBX3vwEYTQo1yyLjX2jKXA63GBpmSjv)))",
+        "descriptor": "sh(wsh(multi(20,03669b8afcec803a0d323e9a17f3ea8e68e8abe5a278020a929adbec52421adbd0,0260b2003c386519fc9eadf2b5cf124dd8eea4c4e68d5e154050a9346ea98ce600,0362a74e399c39ed5593852a30147f2959b56bb827dfa3e60e464b02ccf87dc5e8,0261345b53de74a4d721ef877c255429961b7e43714171ac06168d7e08c542a8b8,02da72e8b46901a65d4374fe6315538d8f368557dda3a1dcf9ea903f3afe7314c8,0318c82dd0b53fd3a932d16e0ba9e278fcc937c582d5781be626ff16e201f72286,0297ccef1ef99f9d73dec9ad37476ddb232f1238aff877af19e72ba04493361009,02e502cfd5c3f972fe9a3e2a18827820638f96b6f347e54d63deb839011fd5765d,03e687710f0e3ebe81c1037074da939d409c0025f17eb86adb9427d28f0f7ae0e9,02c04d3a5274952acdbc76987f3184b346a483d43be40874624b29e3692c1df5af,02ed06e0f418b5b43a7ec01d1d7d27290fa15f75771cb69b642a51471c29c84acd,036d46073cbb9ffee90473f3da429abc8de7f8751199da44485682a989a4bebb24,02f5d1ff7c9029a80a4e36b9a5497027ef7f3e73384a4a94fbfe7c4e9164eec8bc,02e41deffd1b7cce11cde209a781adcffdabd1b91c0ba0375857a2bfd9302419f3,02d76625f7956a7fc505ab02556c23ee72d832f1bac391bcd2d3abce5710a13d06,0399eb0a5487515802dc14544cf10b3666623762fbed2ec38a3975716e2c29c232,02bc2feaa536991d269aae46abb8f3772a5b3ad592314945e51543e7da84c4af6e,0318bf32e5217c1eb771a6d5ce1cd39395dff7ff665704f175c9a5451d95a2f2ca,02c681a6243f16208c2004bb81f5a8a67edfdd3e3711534eadeec3dcf0b010c759,0249fdd6b69768b8d84b4893f8ff84b36835c50183de20fcae8f366a45290d01fd)))#6lwvnz5j",
+        "checksum": "pftecwn7",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": true
+      },
+      {
+        "input": "sh(multi(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0))#ggrsrxfy",
+        "descriptor": "sh(multi(2,[00000000/111'/222]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0))#tjg09x5t",
+        "checksum": "ggrsrxfy",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": true
+      },
+      {
+        "input": "sh(wpkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/10/20/30/40/*'))",
+        "descriptor": "sh(wpkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/10/20/30/40/*'))#cgrkhzrc",
+        "checksum": "cgrkhzrc",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "sh(wpkh(xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi/10/20/30/40/*'))",
+        "descriptor": "sh(wpkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/10/20/30/40/*'))#cgrkhzrc",
+        "checksum": "qxqt7ymh",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": true
+      },
+      {
+        "input": "sh(wpkh(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1))",
+        "descriptor": "sh(wpkh(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))#0aua3a8r",
+        "checksum": "0qtndeve",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": true
+      },
+      {
+        "input": "sh(wpkh(xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi/10/20/30/40/*'))",
+        "descriptor": "sh(wpkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/10/20/30/40/*'))#cgrkhzrc",
+        "checksum": "qxqt7ymh",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": true
+      },
+      {
+        "input": "sh(pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))",
+        "descriptor": "sh(pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))#s53ls94y",
+        "checksum": "s53ls94y",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "sh(wsh(multi(1,03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8,03499fdf9e895e719cfd64e67f07d38e3226aa7b63678949e6e49b241a60e823e4,02d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e)))",
+        "descriptor": "sh(wsh(multi(1,03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8,03499fdf9e895e719cfd64e67f07d38e3226aa7b63678949e6e49b241a60e823e4,02d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e)))#ks05yr6p",
+        "checksum": "ks05yr6p",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "sh(multi(2,[00000000/111'/222]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0))",
+        "descriptor": "sh(multi(2,[00000000/111'/222]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0))#tjg09x5t",
+        "checksum": "tjg09x5t",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      }
+    ],
+    "wpkh": [
+      {
+        "input": "wpkh([ffffffff/13']xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt/1/2/*)",
+        "descriptor": "wpkh([ffffffff/13']xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH/1/2/*)#66s997t5",
+        "checksum": "rgqxhqq9",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": true
+      },
+      {
+        "input": "wpkh([d34db33f/84h/0h/0h]0279be667ef9dcbbac55a06295Ce870b07029Bfcdb2dce28d959f2815b16f81798)#qwlqgth7",
+        "descriptor": "wpkh([d34db33f/84h/0h/0h]0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)#5fp02c75",
+        "checksum": "qwlqgth7",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "wpkh(02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9)",
+        "descriptor": "wpkh(02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9)#8zl0zxma",
+        "checksum": "8zl0zxma",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      }
+    ],
+    "multisig": [
+      {
+        "input": "sortedmulti(2,xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc/*,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0/0/*)",
+        "descriptor": "sortedmulti(2,xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/*,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0/0/*)#lyw3zgk5",
+        "checksum": "h0kvdv2w",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": true
+      },
+      {
+        "input": "multi(1,xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334/*,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)",
+        "descriptor": "multi(1,xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV/*,03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)#ds4nc7vf",
+        "isrange": true,
+        "checksum": "aefpzjr7",
+        "issolvable": true,
+        "hasprivatekeys": true
+      },
+      {
+        "input": "multi(1,022f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe4,025cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bc)",
+        "descriptor": "multi(1,022f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe4,025cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bc)#hzhjw406",
+        "checksum": "hzhjw406",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "multi(1,03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8,03499fdf9e895e719cfd64e67f07d38e3226aa7b63678949e6e49b241a60e823e4,02d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e)",
+        "descriptor": "multi(1,03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8,03499fdf9e895e719cfd64e67f07d38e3226aa7b63678949e6e49b241a60e823e4,02d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e)#3znta99r",
+        "checksum": "3znta99r",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      }
+    ],
+    "addr": [
+      {
+        "input": "addr(2NBFNJTktNa7GZusGbDbGKRZTxdK9VVez3n)",
+        "descriptor": "addr(2NBFNJTktNa7GZusGbDbGKRZTxdK9VVez3n)#l98qe9z6",
+        "checksum": "l98qe9z6",
+        "isrange": false,
+        "issolvable": false,
+        "hasprivatekeys": false,
+        "network": "testnet"
+      },
+      {
+        "input": "addr(bc1pu9s8vvvj6sqxtf26v0xhudgaqryyl3d642heejxrfphhumhgh9vsnugh93)",
+        "descriptor": "addr(bc1pu9s8vvvj6sqxtf26v0xhudgaqryyl3d642heejxrfphhumhgh9vsnugh93)#dg9g0rps",
+        "checksum": "dg9g0rps",
+        "isrange": false,
+        "issolvable": false,
+        "hasprivatekeys": false
+      }
+    ],
+    "wsh": [
+      {
+        "input": "wsh(sortedmulti(2,[e7dd1c50/48'/1'/40'/1h]tpubDFh3VaUEs71ZMcVBmscSSnP4f4r6TvnLssu8yXvpj3uMfAehciMYTrgbfu4KCxXb7oSaz4kriuWRZtQVhZR2oA9toob6aELnsYLN94fXQLF/*,[e7dd1c50/48'/1'/20'/1']tpubDFPemvLnpMqE1BPuturDUh46KxsR8wGSQrA6HofYE7fqxpMAKCcoYWHGA46B6zKY4xcQAc1vLFTcqQ9BvsbHZ4UhzqqF5nUeeNBjNivHxPT/*,[aedb3d12/48'/1'/0'/1']tpubDEbuxto5Kftus28NyPddiEev2yUhzZGpkpQdCK732KBge5FJDhaMdhG1iVw3rMJ2qvABkaLR9HxobkeFkmQZ4RqQgN1KJadDjPn9ANBLo8V/*h))",
+        "descriptor": "wsh(sortedmulti(2,[e7dd1c50/48h/1h/40h/1h]tpubDFh3VaUEs71ZMcVBmscSSnP4f4r6TvnLssu8yXvpj3uMfAehciMYTrgbfu4KCxXb7oSaz4kriuWRZtQVhZR2oA9toob6aELnsYLN94fXQLF/*,[e7dd1c50/48'/1'/20'/1']tpubDFPemvLnpMqE1BPuturDUh46KxsR8wGSQrA6HofYE7fqxpMAKCcoYWHGA46B6zKY4xcQAc1vLFTcqQ9BvsbHZ4UhzqqF5nUeeNBjNivHxPT/*,[aedb3d12/48h/1h/0h/1h]tpubDEbuxto5Kftus28NyPddiEev2yUhzZGpkpQdCK732KBge5FJDhaMdhG1iVw3rMJ2qvABkaLR9HxobkeFkmQZ4RqQgN1KJadDjPn9ANBLo8V/*h))#tyv5wg8e",
+        "checksum": "2wndyvdx",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": false,
+        "network": "testnet"
+      },
+      {
+        "input": "wsh(multi(1,xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334/0,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1))",
+        "descriptor": "wsh(multi(1,xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV/0,03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))#gcn7zwma",
+        "checksum": "eft0rtsu",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": true
+      },
+      {
+        "input": "wsh(multi(2,03a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7,03774ae7f858a9411e5ef4246b70c65aac5649980be5c17891bbec17895da008cb,03d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85a))",
+        "descriptor": "wsh(multi(2,03a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7,03774ae7f858a9411e5ef4246b70c65aac5649980be5c17891bbec17895da008cb,03d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85a))#en3tu306",
+        "checksum": "en3tu306",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "wsh(multi(1,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/0/*,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/0/*))",
+        "descriptor": "wsh(multi(1,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/0/*,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/0/*))#8srnyrlv",
+        "checksum": "8srnyrlv",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": false,
+        "network": "testnet"
+      },
+      {
+        "input": "wsh(pkh(xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi/10/20/30/40/*'))",
+        "descriptor": "wsh(pkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/10/20/30/40/*'))#mnf062h6",
+        "checksum": "ra2jnv04",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": true
+      },
+      {
+        "input": "wsh(pk([d34db33f/44h/0/0]tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/1/*))",
+        "descriptor": "wsh(pk([d34db33f/44h/0/0]tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/1/*))#pyjd2rua",
+        "checksum": "pyjd2rua",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": false,
+        "network": "testnet"
+      }
+    ]
+}

--- a/test/descriptor-test.js
+++ b/test/descriptor-test.js
@@ -1,0 +1,111 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+/**
+ * Parts of these testcases are taken from Bitcoin core
+ * @see https://github.com/bitcoin/bitcoin/blob/master/src/test/descriptor_tests.cpp
+ * @see https://github.com/bitcoin/bitcoin/blob/master/test/functional/rpc_getdescriptorinfo.py
+ */
+
+'use strict';
+
+const assert = require('bsert');
+const parsable = require('./data/descriptors/desc-valid.json');
+const unparsable = require('./data/descriptors/desc-invalid.json');
+const privateKeyDescriptors = require('./data/descriptors/desc-privatekeys.json');
+const common = require('../lib/descriptor/common');
+const {parse} = require('../lib/descriptor/parser');
+const PKDescriptor = require('../lib/descriptor/type/pk');
+const PKHDescriptor = require('../lib/descriptor/type/pkh');
+const WPKHDescriptor = require('../lib/descriptor/type/wpkh');
+const SHDescriptor = require('../lib/descriptor/type/sh');
+const WSHDescriptor = require('../lib/descriptor/type/wsh');
+const ComboDescriptor = require('../lib/descriptor/type/combo');
+const MultisigDescriptor = require('../lib/descriptor/type/multisig');
+const RawDescriptor = require('../lib/descriptor/type/raw');
+const AddressDescriptor = require('../lib/descriptor/type/addr');
+
+function createDescriptorFromOptions(desc, type) {
+  const options = {};
+  options.keyProviders = desc.keyProviders;
+  options.subdescriptors = desc.subdescriptors;
+  options.threshold = desc.threshold;
+  options.isSorted = desc.isSorted;
+  options.address = desc.address;
+  options.script = desc.script;
+  options.network = desc.network;
+
+  switch (type) {
+    case 'pk':
+      return new PKDescriptor(options);
+    case 'pkh':
+      return new PKHDescriptor(options);
+    case 'wpkh':
+      return new WPKHDescriptor(options);
+    case 'combo':
+      return new ComboDescriptor(options);
+    case 'sh':
+      return new SHDescriptor(options);
+    case 'wsh':
+      return new WSHDescriptor(options);
+    case 'multisig':
+      return new MultisigDescriptor(options);
+    case 'addr':
+      return new AddressDescriptor(options);
+    case 'raw':
+      return new RawDescriptor(options);
+  }
+
+  return null;
+}
+
+describe('Descriptor', () => {
+  for (const type in parsable) {
+    if (parsable.hasOwnProperty(type)) {
+      for (const data of parsable[type]) {
+        const {input, descriptor, checksum, isrange, issolvable, hasprivatekeys, requirechecksum, network} = data;
+
+        const desc1 = parse(input, network, requirechecksum);
+
+        it(`should create descriptor object from string for ${input}`, () => {
+          assert.strictEqual(common.createChecksum(input.split('#')[0]), checksum);
+          assert.strictEqual(desc1.isRange(), isrange);
+          assert.strictEqual(desc1.isSolvable(), issolvable);
+          assert.strictEqual(desc1.hasPrivateKeys(), hasprivatekeys);
+          assert.strictEqual(desc1.toString(), descriptor);
+        });
+
+        const desc2 = createDescriptorFromOptions(desc1, type);
+
+        it(`should create descriptor object from options object for ${input}`, () => {
+          assert.strictEqual(common.createChecksum(input.split('#')[0]), checksum);
+          assert.strictEqual(desc2.isRange(), isrange);
+          assert.strictEqual(desc2.isSolvable(), issolvable);
+          assert.strictEqual(desc2.hasPrivateKeys(), hasprivatekeys);
+          assert.strictEqual(desc2.toString(), descriptor);
+        });
+      }
+    }
+  }
+
+  for (const date of privateKeyDescriptors) {
+    it('should output descriptor with private keys when all keys are private', () => {
+      try {
+        const desc = parse(date.input, date.network);
+        assert.strictEqual(desc.toPrivateString(), date.expected);
+      } catch (e) {
+        assert.strictEqual(e.message, date.error);
+      }
+    });
+  }
+
+  for (const data of unparsable) {
+    const {input, error, network, requirechecksum} = data;
+    it(`should throw ('${error}') for ${input}`, () => {
+      assert.throws(
+        () => parse(input, network, requirechecksum),
+        e => e.message === error
+      );
+    });
+  }
+});

--- a/test/keyorigininfo-test.js
+++ b/test/keyorigininfo-test.js
@@ -1,0 +1,189 @@
+/* eslint-disable quotes */
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const HD = require('../lib/hd');
+const assert = require('bsert');
+
+const parsable = [
+  {
+    "input": "d34db33f/44h/0'/0'",
+    "expected": "d34db33f/44h/0h/0h"
+  },
+  {
+    "input": "d34db33f",
+    "expected": "d34db33f"
+  },
+  {
+    "input": "d34db33f/44/0'/0h",
+    "expected": "d34db33f/44/0h/0h"
+  },
+  {
+    "input": "d34db33f/44/0'/0",
+    "expected": "d34db33f/44/0h/0"
+  },
+  {
+    "input": "d34db33f/44h/0/0",
+    "expected": "d34db33f/44h/0/0"
+  },
+  {
+    "input": "d34db33f/44'/0h/0",
+    "expected": "d34db33f/44h/0h/0"
+  },
+  {
+    "input": "d34db33f/44'/0'/0'",
+    "expected": "d34db33f/44h/0h/0h"
+  },
+  {
+    "input": "deadbeef/1/2'/3/4'",
+    "expected": "deadbeef/1/2h/3/4h"
+  },
+  {
+    "input": "ffffffff/13'",
+    "expected": "ffffffff/13h"
+  },
+  {
+    "input": "00000000/111'/222",
+    "expected": "00000000/111h/222"
+  },
+  {
+    "input": "e7dd1c50/48'/1'/40'/1'",
+    "expected": "e7dd1c50/48h/1h/40h/1h"
+  }
+];
+
+const unparsable = {
+  "strings": [
+    {
+      "input": "d34db33f/2147483648/0'/0'",
+      "error": "Key path value 2147483648 is out of range"
+    },
+    {
+      "input": "d34db33f/42949672961/0'/0'",
+      "error": "Path index too large."
+    },
+    {
+      "input": "d34db33f/",
+      "error": "Path index is non-numeric."
+    },
+    {
+      "input": "zzzzzzzz",
+      "error": "Fingerprint zzzzzzzz is not hex"
+    }
+  ],
+  "jsons": [
+    {
+      "input": {
+        "fingerPrint": "aaaaaaaaa",
+        "path": ""
+      },
+      "error": "Expected 8 characters fingerprint, found 9 instead"
+    },
+    {
+      "input": {
+        "fingerPrint": 3545084735,
+        "path": "44h/0h/0h"
+      },
+      "error": "Invalid path root." // path string should start with m for fromJSON
+    },
+    {
+      "input": {
+        "fingerPrint": 3545084735,
+        "path": [42949672961, 2147483648, 2147483648]
+      },
+      "error": "All path indices must be uint32"
+    },
+    {
+      "input": {
+        "fingerPrint": 42949672961,
+        "path": [42949672961, 2147483648, 2147483648]
+      },
+      "error": "Fingerprint must be uint32"
+    }
+  ]
+};
+
+describe('KeyOriginInfo', function () {
+  for (const data of parsable) {
+    it(`should create a KeyOriginInfo object for ${data.input} `, () => {
+      const keyOriginInfo = HD.KeyOriginInfo.fromString(data.input);
+      assert.strictEqual(keyOriginInfo.toString(), data.expected);
+    });
+  }
+
+  for (const data of parsable) {
+    it(`should create a KeyOriginInfo object from raw data for ${data.input}`, () => {
+      const keyOriginInfo1 = HD.KeyOriginInfo.fromString(data.input);
+      const keyOriginInfo2 = HD.KeyOriginInfo.fromRaw(keyOriginInfo1.toRaw());
+      assert.deepStrictEqual(keyOriginInfo2.toString(), data.expected);
+    });
+  }
+
+  for (const data of parsable) {
+    it(`should correctly validate two equal KeyOriginInfo objects for ${data.input}`, () => {
+      const keyOriginInfo1 = HD.KeyOriginInfo.fromString(data.input);
+      const keyOriginInfo2 = HD.KeyOriginInfo.fromString(data.input);
+      assert.strictEqual(keyOriginInfo1.equals(keyOriginInfo2), true);
+    });
+  }
+
+  for (const data of parsable) {
+    it(`should create a KeyOriginInfo object from a JSON object for ${data.input}`, () => {
+      const keyOriginInfo1 = HD.KeyOriginInfo.fromString(data.input);
+      const keyOriginInfo2 = HD.KeyOriginInfo.fromJSON(keyOriginInfo1.toJSON());
+      const keyOriginInfo3 = HD.KeyOriginInfo.fromJSON({
+        fingerPrint: keyOriginInfo1.fingerPrint,
+        path: keyOriginInfo1.path
+      });
+      assert.deepStrictEqual(keyOriginInfo2.toString(), data.expected);
+      assert.deepStrictEqual(keyOriginInfo3.toString(), data.expected);
+    });
+  }
+
+  for (const data of parsable) {
+    it(`should create a KeyOriginInfo object from options object for ${data.input}`, () => {
+      const keyOriginInfo1 = HD.KeyOriginInfo.fromString(data.input);
+      const keyOriginInfo2 = HD.KeyOriginInfo.fromOptions({
+        fingerPrint: keyOriginInfo1.fingerPrint,
+        path: keyOriginInfo1.path
+      });
+      assert.deepStrictEqual(keyOriginInfo2.toString(), data.expected);
+    });
+  }
+
+  for (const data of parsable) {
+    it(`should clone a KeyOriginInfo object for ${data.input}`, () => {
+      const keyOriginInfo1 = HD.KeyOriginInfo.fromString(data.input);
+      const keyOriginInfo2 = keyOriginInfo1.clone();
+      assert.strictEqual(keyOriginInfo1.equals(keyOriginInfo2), true);
+    });
+  }
+
+  for (const data of unparsable.strings) {
+    it(`should throw "${data.error}" for ${data.input} when creating KeyOriginInfo object from string `, () => {
+      assert.throws(
+        () => {
+          HD.KeyOriginInfo.fromString(data.input);
+        },
+        {
+          message: data.error
+        }
+      );
+    });
+  }
+
+  for (const data of unparsable.jsons) {
+    it(`should throw "${data.error}" for json: {fingerPrint: ${data.input.fingerPrint}, path: [${data.input.path}]} when creating KeyOriginInfo object from json `, () => {
+      assert.throws(
+        () => {
+          HD.KeyOriginInfo.fromJSON(data.input);
+        },
+        {
+          message: data.error
+        }
+      );
+    });
+  }
+});

--- a/test/keyprovider-test.js
+++ b/test/keyprovider-test.js
@@ -1,0 +1,59 @@
+/* eslint-disable quotes */
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const KeyProvider = require('../lib/descriptor/keyprovider');
+const assert = require('bsert');
+
+const keys = [
+  {
+    "input": "L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1",
+    "pubkey": "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd",
+    "privkey": "L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1",
+    "hasprivatekey": true,
+    "pubkeysize": 33
+  },
+  {
+    "input": "03a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7",
+    "pubkey": "03a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7",
+    "privkey": null,
+    "hasprivatekey": false,
+    "pubkeysize": 33
+  },
+  {
+    "input": "[d34db33f/44'/0'/0h]tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1'/1'/*'",
+    "pubkey": "[d34db33f/44'/0'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1'/1'/*'",
+    "privkey": null,
+    "hasprivatekey": false,
+    "pubkeysize": 33,
+    "network": "testnet"
+  },
+  {
+    "input": "[01234567/10/20]xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U/2147483647'/0",
+    "pubkey": "[01234567/10/20]xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/2147483647'/0",
+    "privkey": "[01234567/10/20]xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U/2147483647'/0",
+    "hasprivatekey": true,
+    "pubkeysize": 33
+  },
+  {
+    "input": "5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss",
+    "pubkey": "04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235",
+    "privkey": "5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss",
+    "hasprivatekey": true,
+    "pubkeysize": 65
+  }
+];
+
+describe('KeyProvider', () => {
+  for (const data of keys) {
+    it(`should create a KeyProvider object for ${data.input}`, () => {
+      const provider = KeyProvider.fromString(data.input, data.network);
+      assert.strictEqual(provider.toString(), data.pubkey);
+      assert.strictEqual(provider.toPrivateString(), data.privkey);
+      assert.strictEqual(provider.hasPrivateKey(), data.hasprivatekey);
+      assert.strictEqual(provider.getSize(), data.pubkeysize);
+    });
+  }
+});

--- a/test/node-rpc-test.js
+++ b/test/node-rpc-test.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* eslint-disable quotes */
 /* eslint prefer-arrow-callback: "off" */
 
 'use strict';
@@ -10,6 +11,7 @@ const KeyRing = require('../lib/primitives/keyring');
 const Block = require('../lib/primitives/block');
 const util = require('../lib/utils/util');
 const NetAddress = require('../lib/net/netaddress');
+const {createChecksum} = require("../lib/descriptor/common");
 
 const ports = {
   p2p: 49331,
@@ -72,6 +74,104 @@ describe('RPC', function() {
     const info = await nclient.execute('getnetworkinfo', []);
 
     assert.deepEqual(info.localservicenames, ['NETWORK', 'WITNESS']);
+  });
+
+  it('should rpc getdescriptorinfo', async () => {
+    const testcases = [
+      {
+        "input": "sh(wsh(sortedmulti(2,[e7dd1c50/48'/1'/40'/1']tpubDFh3VaUEs71ZMcVBmscSSnP4f4r6TvnLssu8yXvpj3uMfAehciMYTrgbfu4KCxXb7oSaz4kriuWRZtQVhZR2oA9toob6aELnsYLN94fXQLF/*,[e7dd1c50/48'/1'/20'/1']tpubDFPemvLnpMqE1BPuturDUh46KxsR8wGSQrA6HofYE7fqxpMAKCcoYWHGA46B6zKY4xcQAc1vLFTcqQ9BvsbHZ4UhzqqF5nUeeNBjNivHxPT/*,[aedb3d12/48'/1'/0'/1']tpubDEbuxto5Kftus28NyPddiEev2yUhzZGpkpQdCK732KBge5FJDhaMdhG1iVw3rMJ2qvABkaLR9HxobkeFkmQZ4RqQgN1KJadDjPn9ANBLo8V/*)))",
+        "descriptor": "sh(wsh(sortedmulti(2,[e7dd1c50/48'/1'/40'/1']tpubDFh3VaUEs71ZMcVBmscSSnP4f4r6TvnLssu8yXvpj3uMfAehciMYTrgbfu4KCxXb7oSaz4kriuWRZtQVhZR2oA9toob6aELnsYLN94fXQLF/*,[e7dd1c50/48'/1'/20'/1']tpubDFPemvLnpMqE1BPuturDUh46KxsR8wGSQrA6HofYE7fqxpMAKCcoYWHGA46B6zKY4xcQAc1vLFTcqQ9BvsbHZ4UhzqqF5nUeeNBjNivHxPT/*,[aedb3d12/48'/1'/0'/1']tpubDEbuxto5Kftus28NyPddiEev2yUhzZGpkpQdCK732KBge5FJDhaMdhG1iVw3rMJ2qvABkaLR9HxobkeFkmQZ4RqQgN1KJadDjPn9ANBLo8V/*)))#zlh5y6z5",
+        "checksum": "zlh5y6z5",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "sh(wsh(pkh(02e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13)))",
+        "descriptor": "sh(wsh(pkh(02e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13)))#2wtr0ej5",
+        "checksum": "2wtr0ej5",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "sh(wpkh(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556))",
+        "descriptor": "sh(wpkh(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556))#qkrrc7je",
+        "checksum": "qkrrc7je",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "sh(multi(2,022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01,03acd484e2f0c7f65309ad178a9f559abde09796974c57e714c35f110dfc27ccbe))",
+        "descriptor": "sh(multi(2,022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01,03acd484e2f0c7f65309ad178a9f559abde09796974c57e714c35f110dfc27ccbe))#y9zthqta",
+        "checksum": "y9zthqta",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "sh(pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))",
+        "descriptor": "sh(pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))#s53ls94y",
+        "checksum": "s53ls94y",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "sh(wsh(multi(1,03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8,03499fdf9e895e719cfd64e67f07d38e3226aa7b63678949e6e49b241a60e823e4,02d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e)))",
+        "descriptor": "sh(wsh(multi(1,03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8,03499fdf9e895e719cfd64e67f07d38e3226aa7b63678949e6e49b241a60e823e4,02d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e)))#ks05yr6p",
+        "checksum": "ks05yr6p",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "sh(wsh(sortedmulti(2,[e7dd1c50/48'/1'/40'/1']tpubDFh3VaUEs71ZMcVBmscSSnP4f4r6TvnLssu8yXvpj3uMfAehciMYTrgbfu4KCxXb7oSaz4kriuWRZtQVhZR2oA9toob6aELnsYLN94fXQLF/*,[e7dd1c50/48'/1'/20'/1']tpubDFPemvLnpMqE1BPuturDUh46KxsR8wGSQrA6HofYE7fqxpMAKCcoYWHGA46B6zKY4xcQAc1vLFTcqQ9BvsbHZ4UhzqqF5nUeeNBjNivHxPT/*,[aedb3d12/48'/1'/0'/1']tpubDEbuxto5Kftus28NyPddiEev2yUhzZGpkpQdCK732KBge5FJDhaMdhG1iVw3rMJ2qvABkaLR9HxobkeFkmQZ4RqQgN1KJadDjPn9ANBLo8V/*)))",
+        "descriptor": "sh(wsh(sortedmulti(2,[e7dd1c50/48'/1'/40'/1']tpubDFh3VaUEs71ZMcVBmscSSnP4f4r6TvnLssu8yXvpj3uMfAehciMYTrgbfu4KCxXb7oSaz4kriuWRZtQVhZR2oA9toob6aELnsYLN94fXQLF/*,[e7dd1c50/48'/1'/20'/1']tpubDFPemvLnpMqE1BPuturDUh46KxsR8wGSQrA6HofYE7fqxpMAKCcoYWHGA46B6zKY4xcQAc1vLFTcqQ9BvsbHZ4UhzqqF5nUeeNBjNivHxPT/*,[aedb3d12/48'/1'/0'/1']tpubDEbuxto5Kftus28NyPddiEev2yUhzZGpkpQdCK732KBge5FJDhaMdhG1iVw3rMJ2qvABkaLR9HxobkeFkmQZ4RqQgN1KJadDjPn9ANBLo8V/*)))#zlh5y6z5",
+        "checksum": "zlh5y6z5",
+        "isrange": true,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "pkh(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1'/2)",
+        "descriptor": "pkh(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1'/2)#hvxe7cts",
+        "checksum": "hvxe7cts",
+        "isrange": false,
+        "issolvable": true,
+        "hasprivatekeys": false
+      },
+      {
+        "input": "wsh(wpkh(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))",
+        "error": "Invalid descriptor: Can not have wpkh() inside wsh()"
+      },
+      {
+        "input": "wsh(wsh(pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)))",
+        "error": "Invalid descriptor: Can not have wsh() inside wsh()"
+      },
+      {
+        "input": "wsh(sh(pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)))",
+        "error": "Invalid descriptor: Can not have sh() inside wsh()"
+      },
+      {
+        "input": "wsh(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+        "error": "Invalid descriptor: A valid function is needed inside wsh()"
+      }
+    ];
+
+    for (const test of testcases) {
+      try {
+        const result = await nclient.execute("getdescriptorinfo", [test.input]);
+        assert.deepStrictEqual(result.descriptor, test.descriptor);
+        assert.deepStrictEqual(result.checksum, createChecksum(test.input.split("#")[0]));
+        assert.deepStrictEqual(result.isrange, test.isrange);
+        assert.deepStrictEqual(result.issolvable, test.issolvable);
+        assert.deepStrictEqual(result.hasprivatekeys, test.hasprivatekeys);
+      } catch (e) {
+        assert.strictEqual(e.message, test.error);
+      }
+    }
   });
 
   it('should rpc getblockhash', async () => {


### PR DESCRIPTION
This pr implements [getdescriptorinfo](https://developer.bitcoin.org/reference/rpc/getdescriptorinfo.html) rpc by adding a descriptor module.

If the argument string of getdescriptorinfo() rpc is a valid string it is parsed into a **_AbstractDescriptor_** object. 
Along with that various parts of the string, such as origin information, keys (Public/Private), and derivation path (along with **hardened** or **unhardened** information)  are parsed into **_PubKeyProvider_** object respectively. If the descriiptor string contains a checksum it will be validiated and if a checksum is not present we will calculate one. 

**Note: The input descriptor string doesn't require checksum to be present**.

The **AbstractDescriptor** class has **_PKDescriptor_**, **_PKHDescriptor_**, **_WPKHDescriptor_**, **_AddressDescriptor_**, **_MultisigDescriptor,_** **_WSHDescriptor_**,  **_SHDescriptor_**, **_RawDescriptor_**, **_ComboDescriptor_** as its subclasses.

The **_KeyProvider_** class will have **_ConstPubkeyProvider_** (for parsing constant keys with/without origin info) and **_HDKeyProvider_** (for parsing extended (hd - bip32) keys with/without origin info) as its subclasses.

Functions for parsing descriptor string will be present as global function in **_parser.js_**.
**_Checksum_** functions are implemented in common.js.

Functions checking **_isRange(),_**  **_isSolvable()_**, **_hasPrivateKeys()_** etc. will be present in the AbstractDescriptor class. 