### PR TITLE
fix: change shebangs in scripts and some shellcheck fixes

### DIFF
--- a/bin/bcoin
+++ b/bin/bcoin
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rl=0
 daemon=0
 cmd='node'
 
-if ! type perl > /dev/null 2>& 1; then
-  if uname | grep -i 'darwin' > /dev/null; then
-    echo 'Bcoin requires perl to start on OSX.' >& 2
+if ! type perl >/dev/null 2>&1; then
+  if uname | grep -i 'darwin' >/dev/null; then
+    echo 'Bcoin requires perl to start on OSX.' >&2
     exit 1
   fi
   rl=1
@@ -22,44 +22,44 @@ fi
 
 dir=$(dirname "$file")
 
-if test x"$1" = x'cli'; then
+if test "$1" = 'cli'; then
   shift
   exec "${dir}/cli" "$@"
   exit 1
 fi
 
-if test x"$1" = x'wallet'; then
+if test "$1" = 'wallet'; then
   exec "${dir}/cli" "$@"
   exit 1
 fi
 
-if test x"$1" = x'rpc'; then
+if test "$1" = 'rpc'; then
   exec "${dir}/cli" "$@"
   exit 1
 fi
 
 for arg in "$@"; do
   case "$arg" in
-    --daemon)
-      daemon=1
+  --daemon)
+    daemon=1
     ;;
-    --spv)
-      cmd='spvnode'
+  --spv)
+    cmd='spvnode'
     ;;
   esac
 done
 
 if test $daemon -eq 1; then
   # And yet again, OSX doesn't support something.
-  if ! type setsid > /dev/null 2>& 1; then
+  if ! type setsid >/dev/null 2>&1; then
     (
-      "${dir}/${cmd}" "$@" > /dev/null 2>& 1 &
+      "${dir}/${cmd}" "$@" >/dev/null 2>&1 &
       echo "$!"
     )
     exit 0
   fi
   (
-    setsid "${dir}/${cmd}" "$@" > /dev/null 2>& 1 &
+    setsid "${dir}/${cmd}" "$@" >/dev/null 2>&1 &
     echo "$!"
   )
   exit 0

--- a/bin/bwallet
+++ b/bin/bwallet
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rl=0
 daemon=0
 
-if ! type perl > /dev/null 2>& 1; then
-  if uname | grep -i 'darwin' > /dev/null; then
-    echo 'Bcoin requires perl to start on OSX.' >& 2
+if ! type perl >/dev/null 2>&1; then
+  if uname | grep -i 'darwin' >/dev/null; then
+    echo 'Bcoin requires perl to start on OSX.' >&2
     exit 1
   fi
   rl=1
@@ -21,7 +21,7 @@ fi
 
 dir=$(dirname "$file")
 
-if test x"$1" = x'cli'; then
+if test "$1" = 'cli'; then
   shift
   exec "${dir}/cli" "wallet" "$@"
   exit 1
@@ -29,23 +29,23 @@ fi
 
 for arg in "$@"; do
   case "$arg" in
-    --daemon)
-      daemon=1
+  --daemon)
+    daemon=1
     ;;
   esac
 done
 
 if test $daemon -eq 1; then
   # And yet again, OSX doesn't support something.
-  if ! type setsid > /dev/null 2>& 1; then
+  if ! type setsid >/dev/null 2>&1; then
     (
-      "${dir}/wallet" "$@" > /dev/null 2>& 1 &
+      "${dir}/wallet" "$@" >/dev/null 2>&1 &
       echo "$!"
     )
     exit 0
   fi
   (
-    setsid "${dir}/wallet" "$@" > /dev/null 2>& 1 &
+    setsid "${dir}/wallet" "$@" >/dev/null 2>&1 &
     echo "$!"
   )
   exit 0


### PR DESCRIPTION
On some systems bash might not be necessarily inside `/bin/bash` so changed to shebangs to `/usr/bin/env bash`

Also performed some [shellcheck](https://www.shellcheck.net/) fixes.