### PR TITLE
fix: neither uint64 or int64 safe integer

### DIFF
--- a/lib/btc/amount.js
+++ b/lib/btc/amount.js
@@ -143,7 +143,7 @@ class Amount {
 
   fromValue(value) {
     assert(Number.isSafeInteger(value) && value >= 0,
-      'Value must be an int64.');
+      'Value must be a safe integer.');
     this.value = value;
     return this;
   }

--- a/lib/btc/uri.js
+++ b/lib/btc/uri.js
@@ -57,7 +57,7 @@ class URI {
 
     if (options.amount != null) {
       assert(Number.isSafeInteger(options.amount) && options.amount >= 0,
-        'Amount must be a uint64.');
+        'Amount must be a safe integer.');
       this.amount = options.amount;
     }
 

--- a/lib/primitives/coin.js
+++ b/lib/primitives/coin.js
@@ -79,7 +79,7 @@ class Coin extends Output {
 
     if (options.value != null) {
       assert(Number.isSafeInteger(options.value) && options.value >= 0,
-        'Value must be a uint64.');
+        'Value must be a safe integer.');
       this.value = options.value;
     }
 
@@ -271,7 +271,7 @@ class Coin extends Output {
     assert(json.height === -1 || (json.height >>> 0) === json.height,
       'Height must be a uint32.');
     assert(Number.isSafeInteger(json.value) && json.value >= 0,
-      'Value must be a uint64.');
+      'Value must be a safe integer.');
     assert(typeof json.coinbase === 'boolean', 'Coinbase must be a boolean.');
 
     this.version = json.version;

--- a/lib/primitives/output.js
+++ b/lib/primitives/output.js
@@ -50,7 +50,7 @@ class Output {
 
     if (options.value) {
       assert(Number.isSafeInteger(options.value) && options.value >= 0,
-        'Value must be a uint64.');
+        'Value must be a safe integer.');
       this.value = options.value;
     }
 
@@ -90,7 +90,7 @@ class Output {
 
     assert(script instanceof Script, 'Script must be a Script.');
     assert(Number.isSafeInteger(value) && value >= 0,
-      'Value must be a uint64.');
+      'Value must be a safe integer.');
 
     this.script = script;
     this.value = value;


### PR DESCRIPTION
`Number.isSafeInteger` is only true when int54.
Because here also checks whether positive, it's actually uint53 which can pass these assertions.
both int64 and uint64 wrong and misleading