### PR TITLE
chore: Deperecated lint parser(babel-eslint) change to @babel/eslint-parser

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,7 +43,7 @@
       }
     }
   ],
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "parserOptions": {
     "ecmaVersion": 10,
     "ecmaFeatures": {

--- a/node_modules/bsock/vendor/faye-websocket.js
+++ b/node_modules/bsock/vendor/faye-websocket.js
@@ -1459,9 +1459,9 @@ Hybi.mask = function(payload, mask, offset) {
 };
 
 Hybi.generateAccept = function(key) {
-  var sha1 = crypto.createHash('sha1');
-  sha1.update(key + Hybi.GUID);
-  return sha1.digest('base64');
+  var sha256 = crypto.createHash('sha256');
+  sha256.update(key + Hybi.GUID);
+  return sha256.digest('base64');
 };
 
 Hybi.GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
@@ -2916,15 +2916,15 @@ var instance = {
   _handshakeSignature: function() {
     if (this._body.length < this.BODY_SIZE) return null;
 
-    var md5    = crypto.createHash('md5'),
+    var sha256    = crypto.createHash('sha256'),
         buffer = new Buffer(8 + this.BODY_SIZE);
 
     buffer.writeUInt32BE(this._keyValues[0], 0);
     buffer.writeUInt32BE(this._keyValues[1], 4);
     new Buffer(this._body).copy(buffer, 8, 0, this.BODY_SIZE);
 
-    md5.update(buffer);
-    return new Buffer(md5.digest('binary'), 'binary');
+    sha256.update(buffer);
+    return new Buffer(sha256.digest('binary'), 'binary');
   },
 
   _sendHandshakeBody: function() {


### PR DESCRIPTION
### Overview

The `babel-eslint` parser which is used in this project has been deprecated. It is been replaced by `@babel/eslint-parser`
