### PR TITLE
test: bslint test error in CI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,19 +1,9 @@
 {
   "env": {
-    "es6": true,
+    "es2024": true,
     "node": true
   },
   "extends": "eslint:recommended",
-  "globals": {
-    "Atomics": "readable",
-    "BigInt": "readable",
-    "BigInt64Array": "readable",
-    "BigUint64Array": "readable",
-    "queueMicrotask": "readable",
-    "SharedArrayBuffer": "readable",
-    "TextEncoder": "readable",
-    "TextDecoder": "readable"
-  },
   "overrides": [
     {
       "files": ["*.mjs"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,9 +43,8 @@
       }
     }
   ],
-  "parser": "babel-eslint",
   "parserOptions": {
-    "ecmaVersion": 10,
+    "ecmaVersion": "latest",
     "ecmaFeatures": {
       "globalReturn": true
     },

--- a/test/descriptor-test.js
+++ b/test/descriptor-test.js
@@ -62,7 +62,7 @@ function createDescriptorFromOptions(desc, type) {
 
 describe('Descriptor', () => {
   for (const type in parsable) {
-    if (parsable.hasOwnProperty(type)) {
+    if (Object.prototype.hasOwnProperty.call(type)) {
       for (const data of parsable[type]) {
         const {input, descriptor, checksum, isrange, issolvable, hasprivatekeys, requirechecksum, network} = data;
 
@@ -111,7 +111,7 @@ describe('Descriptor', () => {
   }
 
   for (const type in validAddresses) {
-    if (validAddresses.hasOwnProperty(type)) {
+    if (Object.property.hasOwnProperty.call(type)) {
       for (const data of validAddresses[type]) {
         const {input, network, range, error} = data;
 

--- a/test/descriptor-test.js
+++ b/test/descriptor-test.js
@@ -111,7 +111,7 @@ describe('Descriptor', () => {
   }
 
   for (const type in validAddresses) {
-    if (Object.property.hasOwnProperty.call(type)) {
+    if (validAddresses.hasOwnProperty.call(type)) {
       for (const data of validAddresses[type]) {
         const {input, network, range, error} = data;
 


### PR DESCRIPTION
### Overview 

This change fixes the CI lint error in the test `bcoin/test/descriptor-test.js` due to the usage of the `hasOwnProperty` call on a local object.

[Reference/Stackoverflow](https://stackoverflow.com/questions/39282873/object-hasownproperty-yields-the-eslint-no-prototype-builtins-error-how-to)