### PR TITLE
feat: align 'estimatesmartfee' rpc with bitcoind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ node ./migrate/walletdb7to8.js /path/to/bcoin/wallet
 #### RPC
 
 - Added `getnodeaddresses` which returns entries from the hostlist.
+- Updated `estimatesmartfee` to return attribute `feerate` (previously `fee`).
 
 ### Indexer changes
 

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2231,7 +2231,7 @@ class RPC extends RPCBase {
       fee = Amount.btc(fee, true);
 
     return {
-      fee: fee,
+      feerate: fee,
       blocks: blocks
     };
   }

--- a/test/node-rpc-test.js
+++ b/test/node-rpc-test.js
@@ -542,16 +542,22 @@ describe('RPC', function() {
   });
 
   describe('utilities', function() {
-    // 0-in, 2-out
-    const rawTX1 =
-      '0100000000024e61bc00000000001976a914fbdd46898a6d70a682cbd34420cc' +
-      'f0b6bb64493788acf67e4929010000001976a9141b002b6fc0f457bf8d092722' +
-      '510fce9f37f0423b88ac00000000';
-
     it('should decoderawtransaction', async () => {
+      // 0-in, 2-out
+      const rawTX1 =
+        '0100000000024e61bc00000000001976a914fbdd46898a6d70a682cbd34420cc' +
+        'f0b6bb64493788acf67e4929010000001976a9141b002b6fc0f457bf8d092722' +
+        '510fce9f37f0423b88ac00000000';
       const result = await nclient.execute('decoderawtransaction', [rawTX1]);
       assert.strictEqual(result.vin.length, 0);
       assert.strictEqual(result.vout.length, 2);
+    });
+    it('should estimate fee rate', async () => {
+      const result = await nclient.execute('estimatesmartfee', [6]);
+      assert.deepStrictEqual(result, {
+        blocks: 6,
+        feerate: -1
+      });
     });
   });
 });


### PR DESCRIPTION
Changes the returned json attribute from 'estimatesmartfee' rpc to align with bitcoind [docs](https://developer.bitcoin.org/reference/rpc/estimatesmartfee.html#result) . Also added a crude test to verify the same.

Fixes https://github.com/bcoin-org/bcoin/issues/1153 
